### PR TITLE
slice.go: adding check for zones being attached

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -41,6 +41,7 @@ func (c *Core) InsertChain(blocks types.Blocks) (int, error) {
 		// check the order of the block
 		blockOrder, err := c.engine.GetDifficultyOrder(block.Header())
 		if err != nil {
+			fmt.Println("Err getting blockOrder", err)
 			return i, err
 		}
 		// if the order of the block is less than the context


### PR DESCRIPTION
Potentially useful check to repoint subordinate heads when dom heads change. Example of the head going back on RTR twist:
![Screen Shot 2022-08-26 at 6 49 06 PM](https://user-images.githubusercontent.com/14866363/187004796-b885c340-b2a1-46e4-8a6b-1200359767b4.png)
![Screen Shot 2022-08-26 at 6 50 11 PM](https://user-images.githubusercontent.com/14866363/187004861-21063510-810d-4dad-96d0-24c1dc74e4a9.png)
![Screen Shot 2022-08-26 at 6 50 32 PM](https://user-images.githubusercontent.com/14866363/187004883-aeb4a1ca-bd35-4501-af46-16eab7731f22.png)

