### PR TITLE
Revert "Removed v4wire"

### DIFF
--- a/p2p/discover/common.go
+++ b/p2p/discover/common.go
@@ -62,6 +62,11 @@ func (cfg Config) withDefaults() Config {
 	return cfg
 }
 
+// ListenUDP starts listening for discovery packets on the given UDP socket.
+func ListenUDP(c UDPConn, ln *enode.LocalNode, cfg Config) (*UDPv4, error) {
+	return ListenV4(c, ln, cfg)
+}
+
 // ReadPacket is a packet that couldn't be handled. Those packets are sent to the unhandled
 // channel if configured.
 type ReadPacket struct {

--- a/p2p/discover/v4_lookup_test.go
+++ b/p2p/discover/v4_lookup_test.go
@@ -1,0 +1,347 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package discover
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"net"
+	"sort"
+	"testing"
+
+	"github.com/dominant-strategies/go-quai/crypto"
+	"github.com/dominant-strategies/go-quai/p2p/discover/v4wire"
+	"github.com/dominant-strategies/go-quai/p2p/enode"
+	"github.com/dominant-strategies/go-quai/p2p/enr"
+)
+
+func TestUDPv4_Lookup(t *testing.T) {
+	t.Parallel()
+	test := newUDPTest(t)
+
+	// Lookup on empty table returns no nodes.
+	targetKey, _ := decodePubkey(crypto.S256(), lookupTestnet.target[:])
+	if results := test.udp.LookupPubkey(targetKey); len(results) > 0 {
+		t.Fatalf("lookup on empty table returned %d results: %#v", len(results), results)
+	}
+
+	// Seed table with initial node.
+	fillTable(test.table, []*node{wrapNode(lookupTestnet.node(256, 0))})
+
+	// Start the lookup.
+	resultC := make(chan []*enode.Node, 1)
+	go func() {
+		resultC <- test.udp.LookupPubkey(targetKey)
+		test.close()
+	}()
+
+	// Answer lookup packets.
+	serveTestnet(test, lookupTestnet)
+
+	// Verify result nodes.
+	results := <-resultC
+	t.Logf("results:")
+	for _, e := range results {
+		t.Logf("  ld=%d, %x", enode.LogDist(lookupTestnet.target.id(), e.ID()), e.ID().Bytes())
+	}
+	if len(results) != bucketSize {
+		t.Errorf("wrong number of results: got %d, want %d", len(results), bucketSize)
+	}
+	checkLookupResults(t, lookupTestnet, results)
+}
+
+func TestUDPv4_LookupIterator(t *testing.T) {
+	t.Parallel()
+	test := newUDPTest(t)
+	defer test.close()
+
+	// Seed table with initial nodes.
+	bootnodes := make([]*node, len(lookupTestnet.dists[256]))
+	for i := range lookupTestnet.dists[256] {
+		bootnodes[i] = wrapNode(lookupTestnet.node(256, i))
+	}
+	fillTable(test.table, bootnodes)
+	go serveTestnet(test, lookupTestnet)
+
+	// Create the iterator and collect the nodes it yields.
+	iter := test.udp.RandomNodes()
+	seen := make(map[enode.ID]*enode.Node)
+	for limit := lookupTestnet.len(); iter.Next() && len(seen) < limit; {
+		seen[iter.Node().ID()] = iter.Node()
+	}
+	iter.Close()
+
+	// Check that all nodes in lookupTestnet were seen by the iterator.
+	results := make([]*enode.Node, 0, len(seen))
+	for _, n := range seen {
+		results = append(results, n)
+	}
+	sortByID(results)
+	want := lookupTestnet.nodes()
+	if err := checkNodesEqual(results, want); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestUDPv4_LookupIteratorClose checks that lookupIterator ends when its Close
+// method is called.
+func TestUDPv4_LookupIteratorClose(t *testing.T) {
+	t.Parallel()
+	test := newUDPTest(t)
+	defer test.close()
+
+	// Seed table with initial nodes.
+	bootnodes := make([]*node, len(lookupTestnet.dists[256]))
+	for i := range lookupTestnet.dists[256] {
+		bootnodes[i] = wrapNode(lookupTestnet.node(256, i))
+	}
+	fillTable(test.table, bootnodes)
+	go serveTestnet(test, lookupTestnet)
+
+	it := test.udp.RandomNodes()
+	if ok := it.Next(); !ok || it.Node() == nil {
+		t.Fatalf("iterator didn't return any node")
+	}
+
+	it.Close()
+
+	ncalls := 0
+	for ; ncalls < 100 && it.Next(); ncalls++ {
+		if it.Node() == nil {
+			t.Error("iterator returned Node() == nil node after Next() == true")
+		}
+	}
+	t.Logf("iterator returned %d nodes after close", ncalls)
+	if it.Next() {
+		t.Errorf("Next() == true after close and %d more calls", ncalls)
+	}
+	if n := it.Node(); n != nil {
+		t.Errorf("iterator returned non-nil node after close and %d more calls", ncalls)
+	}
+}
+
+func serveTestnet(test *udpTest, testnet *preminedTestnet) {
+	for done := false; !done; {
+		done = test.waitPacketOut(func(p v4wire.Packet, to *net.UDPAddr, hash []byte) {
+			n, key := testnet.nodeByAddr(to)
+			switch p.(type) {
+			case *v4wire.Ping:
+				test.packetInFrom(nil, key, to, &v4wire.Pong{Expiration: futureExp, ReplyTok: hash})
+			case *v4wire.Findnode:
+				dist := enode.LogDist(n.ID(), testnet.target.id())
+				nodes := testnet.nodesAtDistance(dist - 1)
+				test.packetInFrom(nil, key, to, &v4wire.Neighbors{Expiration: futureExp, Nodes: nodes})
+			}
+		})
+	}
+}
+
+// checkLookupResults verifies that the results of a lookup are the closest nodes to
+// the testnet's target.
+func checkLookupResults(t *testing.T, tn *preminedTestnet, results []*enode.Node) {
+	t.Helper()
+	t.Logf("results:")
+	for _, e := range results {
+		t.Logf("  ld=%d, %x", enode.LogDist(tn.target.id(), e.ID()), e.ID().Bytes())
+	}
+	if hasDuplicates(wrapNodes(results)) {
+		t.Errorf("result set contains duplicate entries")
+	}
+	if !sortedByDistanceTo(tn.target.id(), wrapNodes(results)) {
+		t.Errorf("result set not sorted by distance to target")
+	}
+	wantNodes := tn.closest(len(results))
+	if err := checkNodesEqual(results, wantNodes); err != nil {
+		t.Error(err)
+	}
+}
+
+// This is the test network for the Lookup test.
+// The nodes were obtained by running lookupTestnet.mine with a random NodeID as target.
+var lookupTestnet = &preminedTestnet{
+	target: hexEncPubkey("5d485bdcbe9bc89314a10ae9231e429d33853e3a8fa2af39f5f827370a2e4185e344ace5d16237491dad41f278f1d3785210d29ace76cd627b9147ee340b1125"),
+	dists: [257][]*ecdsa.PrivateKey{
+		251: {
+			hexEncPrivkey("29738ba0c1a4397d6a65f292eee07f02df8e58d41594ba2be3cf84ce0fc58169"),
+			hexEncPrivkey("511b1686e4e58a917f7f848e9bf5539d206a68f5ad6b54b552c2399fe7d174ae"),
+			hexEncPrivkey("d09e5eaeec0fd596236faed210e55ef45112409a5aa7f3276d26646080dcfaeb"),
+			hexEncPrivkey("c1e20dbbf0d530e50573bd0a260b32ec15eb9190032b4633d44834afc8afe578"),
+			hexEncPrivkey("ed5f38f5702d92d306143e5d9154fb21819777da39af325ea359f453d179e80b"),
+		},
+		252: {
+			hexEncPrivkey("1c9b1cafbec00848d2c174b858219914b42a7d5c9359b1ca03fd650e8239ae94"),
+			hexEncPrivkey("e0e1e8db4a6f13c1ffdd3e96b72fa7012293ced187c9dcdcb9ba2af37a46fa10"),
+			hexEncPrivkey("3d53823e0a0295cb09f3e11d16c1b44d07dd37cec6f739b8df3a590189fe9fb9"),
+		},
+		253: {
+			hexEncPrivkey("2d0511ae9bf590166597eeab86b6f27b1ab761761eaea8965487b162f8703847"),
+			hexEncPrivkey("6cfbd7b8503073fc3dbdb746a7c672571648d3bd15197ccf7f7fef3d904f53a2"),
+			hexEncPrivkey("a30599b12827b69120633f15b98a7f6bc9fc2e9a0fd6ae2ebb767c0e64d743ab"),
+			hexEncPrivkey("14a98db9b46a831d67eff29f3b85b1b485bb12ae9796aea98d91be3dc78d8a91"),
+			hexEncPrivkey("2369ff1fc1ff8ca7d20b17e2673adc3365c3674377f21c5d9dafaff21fe12e24"),
+			hexEncPrivkey("9ae91101d6b5048607f41ec0f690ef5d09507928aded2410aabd9237aa2727d7"),
+			hexEncPrivkey("05e3c59090a3fd1ae697c09c574a36fcf9bedd0afa8fe3946f21117319ca4973"),
+			hexEncPrivkey("06f31c5ea632658f718a91a1b1b9ae4b7549d7b3bc61cbc2be5f4a439039f3ad"),
+		},
+		254: {
+			hexEncPrivkey("dec742079ec00ff4ec1284d7905bc3de2366f67a0769431fd16f80fd68c58a7c"),
+			hexEncPrivkey("ff02c8861fa12fbd129d2a95ea663492ef9c1e51de19dcfbbfe1c59894a28d2b"),
+			hexEncPrivkey("4dded9e4eefcbce4262be4fd9e8a773670ab0b5f448f286ec97dfc8cf681444a"),
+			hexEncPrivkey("750d931e2a8baa2c9268cb46b7cd851f4198018bed22f4dceb09dd334a2395f6"),
+			hexEncPrivkey("ce1435a956a98ffec484cd11489c4f165cf1606819ab6b521cee440f0c677e9e"),
+			hexEncPrivkey("996e7f8d1638be92d7328b4770f47e5420fc4bafecb4324fd33b1f5d9f403a75"),
+			hexEncPrivkey("ebdc44e77a6cc0eb622e58cf3bb903c3da4c91ca75b447b0168505d8fc308b9c"),
+			hexEncPrivkey("46bd1eddcf6431bea66fc19ebc45df191c1c7d6ed552dcdc7392885009c322f0"),
+		},
+		255: {
+			hexEncPrivkey("da8645f90826e57228d9ea72aff84500060ad111a5d62e4af831ed8e4b5acfb8"),
+			hexEncPrivkey("3c944c5d9af51d4c1d43f5d0f3a1a7ef65d5e82744d669b58b5fed242941a566"),
+			hexEncPrivkey("5ebcde76f1d579eebf6e43b0ffe9157e65ffaa391175d5b9aa988f47df3e33da"),
+			hexEncPrivkey("97f78253a7d1d796e4eaabce721febcc4550dd68fb11cc818378ba807a2cb7de"),
+			hexEncPrivkey("a38cd7dc9b4079d1c0406afd0fdb1165c285f2c44f946eca96fc67772c988c7d"),
+			hexEncPrivkey("d64cbb3ffdf712c372b7a22a176308ef8f91861398d5dbaf326fd89c6eaeef1c"),
+			hexEncPrivkey("d269609743ef29d6446e3355ec647e38d919c82a4eb5837e442efd7f4218944f"),
+			hexEncPrivkey("d8f7bcc4a530efde1d143717007179e0d9ace405ddaaf151c4d863753b7fd64c"),
+		},
+		256: {
+			hexEncPrivkey("8c5b422155d33ea8e9d46f71d1ad3e7b24cb40051413ffa1a81cff613d243ba9"),
+			hexEncPrivkey("937b1af801def4e8f5a3a8bd225a8bcff1db764e41d3e177f2e9376e8dd87233"),
+			hexEncPrivkey("120260dce739b6f71f171da6f65bc361b5fad51db74cf02d3e973347819a6518"),
+			hexEncPrivkey("1fa56cf25d4b46c2bf94e82355aa631717b63190785ac6bae545a88aadc304a9"),
+			hexEncPrivkey("3c38c503c0376f9b4adcbe935d5f4b890391741c764f61b03cd4d0d42deae002"),
+			hexEncPrivkey("3a54af3e9fa162bc8623cdf3e5d9b70bf30ade1d54cc3abea8659aba6cff471f"),
+			hexEncPrivkey("6799a02ea1999aefdcbcc4d3ff9544478be7365a328d0d0f37c26bd95ade0cda"),
+			hexEncPrivkey("e24a7bc9051058f918646b0f6e3d16884b2a55a15553b89bab910d55ebc36116"),
+		},
+	},
+}
+
+type preminedTestnet struct {
+	target encPubkey
+	dists  [hashBits + 1][]*ecdsa.PrivateKey
+}
+
+func (tn *preminedTestnet) len() int {
+	n := 0
+	for _, keys := range tn.dists {
+		n += len(keys)
+	}
+	return n
+}
+
+func (tn *preminedTestnet) nodes() []*enode.Node {
+	result := make([]*enode.Node, 0, tn.len())
+	for dist, keys := range tn.dists {
+		for index := range keys {
+			result = append(result, tn.node(dist, index))
+		}
+	}
+	sortByID(result)
+	return result
+}
+
+func (tn *preminedTestnet) node(dist, index int) *enode.Node {
+	key := tn.dists[dist][index]
+	rec := new(enr.Record)
+	rec.Set(enr.IP{127, byte(dist >> 8), byte(dist), byte(index)})
+	rec.Set(enr.UDP(5000))
+	enode.SignV4(rec, key)
+	n, _ := enode.New(enode.ValidSchemes, rec)
+	return n
+}
+
+func (tn *preminedTestnet) nodeByAddr(addr *net.UDPAddr) (*enode.Node, *ecdsa.PrivateKey) {
+	dist := int(addr.IP[1])<<8 + int(addr.IP[2])
+	index := int(addr.IP[3])
+	key := tn.dists[dist][index]
+	return tn.node(dist, index), key
+}
+
+func (tn *preminedTestnet) nodesAtDistance(dist int) []v4wire.Node {
+	result := make([]v4wire.Node, len(tn.dists[dist]))
+	for i := range result {
+		result[i] = nodeToRPC(wrapNode(tn.node(dist, i)))
+	}
+	return result
+}
+
+func (tn *preminedTestnet) neighborsAtDistances(base *enode.Node, distances []uint, elems int) []*enode.Node {
+	var result []*enode.Node
+	for d := range lookupTestnet.dists {
+		for i := range lookupTestnet.dists[d] {
+			n := lookupTestnet.node(d, i)
+			d := enode.LogDist(base.ID(), n.ID())
+			if containsUint(uint(d), distances) {
+				result = append(result, n)
+				if len(result) >= elems {
+					return result
+				}
+			}
+		}
+	}
+	return result
+}
+
+func (tn *preminedTestnet) closest(n int) (nodes []*enode.Node) {
+	for d := range tn.dists {
+		for i := range tn.dists[d] {
+			nodes = append(nodes, tn.node(d, i))
+		}
+	}
+	sort.Slice(nodes, func(i, j int) bool {
+		return enode.DistCmp(tn.target.id(), nodes[i].ID(), nodes[j].ID()) < 0
+	})
+	return nodes[:n]
+}
+
+var _ = (*preminedTestnet).mine // avoid linter warning about mine being dead code.
+
+// mine generates a testnet struct literal with nodes at
+// various distances to the network's target.
+func (tn *preminedTestnet) mine() {
+	// Clear existing slices first (useful when re-mining).
+	for i := range tn.dists {
+		tn.dists[i] = nil
+	}
+
+	targetSha := tn.target.id()
+	found, need := 0, 40
+	for found < need {
+		k := newkey()
+		ld := enode.LogDist(targetSha, encodePubkey(&k.PublicKey).id())
+		if len(tn.dists[ld]) < 8 {
+			tn.dists[ld] = append(tn.dists[ld], k)
+			found++
+			fmt.Printf("found ID with ld %d (%d/%d)\n", ld, found, need)
+		}
+	}
+	fmt.Printf("&preminedTestnet{\n")
+	fmt.Printf("	target: hexEncPubkey(\"%x\"),\n", tn.target[:])
+	fmt.Printf("	dists: [%d][]*ecdsa.PrivateKey{\n", len(tn.dists))
+	for ld, ns := range tn.dists {
+		if len(ns) == 0 {
+			continue
+		}
+		fmt.Printf("		%d: {\n", ld)
+		for _, key := range ns {
+			fmt.Printf("			hexEncPrivkey(\"%x\"),\n", crypto.FromECDSA(key))
+		}
+		fmt.Printf("		},\n")
+	}
+	fmt.Printf("	},\n")
+	fmt.Printf("}\n")
+}

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -1,0 +1,787 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package discover
+
+import (
+	"bytes"
+	"container/list"
+	"context"
+	"crypto/ecdsa"
+	crand "crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/dominant-strategies/go-quai/crypto"
+	"github.com/dominant-strategies/go-quai/log"
+	"github.com/dominant-strategies/go-quai/p2p/discover/v4wire"
+	"github.com/dominant-strategies/go-quai/p2p/enode"
+	"github.com/dominant-strategies/go-quai/p2p/netutil"
+)
+
+// Errors
+var (
+	errExpired          = errors.New("expired")
+	errUnsolicitedReply = errors.New("unsolicited reply")
+	errUnknownNode      = errors.New("unknown node")
+	errTimeout          = errors.New("RPC timeout")
+	errClockWarp        = errors.New("reply deadline too far in the future")
+	errClosed           = errors.New("socket closed")
+	errLowPort          = errors.New("low port")
+)
+
+const (
+	respTimeout    = 500 * time.Millisecond
+	expiration     = 20 * time.Second
+	bondExpiration = 24 * time.Hour
+
+	maxFindnodeFailures = 5                // nodes exceeding this limit are dropped
+	ntpFailureThreshold = 32               // Continuous timeouts after which to check NTP
+	ntpWarningCooldown  = 10 * time.Minute // Minimum amount of time to pass before repeating NTP warning
+	driftThreshold      = 10 * time.Second // Allowed clock drift before warning user
+
+	// Discovery packets are defined to be no larger than 1280 bytes.
+	// Packets larger than this size will be cut at the end and treated
+	// as invalid because their hash won't match.
+	maxPacketSize = 1280
+)
+
+// UDPv4 implements the v4 wire protocol.
+type UDPv4 struct {
+	conn        UDPConn
+	log         log.Logger
+	netrestrict *netutil.Netlist
+	priv        *ecdsa.PrivateKey
+	localNode   *enode.LocalNode
+	db          *enode.DB
+	tab         *Table
+	closeOnce   sync.Once
+	wg          sync.WaitGroup
+
+	addReplyMatcher chan *replyMatcher
+	gotreply        chan reply
+	closeCtx        context.Context
+	cancelCloseCtx  context.CancelFunc
+}
+
+// replyMatcher represents a pending reply.
+//
+// Some implementations of the protocol wish to send more than one
+// reply packet to findnode. In general, any neighbors packet cannot
+// be matched up with a specific findnode packet.
+//
+// Our implementation handles this by storing a callback function for
+// each pending reply. Incoming packets from a node are dispatched
+// to all callback functions for that node.
+type replyMatcher struct {
+	// these fields must match in the reply.
+	from  enode.ID
+	ip    net.IP
+	ptype byte
+
+	// time when the request must complete
+	deadline time.Time
+
+	// callback is called when a matching reply arrives. If it returns matched == true, the
+	// reply was acceptable. The second return value indicates whether the callback should
+	// be removed from the pending reply queue. If it returns false, the reply is considered
+	// incomplete and the callback will be invoked again for the next matching reply.
+	callback replyMatchFunc
+
+	// errc receives nil when the callback indicates completion or an
+	// error if no further reply is received within the timeout.
+	errc chan error
+
+	// reply contains the most recent reply. This field is safe for reading after errc has
+	// received a value.
+	reply v4wire.Packet
+}
+
+type replyMatchFunc func(v4wire.Packet) (matched bool, requestDone bool)
+
+// reply is a reply packet from a certain node.
+type reply struct {
+	from enode.ID
+	ip   net.IP
+	data v4wire.Packet
+	// loop indicates whether there was
+	// a matching request by sending on this channel.
+	matched chan<- bool
+}
+
+func ListenV4(c UDPConn, ln *enode.LocalNode, cfg Config) (*UDPv4, error) {
+	cfg = cfg.withDefaults()
+	closeCtx, cancel := context.WithCancel(context.Background())
+	t := &UDPv4{
+		conn:            c,
+		priv:            cfg.PrivateKey,
+		netrestrict:     cfg.NetRestrict,
+		localNode:       ln,
+		db:              ln.Database(),
+		gotreply:        make(chan reply),
+		addReplyMatcher: make(chan *replyMatcher),
+		closeCtx:        closeCtx,
+		cancelCloseCtx:  cancel,
+		log:             cfg.Log,
+	}
+
+	tab, err := newTable(t, ln.Database(), cfg.Bootnodes, t.log)
+	if err != nil {
+		return nil, err
+	}
+	t.tab = tab
+	go tab.loop()
+
+	t.wg.Add(2)
+	go t.loop()
+	go t.readLoop(cfg.Unhandled)
+	return t, nil
+}
+
+// Self returns the local node.
+func (t *UDPv4) Self() *enode.Node {
+	return t.localNode.Node()
+}
+
+// Close shuts down the socket and aborts any running queries.
+func (t *UDPv4) Close() {
+	t.closeOnce.Do(func() {
+		t.cancelCloseCtx()
+		t.conn.Close()
+		t.wg.Wait()
+		t.tab.close()
+	})
+}
+
+// Resolve searches for a specific node with the given ID and tries to get the most recent
+// version of the node record for it. It returns n if the node could not be resolved.
+func (t *UDPv4) Resolve(n *enode.Node) *enode.Node {
+	// Try asking directly. This works if the node is still responding on the endpoint we have.
+	if rn, err := t.RequestENR(n); err == nil {
+		return rn
+	}
+	// Check table for the ID, we might have a newer version there.
+	if intable := t.tab.getNode(n.ID()); intable != nil && intable.Seq() > n.Seq() {
+		n = intable
+		if rn, err := t.RequestENR(n); err == nil {
+			return rn
+		}
+	}
+	// Otherwise perform a network lookup.
+	var key enode.Secp256k1
+	if n.Load(&key) != nil {
+		return n // no secp256k1 key
+	}
+	result := t.LookupPubkey((*ecdsa.PublicKey)(&key))
+	for _, rn := range result {
+		if rn.ID() == n.ID() {
+			if rn, err := t.RequestENR(rn); err == nil {
+				return rn
+			}
+		}
+	}
+	return n
+}
+
+func (t *UDPv4) ourEndpoint() v4wire.Endpoint {
+	n := t.Self()
+	a := &net.UDPAddr{IP: n.IP(), Port: n.UDP()}
+	return v4wire.NewEndpoint(a, uint16(n.TCP()))
+}
+
+// Ping sends a ping message to the given node.
+func (t *UDPv4) Ping(n *enode.Node) error {
+	_, err := t.ping(n)
+	return err
+}
+
+// ping sends a ping message to the given node and waits for a reply.
+func (t *UDPv4) ping(n *enode.Node) (seq uint64, err error) {
+	rm := t.sendPing(n.ID(), &net.UDPAddr{IP: n.IP(), Port: n.UDP()}, nil)
+	if err = <-rm.errc; err == nil {
+		seq = rm.reply.(*v4wire.Pong).ENRSeq
+	}
+	return seq, err
+}
+
+// sendPing sends a ping message to the given node and invokes the callback
+// when the reply arrives.
+func (t *UDPv4) sendPing(toid enode.ID, toaddr *net.UDPAddr, callback func()) *replyMatcher {
+	req := t.makePing(toaddr)
+	packet, hash, err := v4wire.Encode(t.priv, req)
+	if err != nil {
+		errc := make(chan error, 1)
+		errc <- err
+		return &replyMatcher{errc: errc}
+	}
+	// Add a matcher for the reply to the pending reply queue. Pongs are matched if they
+	// reference the ping we're about to send.
+	rm := t.pending(toid, toaddr.IP, v4wire.PongPacket, func(p v4wire.Packet) (matched bool, requestDone bool) {
+		matched = bytes.Equal(p.(*v4wire.Pong).ReplyTok, hash)
+		if matched && callback != nil {
+			callback()
+		}
+		return matched, matched
+	})
+	// Send the packet.
+	t.localNode.UDPContact(toaddr)
+	t.write(toaddr, toid, req.Name(), packet)
+	return rm
+}
+
+func (t *UDPv4) makePing(toaddr *net.UDPAddr) *v4wire.Ping {
+	return &v4wire.Ping{
+		Version:    4,
+		From:       t.ourEndpoint(),
+		To:         v4wire.NewEndpoint(toaddr, 0),
+		Expiration: uint64(time.Now().Add(expiration).Unix()),
+		ENRSeq:     t.localNode.Node().Seq(),
+	}
+}
+
+// LookupPubkey finds the closest nodes to the given public key.
+func (t *UDPv4) LookupPubkey(key *ecdsa.PublicKey) []*enode.Node {
+	if t.tab.len() == 0 {
+		// All nodes were dropped, refresh. The very first query will hit this
+		// case and run the bootstrapping logic.
+		<-t.tab.refresh()
+	}
+	return t.newLookup(t.closeCtx, encodePubkey(key)).run()
+}
+
+// RandomNodes is an iterator yielding nodes from a random walk of the DHT.
+func (t *UDPv4) RandomNodes() enode.Iterator {
+	return newLookupIterator(t.closeCtx, t.newRandomLookup)
+}
+
+// lookupRandom implements transport.
+func (t *UDPv4) lookupRandom() []*enode.Node {
+	return t.newRandomLookup(t.closeCtx).run()
+}
+
+// lookupSelf implements transport.
+func (t *UDPv4) lookupSelf() []*enode.Node {
+	return t.newLookup(t.closeCtx, encodePubkey(&t.priv.PublicKey)).run()
+}
+
+func (t *UDPv4) newRandomLookup(ctx context.Context) *lookup {
+	var target encPubkey
+	crand.Read(target[:])
+	return t.newLookup(ctx, target)
+}
+
+func (t *UDPv4) newLookup(ctx context.Context, targetKey encPubkey) *lookup {
+	target := enode.ID(crypto.Keccak256Hash(targetKey[:]))
+	ekey := v4wire.Pubkey(targetKey)
+	it := newLookup(ctx, t.tab, target, func(n *node) ([]*node, error) {
+		return t.findnode(n.ID(), n.addr(), ekey)
+	})
+	return it
+}
+
+// findnode sends a findnode request to the given node and waits until
+// the node has sent up to k neighbors.
+func (t *UDPv4) findnode(toid enode.ID, toaddr *net.UDPAddr, target v4wire.Pubkey) ([]*node, error) {
+	t.ensureBond(toid, toaddr)
+
+	// Add a matcher for 'neighbours' replies to the pending reply queue. The matcher is
+	// active until enough nodes have been received.
+	nodes := make([]*node, 0, bucketSize)
+	nreceived := 0
+	rm := t.pending(toid, toaddr.IP, v4wire.NeighborsPacket, func(r v4wire.Packet) (matched bool, requestDone bool) {
+		reply := r.(*v4wire.Neighbors)
+		for _, rn := range reply.Nodes {
+			nreceived++
+			n, err := t.nodeFromRPC(toaddr, rn)
+			if err != nil {
+				t.log.Trace("Invalid neighbor node received", "ip", rn.IP, "addr", toaddr, "err", err)
+				continue
+			}
+			nodes = append(nodes, n)
+		}
+		return true, nreceived >= bucketSize
+	})
+	t.send(toaddr, toid, &v4wire.Findnode{
+		Target:     target,
+		Expiration: uint64(time.Now().Add(expiration).Unix()),
+	})
+	// Ensure that callers don't see a timeout if the node actually responded. Since
+	// findnode can receive more than one neighbors response, the reply matcher will be
+	// active until the remote node sends enough nodes. If the remote end doesn't have
+	// enough nodes the reply matcher will time out waiting for the second reply, but
+	// there's no need for an error in that case.
+	err := <-rm.errc
+	if err == errTimeout && rm.reply != nil {
+		err = nil
+	}
+	return nodes, err
+}
+
+// RequestENR sends enrRequest to the given node and waits for a response.
+func (t *UDPv4) RequestENR(n *enode.Node) (*enode.Node, error) {
+	addr := &net.UDPAddr{IP: n.IP(), Port: n.UDP()}
+	t.ensureBond(n.ID(), addr)
+
+	req := &v4wire.ENRRequest{
+		Expiration: uint64(time.Now().Add(expiration).Unix()),
+	}
+	packet, hash, err := v4wire.Encode(t.priv, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Add a matcher for the reply to the pending reply queue. Responses are matched if
+	// they reference the request we're about to send.
+	rm := t.pending(n.ID(), addr.IP, v4wire.ENRResponsePacket, func(r v4wire.Packet) (matched bool, requestDone bool) {
+		matched = bytes.Equal(r.(*v4wire.ENRResponse).ReplyTok, hash)
+		return matched, matched
+	})
+	// Send the packet and wait for the reply.
+	t.write(addr, n.ID(), req.Name(), packet)
+	if err := <-rm.errc; err != nil {
+		return nil, err
+	}
+	// Verify the response record.
+	respN, err := enode.New(enode.ValidSchemes, &rm.reply.(*v4wire.ENRResponse).Record)
+	if err != nil {
+		return nil, err
+	}
+	if respN.ID() != n.ID() {
+		return nil, fmt.Errorf("invalid ID in response record")
+	}
+	if respN.Seq() < n.Seq() {
+		return n, nil // response record is older
+	}
+	if err := netutil.CheckRelayIP(addr.IP, respN.IP()); err != nil {
+		return nil, fmt.Errorf("invalid IP in response record: %v", err)
+	}
+	return respN, nil
+}
+
+// pending adds a reply matcher to the pending reply queue.
+// see the documentation of type replyMatcher for a detailed explanation.
+func (t *UDPv4) pending(id enode.ID, ip net.IP, ptype byte, callback replyMatchFunc) *replyMatcher {
+	ch := make(chan error, 1)
+	p := &replyMatcher{from: id, ip: ip, ptype: ptype, callback: callback, errc: ch}
+	select {
+	case t.addReplyMatcher <- p:
+		// loop will handle it
+	case <-t.closeCtx.Done():
+		ch <- errClosed
+	}
+	return p
+}
+
+// handleReply dispatches a reply packet, invoking reply matchers. It returns
+// whether any matcher considered the packet acceptable.
+func (t *UDPv4) handleReply(from enode.ID, fromIP net.IP, req v4wire.Packet) bool {
+	matched := make(chan bool, 1)
+	select {
+	case t.gotreply <- reply{from, fromIP, req, matched}:
+		// loop will handle it
+		return <-matched
+	case <-t.closeCtx.Done():
+		return false
+	}
+}
+
+// loop runs in its own goroutine. it keeps track of
+// the refresh timer and the pending reply queue.
+func (t *UDPv4) loop() {
+	defer t.wg.Done()
+
+	var (
+		plist        = list.New()
+		timeout      = time.NewTimer(0)
+		nextTimeout  *replyMatcher // head of plist when timeout was last reset
+		contTimeouts = 0           // number of continuous timeouts to do NTP checks
+		ntpWarnTime  = time.Unix(0, 0)
+	)
+	<-timeout.C // ignore first timeout
+	defer timeout.Stop()
+
+	resetTimeout := func() {
+		if plist.Front() == nil || nextTimeout == plist.Front().Value {
+			return
+		}
+		// Start the timer so it fires when the next pending reply has expired.
+		now := time.Now()
+		for el := plist.Front(); el != nil; el = el.Next() {
+			nextTimeout = el.Value.(*replyMatcher)
+			if dist := nextTimeout.deadline.Sub(now); dist < 2*respTimeout {
+				timeout.Reset(dist)
+				return
+			}
+			// Remove pending replies whose deadline is too far in the
+			// future. These can occur if the system clock jumped
+			// backwards after the deadline was assigned.
+			nextTimeout.errc <- errClockWarp
+			plist.Remove(el)
+		}
+		nextTimeout = nil
+		timeout.Stop()
+	}
+
+	for {
+		resetTimeout()
+
+		select {
+		case <-t.closeCtx.Done():
+			for el := plist.Front(); el != nil; el = el.Next() {
+				el.Value.(*replyMatcher).errc <- errClosed
+			}
+			return
+
+		case p := <-t.addReplyMatcher:
+			p.deadline = time.Now().Add(respTimeout)
+			plist.PushBack(p)
+
+		case r := <-t.gotreply:
+			var matched bool // whether any replyMatcher considered the reply acceptable.
+			for el := plist.Front(); el != nil; el = el.Next() {
+				p := el.Value.(*replyMatcher)
+				if p.from == r.from && p.ptype == r.data.Kind() && p.ip.Equal(r.ip) {
+					ok, requestDone := p.callback(r.data)
+					matched = matched || ok
+					p.reply = r.data
+					// Remove the matcher if callback indicates that all replies have been received.
+					if requestDone {
+						p.errc <- nil
+						plist.Remove(el)
+					}
+					// Reset the continuous timeout counter (time drift detection)
+					contTimeouts = 0
+				}
+			}
+			r.matched <- matched
+
+		case now := <-timeout.C:
+			nextTimeout = nil
+
+			// Notify and remove callbacks whose deadline is in the past.
+			for el := plist.Front(); el != nil; el = el.Next() {
+				p := el.Value.(*replyMatcher)
+				if now.After(p.deadline) || now.Equal(p.deadline) {
+					p.errc <- errTimeout
+					plist.Remove(el)
+					contTimeouts++
+				}
+			}
+			// If we've accumulated too many timeouts, do an NTP time sync check
+			if contTimeouts > ntpFailureThreshold {
+				if time.Since(ntpWarnTime) >= ntpWarningCooldown {
+					ntpWarnTime = time.Now()
+					go checkClockDrift()
+				}
+				contTimeouts = 0
+			}
+		}
+	}
+}
+
+func (t *UDPv4) send(toaddr *net.UDPAddr, toid enode.ID, req v4wire.Packet) ([]byte, error) {
+	packet, hash, err := v4wire.Encode(t.priv, req)
+	if err != nil {
+		return hash, err
+	}
+	return hash, t.write(toaddr, toid, req.Name(), packet)
+}
+
+func (t *UDPv4) write(toaddr *net.UDPAddr, toid enode.ID, what string, packet []byte) error {
+	_, err := t.conn.WriteToUDP(packet, toaddr)
+	t.log.Trace(">> "+what, "id", toid, "addr", toaddr, "err", err)
+	return err
+}
+
+// readLoop runs in its own goroutine. it handles incoming UDP packets.
+func (t *UDPv4) readLoop(unhandled chan<- ReadPacket) {
+	defer t.wg.Done()
+	if unhandled != nil {
+		defer close(unhandled)
+	}
+
+	buf := make([]byte, maxPacketSize)
+	for {
+		nbytes, from, err := t.conn.ReadFromUDP(buf)
+		if netutil.IsTemporaryError(err) {
+			// Ignore temporary read errors.
+			t.log.Debug("Temporary UDP read error", "err", err)
+			continue
+		} else if err != nil {
+			// Shut down the loop for permament errors.
+			if err != io.EOF {
+				t.log.Debug("UDP read error", "err", err)
+			}
+			return
+		}
+		if t.handlePacket(from, buf[:nbytes]) != nil && unhandled != nil {
+			select {
+			case unhandled <- ReadPacket{buf[:nbytes], from}:
+			default:
+			}
+		}
+	}
+}
+
+func (t *UDPv4) handlePacket(from *net.UDPAddr, buf []byte) error {
+	rawpacket, fromKey, hash, err := v4wire.Decode(buf)
+	if err != nil {
+		t.log.Debug("Bad discv4 packet", "addr", from, "err", err)
+		return err
+	}
+	packet := t.wrapPacket(rawpacket)
+	fromID := fromKey.ID()
+	if err == nil && packet.preverify != nil {
+		err = packet.preverify(packet, from, fromID, fromKey)
+	}
+	t.log.Trace("<< "+packet.Name(), "id", fromID, "addr", from, "err", err)
+	if err == nil && packet.handle != nil {
+		packet.handle(packet, from, fromID, hash)
+	}
+	return err
+}
+
+// checkBond checks if the given node has a recent enough endpoint proof.
+func (t *UDPv4) checkBond(id enode.ID, ip net.IP) bool {
+	return time.Since(t.db.LastPongReceived(id, ip)) < bondExpiration
+}
+
+// ensureBond solicits a ping from a node if we haven't seen a ping from it for a while.
+// This ensures there is a valid endpoint proof on the remote end.
+func (t *UDPv4) ensureBond(toid enode.ID, toaddr *net.UDPAddr) {
+	tooOld := time.Since(t.db.LastPingReceived(toid, toaddr.IP)) > bondExpiration
+	if tooOld || t.db.FindFails(toid, toaddr.IP) > maxFindnodeFailures {
+		rm := t.sendPing(toid, toaddr, nil)
+		<-rm.errc
+		// Wait for them to ping back and process our pong.
+		time.Sleep(respTimeout)
+	}
+}
+
+func (t *UDPv4) nodeFromRPC(sender *net.UDPAddr, rn v4wire.Node) (*node, error) {
+	if rn.UDP <= 1024 {
+		return nil, errLowPort
+	}
+	if err := netutil.CheckRelayIP(sender.IP, rn.IP); err != nil {
+		return nil, err
+	}
+	if t.netrestrict != nil && !t.netrestrict.Contains(rn.IP) {
+		return nil, errors.New("not contained in netrestrict list")
+	}
+	key, err := v4wire.DecodePubkey(crypto.S256(), rn.ID)
+	if err != nil {
+		return nil, err
+	}
+	n := wrapNode(enode.NewV4(key, rn.IP, int(rn.TCP), int(rn.UDP)))
+	err = n.ValidateComplete()
+	return n, err
+}
+
+func nodeToRPC(n *node) v4wire.Node {
+	var key ecdsa.PublicKey
+	var ekey v4wire.Pubkey
+	if err := n.Load((*enode.Secp256k1)(&key)); err == nil {
+		ekey = v4wire.EncodePubkey(&key)
+	}
+	return v4wire.Node{ID: ekey, IP: n.IP(), UDP: uint16(n.UDP()), TCP: uint16(n.TCP())}
+}
+
+// wrapPacket returns the handler functions applicable to a packet.
+func (t *UDPv4) wrapPacket(p v4wire.Packet) *packetHandlerV4 {
+	var h packetHandlerV4
+	h.Packet = p
+	switch p.(type) {
+	case *v4wire.Ping:
+		h.preverify = t.verifyPing
+		h.handle = t.handlePing
+	case *v4wire.Pong:
+		h.preverify = t.verifyPong
+	case *v4wire.Findnode:
+		h.preverify = t.verifyFindnode
+		h.handle = t.handleFindnode
+	case *v4wire.Neighbors:
+		h.preverify = t.verifyNeighbors
+	case *v4wire.ENRRequest:
+		h.preverify = t.verifyENRRequest
+		h.handle = t.handleENRRequest
+	case *v4wire.ENRResponse:
+		h.preverify = t.verifyENRResponse
+	}
+	return &h
+}
+
+// packetHandlerV4 wraps a packet with handler functions.
+type packetHandlerV4 struct {
+	v4wire.Packet
+	senderKey *ecdsa.PublicKey // used for ping
+
+	// preverify checks whether the packet is valid and should be handled at all.
+	preverify func(p *packetHandlerV4, from *net.UDPAddr, fromID enode.ID, fromKey v4wire.Pubkey) error
+	// handle handles the packet.
+	handle func(req *packetHandlerV4, from *net.UDPAddr, fromID enode.ID, mac []byte)
+}
+
+// PING/v4
+
+func (t *UDPv4) verifyPing(h *packetHandlerV4, from *net.UDPAddr, fromID enode.ID, fromKey v4wire.Pubkey) error {
+	req := h.Packet.(*v4wire.Ping)
+
+	senderKey, err := v4wire.DecodePubkey(crypto.S256(), fromKey)
+	if err != nil {
+		return err
+	}
+	if v4wire.Expired(req.Expiration) {
+		return errExpired
+	}
+	h.senderKey = senderKey
+	return nil
+}
+
+func (t *UDPv4) handlePing(h *packetHandlerV4, from *net.UDPAddr, fromID enode.ID, mac []byte) {
+	req := h.Packet.(*v4wire.Ping)
+
+	// Reply.
+	t.send(from, fromID, &v4wire.Pong{
+		To:         v4wire.NewEndpoint(from, req.From.TCP),
+		ReplyTok:   mac,
+		Expiration: uint64(time.Now().Add(expiration).Unix()),
+		ENRSeq:     t.localNode.Node().Seq(),
+	})
+
+	// Ping back if our last pong on file is too far in the past.
+	n := wrapNode(enode.NewV4(h.senderKey, from.IP, int(req.From.TCP), from.Port))
+	if time.Since(t.db.LastPongReceived(n.ID(), from.IP)) > bondExpiration {
+		t.sendPing(fromID, from, func() {
+			t.tab.addVerifiedNode(n)
+		})
+	} else {
+		t.tab.addVerifiedNode(n)
+	}
+
+	// Update node database and endpoint predictor.
+	t.db.UpdateLastPingReceived(n.ID(), from.IP, time.Now())
+	t.localNode.UDPEndpointStatement(from, &net.UDPAddr{IP: req.To.IP, Port: int(req.To.UDP)})
+}
+
+// PONG/v4
+
+func (t *UDPv4) verifyPong(h *packetHandlerV4, from *net.UDPAddr, fromID enode.ID, fromKey v4wire.Pubkey) error {
+	req := h.Packet.(*v4wire.Pong)
+
+	if v4wire.Expired(req.Expiration) {
+		return errExpired
+	}
+	if !t.handleReply(fromID, from.IP, req) {
+		return errUnsolicitedReply
+	}
+	t.localNode.UDPEndpointStatement(from, &net.UDPAddr{IP: req.To.IP, Port: int(req.To.UDP)})
+	t.db.UpdateLastPongReceived(fromID, from.IP, time.Now())
+	return nil
+}
+
+// FINDNODE/v4
+
+func (t *UDPv4) verifyFindnode(h *packetHandlerV4, from *net.UDPAddr, fromID enode.ID, fromKey v4wire.Pubkey) error {
+	req := h.Packet.(*v4wire.Findnode)
+
+	if v4wire.Expired(req.Expiration) {
+		return errExpired
+	}
+	if !t.checkBond(fromID, from.IP) {
+		// No endpoint proof pong exists, we don't process the packet. This prevents an
+		// attack vector where the discovery protocol could be used to amplify traffic in a
+		// DDOS attack. A malicious actor would send a findnode request with the IP address
+		// and UDP port of the target as the source address. The recipient of the findnode
+		// packet would then send a neighbors packet (which is a much bigger packet than
+		// findnode) to the victim.
+		return errUnknownNode
+	}
+	return nil
+}
+
+func (t *UDPv4) handleFindnode(h *packetHandlerV4, from *net.UDPAddr, fromID enode.ID, mac []byte) {
+	req := h.Packet.(*v4wire.Findnode)
+
+	// Determine closest nodes.
+	target := enode.ID(crypto.Keccak256Hash(req.Target[:]))
+	closest := t.tab.findnodeByID(target, bucketSize, true).entries
+
+	// Send neighbors in chunks with at most maxNeighbors per packet
+	// to stay below the packet size limit.
+	p := v4wire.Neighbors{Expiration: uint64(time.Now().Add(expiration).Unix())}
+	var sent bool
+	for _, n := range closest {
+		if netutil.CheckRelayIP(from.IP, n.IP()) == nil {
+			p.Nodes = append(p.Nodes, nodeToRPC(n))
+		}
+		if len(p.Nodes) == v4wire.MaxNeighbors {
+			t.send(from, fromID, &p)
+			p.Nodes = p.Nodes[:0]
+			sent = true
+		}
+	}
+	if len(p.Nodes) > 0 || !sent {
+		t.send(from, fromID, &p)
+	}
+}
+
+// NEIGHBORS/v4
+
+func (t *UDPv4) verifyNeighbors(h *packetHandlerV4, from *net.UDPAddr, fromID enode.ID, fromKey v4wire.Pubkey) error {
+	req := h.Packet.(*v4wire.Neighbors)
+
+	if v4wire.Expired(req.Expiration) {
+		return errExpired
+	}
+	if !t.handleReply(fromID, from.IP, h.Packet) {
+		return errUnsolicitedReply
+	}
+	return nil
+}
+
+// ENRREQUEST/v4
+
+func (t *UDPv4) verifyENRRequest(h *packetHandlerV4, from *net.UDPAddr, fromID enode.ID, fromKey v4wire.Pubkey) error {
+	req := h.Packet.(*v4wire.ENRRequest)
+
+	if v4wire.Expired(req.Expiration) {
+		return errExpired
+	}
+	if !t.checkBond(fromID, from.IP) {
+		return errUnknownNode
+	}
+	return nil
+}
+
+func (t *UDPv4) handleENRRequest(h *packetHandlerV4, from *net.UDPAddr, fromID enode.ID, mac []byte) {
+	t.send(from, fromID, &v4wire.ENRResponse{
+		ReplyTok: mac,
+		Record:   *t.localNode.Node().Record(),
+	})
+}
+
+// ENRRESPONSE/v4
+
+func (t *UDPv4) verifyENRResponse(h *packetHandlerV4, from *net.UDPAddr, fromID enode.ID, fromKey v4wire.Pubkey) error {
+	if !t.handleReply(fromID, from.IP, h.Packet) {
+		return errUnsolicitedReply
+	}
+	return nil
+}

--- a/p2p/discover/v4_udp_test.go
+++ b/p2p/discover/v4_udp_test.go
@@ -1,0 +1,666 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package discover
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	crand "crypto/rand"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"net"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dominant-strategies/go-quai/internal/testlog"
+	"github.com/dominant-strategies/go-quai/log"
+	"github.com/dominant-strategies/go-quai/p2p/discover/v4wire"
+	"github.com/dominant-strategies/go-quai/p2p/enode"
+	"github.com/dominant-strategies/go-quai/p2p/enr"
+)
+
+// shared test variables
+var (
+	futureExp          = uint64(time.Now().Add(10 * time.Hour).Unix())
+	testTarget         = v4wire.Pubkey{0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1}
+	testRemote         = v4wire.Endpoint{IP: net.ParseIP("1.1.1.1").To4(), UDP: 1, TCP: 2}
+	testLocalAnnounced = v4wire.Endpoint{IP: net.ParseIP("2.2.2.2").To4(), UDP: 3, TCP: 4}
+	testLocal          = v4wire.Endpoint{IP: net.ParseIP("3.3.3.3").To4(), UDP: 5, TCP: 6}
+)
+
+type udpTest struct {
+	t                   *testing.T
+	pipe                *dgramPipe
+	table               *Table
+	db                  *enode.DB
+	udp                 *UDPv4
+	sent                [][]byte
+	localkey, remotekey *ecdsa.PrivateKey
+	remoteaddr          *net.UDPAddr
+}
+
+func newUDPTest(t *testing.T) *udpTest {
+	test := &udpTest{
+		t:          t,
+		pipe:       newpipe(),
+		localkey:   newkey(),
+		remotekey:  newkey(),
+		remoteaddr: &net.UDPAddr{IP: net.IP{10, 0, 1, 99}, Port: 30303},
+	}
+
+	test.db, _ = enode.OpenDB("")
+	ln := enode.NewLocalNode(test.db, test.localkey)
+	test.udp, _ = ListenV4(test.pipe, ln, Config{
+		PrivateKey: test.localkey,
+		Log:        testlog.Logger(t, log.LvlTrace),
+	})
+	test.table = test.udp.tab
+	// Wait for initial refresh so the table doesn't send unexpected findnode.
+	<-test.table.initDone
+	return test
+}
+
+func (test *udpTest) close() {
+	test.udp.Close()
+	test.db.Close()
+}
+
+// handles a packet as if it had been sent to the transport.
+func (test *udpTest) packetIn(wantError error, data v4wire.Packet) {
+	test.t.Helper()
+
+	test.packetInFrom(wantError, test.remotekey, test.remoteaddr, data)
+}
+
+// handles a packet as if it had been sent to the transport by the key/endpoint.
+func (test *udpTest) packetInFrom(wantError error, key *ecdsa.PrivateKey, addr *net.UDPAddr, data v4wire.Packet) {
+	test.t.Helper()
+
+	enc, _, err := v4wire.Encode(key, data)
+	if err != nil {
+		test.t.Errorf("%s encode error: %v", data.Name(), err)
+	}
+	test.sent = append(test.sent, enc)
+	if err = test.udp.handlePacket(addr, enc); err != wantError {
+		test.t.Errorf("error mismatch: got %q, want %q", err, wantError)
+	}
+}
+
+// waits for a packet to be sent by the transport.
+// validate should have type func(X, *net.UDPAddr, []byte), where X is a packet type.
+func (test *udpTest) waitPacketOut(validate interface{}) (closed bool) {
+	test.t.Helper()
+
+	dgram, err := test.pipe.receive()
+	if err == errClosed {
+		return true
+	} else if err != nil {
+		test.t.Error("packet receive error:", err)
+		return false
+	}
+	p, _, hash, err := v4wire.Decode(dgram.data)
+	if err != nil {
+		test.t.Errorf("sent packet decode error: %v", err)
+		return false
+	}
+	fn := reflect.ValueOf(validate)
+	exptype := fn.Type().In(0)
+	if !reflect.TypeOf(p).AssignableTo(exptype) {
+		test.t.Errorf("sent packet type mismatch, got: %v, want: %v", reflect.TypeOf(p), exptype)
+		return false
+	}
+	fn.Call([]reflect.Value{reflect.ValueOf(p), reflect.ValueOf(&dgram.to), reflect.ValueOf(hash)})
+	return false
+}
+
+func TestUDPv4_packetErrors(t *testing.T) {
+	test := newUDPTest(t)
+	defer test.close()
+
+	test.packetIn(errExpired, &v4wire.Ping{From: testRemote, To: testLocalAnnounced, Version: 4})
+	test.packetIn(errUnsolicitedReply, &v4wire.Pong{ReplyTok: []byte{}, Expiration: futureExp})
+	test.packetIn(errUnknownNode, &v4wire.Findnode{Expiration: futureExp})
+	test.packetIn(errUnsolicitedReply, &v4wire.Neighbors{Expiration: futureExp})
+}
+
+func TestUDPv4_pingTimeout(t *testing.T) {
+	t.Parallel()
+	test := newUDPTest(t)
+	defer test.close()
+
+	key := newkey()
+	toaddr := &net.UDPAddr{IP: net.ParseIP("1.2.3.4"), Port: 2222}
+	node := enode.NewV4(&key.PublicKey, toaddr.IP, 0, toaddr.Port)
+	if _, err := test.udp.ping(node); err != errTimeout {
+		t.Error("expected timeout error, got", err)
+	}
+}
+
+type testPacket byte
+
+func (req testPacket) Kind() byte   { return byte(req) }
+func (req testPacket) Name() string { return "" }
+
+func TestUDPv4_responseTimeouts(t *testing.T) {
+	t.Parallel()
+	test := newUDPTest(t)
+	defer test.close()
+
+	rand.Seed(time.Now().UnixNano())
+	randomDuration := func(max time.Duration) time.Duration {
+		return time.Duration(rand.Int63n(int64(max)))
+	}
+
+	var (
+		nReqs      = 200
+		nTimeouts  = 0                       // number of requests with ptype > 128
+		nilErr     = make(chan error, nReqs) // for requests that get a reply
+		timeoutErr = make(chan error, nReqs) // for requests that time out
+	)
+	for i := 0; i < nReqs; i++ {
+		// Create a matcher for a random request in udp.loop. Requests
+		// with ptype <= 128 will not get a reply and should time out.
+		// For all other requests, a reply is scheduled to arrive
+		// within the timeout window.
+		p := &replyMatcher{
+			ptype:    byte(rand.Intn(255)),
+			callback: func(v4wire.Packet) (bool, bool) { return true, true },
+		}
+		binary.BigEndian.PutUint64(p.from[:], uint64(i))
+		if p.ptype <= 128 {
+			p.errc = timeoutErr
+			test.udp.addReplyMatcher <- p
+			nTimeouts++
+		} else {
+			p.errc = nilErr
+			test.udp.addReplyMatcher <- p
+			time.AfterFunc(randomDuration(60*time.Millisecond), func() {
+				if !test.udp.handleReply(p.from, p.ip, testPacket(p.ptype)) {
+					t.Logf("not matched: %v", p)
+				}
+			})
+		}
+		time.Sleep(randomDuration(30 * time.Millisecond))
+	}
+
+	// Check that all timeouts were delivered and that the rest got nil errors.
+	// The replies must be delivered.
+	var (
+		recvDeadline        = time.After(20 * time.Second)
+		nTimeoutsRecv, nNil = 0, 0
+	)
+	for i := 0; i < nReqs; i++ {
+		select {
+		case err := <-timeoutErr:
+			if err != errTimeout {
+				t.Fatalf("got non-timeout error on timeoutErr %d: %v", i, err)
+			}
+			nTimeoutsRecv++
+		case err := <-nilErr:
+			if err != nil {
+				t.Fatalf("got non-nil error on nilErr %d: %v", i, err)
+			}
+			nNil++
+		case <-recvDeadline:
+			t.Fatalf("exceeded recv deadline")
+		}
+	}
+	if nTimeoutsRecv != nTimeouts {
+		t.Errorf("wrong number of timeout errors received: got %d, want %d", nTimeoutsRecv, nTimeouts)
+	}
+	if nNil != nReqs-nTimeouts {
+		t.Errorf("wrong number of successful replies: got %d, want %d", nNil, nReqs-nTimeouts)
+	}
+}
+
+func TestUDPv4_findnodeTimeout(t *testing.T) {
+	t.Parallel()
+	test := newUDPTest(t)
+	defer test.close()
+
+	toaddr := &net.UDPAddr{IP: net.ParseIP("1.2.3.4"), Port: 2222}
+	toid := enode.ID{1, 2, 3, 4}
+	target := v4wire.Pubkey{4, 5, 6, 7}
+	result, err := test.udp.findnode(toid, toaddr, target)
+	if err != errTimeout {
+		t.Error("expected timeout error, got", err)
+	}
+	if len(result) > 0 {
+		t.Error("expected empty result, got", result)
+	}
+}
+
+func TestUDPv4_findnode(t *testing.T) {
+	test := newUDPTest(t)
+	defer test.close()
+
+	// put a few nodes into the table. their exact
+	// distribution shouldn't matter much, although we need to
+	// take care not to overflow any bucket.
+	nodes := &nodesByDistance{target: testTarget.ID()}
+	live := make(map[enode.ID]bool)
+	numCandidates := 2 * bucketSize
+	for i := 0; i < numCandidates; i++ {
+		key := newkey()
+		ip := net.IP{10, 13, 0, byte(i)}
+		n := wrapNode(enode.NewV4(&key.PublicKey, ip, 0, 2000))
+		// Ensure half of table content isn't verified live yet.
+		if i > numCandidates/2 {
+			n.livenessChecks = 1
+			live[n.ID()] = true
+		}
+		nodes.push(n, numCandidates)
+	}
+	fillTable(test.table, nodes.entries)
+
+	// ensure there's a bond with the test node,
+	// findnode won't be accepted otherwise.
+	remoteID := v4wire.EncodePubkey(&test.remotekey.PublicKey).ID()
+	test.table.db.UpdateLastPongReceived(remoteID, test.remoteaddr.IP, time.Now())
+
+	// check that closest neighbors are returned.
+	expected := test.table.findnodeByID(testTarget.ID(), bucketSize, true)
+	test.packetIn(nil, &v4wire.Findnode{Target: testTarget, Expiration: futureExp})
+	waitNeighbors := func(want []*node) {
+		test.waitPacketOut(func(p *v4wire.Neighbors, to *net.UDPAddr, hash []byte) {
+			if len(p.Nodes) != len(want) {
+				t.Errorf("wrong number of results: got %d, want %d", len(p.Nodes), bucketSize)
+			}
+			for i, n := range p.Nodes {
+				if n.ID.ID() != want[i].ID() {
+					t.Errorf("result mismatch at %d:\n  got:  %v\n  want: %v", i, n, expected.entries[i])
+				}
+				if !live[n.ID.ID()] {
+					t.Errorf("result includes dead node %v", n.ID.ID())
+				}
+			}
+		})
+	}
+	// Receive replies.
+	want := expected.entries
+	if len(want) > v4wire.MaxNeighbors {
+		waitNeighbors(want[:v4wire.MaxNeighbors])
+		want = want[v4wire.MaxNeighbors:]
+	}
+	waitNeighbors(want)
+}
+
+func TestUDPv4_findnodeMultiReply(t *testing.T) {
+	test := newUDPTest(t)
+	defer test.close()
+
+	rid := enode.PubkeyToIDV4(&test.remotekey.PublicKey)
+	test.table.db.UpdateLastPingReceived(rid, test.remoteaddr.IP, time.Now())
+
+	// queue a pending findnode request
+	resultc, errc := make(chan []*node), make(chan error)
+	go func() {
+		rid := encodePubkey(&test.remotekey.PublicKey).id()
+		ns, err := test.udp.findnode(rid, test.remoteaddr, testTarget)
+		if err != nil && len(ns) == 0 {
+			errc <- err
+		} else {
+			resultc <- ns
+		}
+	}()
+
+	// wait for the findnode to be sent.
+	// after it is sent, the transport is waiting for a reply
+	test.waitPacketOut(func(p *v4wire.Findnode, to *net.UDPAddr, hash []byte) {
+		if p.Target != testTarget {
+			t.Errorf("wrong target: got %v, want %v", p.Target, testTarget)
+		}
+	})
+
+	// send the reply as two packets.
+	list := []*node{
+		wrapNode(enode.MustParse("enode://ba85011c70bcc5c04d8607d3a0ed29aa6179c092cbdda10d5d32684fb33ed01bd94f588ca8f91ac48318087dcb02eaf36773a7a453f0eedd6742af668097b29c@10.0.1.16:30303?discport=30304")),
+		wrapNode(enode.MustParse("enode://81fa361d25f157cd421c60dcc28d8dac5ef6a89476633339c5df30287474520caca09627da18543d9079b5b288698b542d56167aa5c09111e55acdbbdf2ef799@10.0.1.16:30303")),
+		wrapNode(enode.MustParse("enode://9bffefd833d53fac8e652415f4973bee289e8b1a5c6c4cbe70abf817ce8a64cee11b823b66a987f51aaa9fba0d6a91b3e6bf0d5a5d1042de8e9eeea057b217f8@10.0.1.36:30301?discport=17")),
+		wrapNode(enode.MustParse("enode://1b5b4aa662d7cb44a7221bfba67302590b643028197a7d5214790f3bac7aaa4a3241be9e83c09cf1f6c69d007c634faae3dc1b1221793e8446c0b3a09de65960@10.0.1.16:30303")),
+	}
+	rpclist := make([]v4wire.Node, len(list))
+	for i := range list {
+		rpclist[i] = nodeToRPC(list[i])
+	}
+	test.packetIn(nil, &v4wire.Neighbors{Expiration: futureExp, Nodes: rpclist[:2]})
+	test.packetIn(nil, &v4wire.Neighbors{Expiration: futureExp, Nodes: rpclist[2:]})
+
+	// check that the sent neighbors are all returned by findnode
+	select {
+	case result := <-resultc:
+		want := append(list[:2], list[3:]...)
+		if !reflect.DeepEqual(result, want) {
+			t.Errorf("neighbors mismatch:\n  got:  %v\n  want: %v", result, want)
+		}
+	case err := <-errc:
+		t.Errorf("findnode error: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Error("findnode did not return within 5 seconds")
+	}
+}
+
+// This test checks that reply matching of pong verifies the ping hash.
+func TestUDPv4_pingMatch(t *testing.T) {
+	test := newUDPTest(t)
+	defer test.close()
+
+	randToken := make([]byte, 32)
+	crand.Read(randToken)
+
+	test.packetIn(nil, &v4wire.Ping{From: testRemote, To: testLocalAnnounced, Version: 4, Expiration: futureExp})
+	test.waitPacketOut(func(*v4wire.Pong, *net.UDPAddr, []byte) {})
+	test.waitPacketOut(func(*v4wire.Ping, *net.UDPAddr, []byte) {})
+	test.packetIn(errUnsolicitedReply, &v4wire.Pong{ReplyTok: randToken, To: testLocalAnnounced, Expiration: futureExp})
+}
+
+// This test checks that reply matching of pong verifies the sender IP address.
+func TestUDPv4_pingMatchIP(t *testing.T) {
+	test := newUDPTest(t)
+	defer test.close()
+
+	test.packetIn(nil, &v4wire.Ping{From: testRemote, To: testLocalAnnounced, Version: 4, Expiration: futureExp})
+	test.waitPacketOut(func(*v4wire.Pong, *net.UDPAddr, []byte) {})
+
+	test.waitPacketOut(func(p *v4wire.Ping, to *net.UDPAddr, hash []byte) {
+		wrongAddr := &net.UDPAddr{IP: net.IP{33, 44, 1, 2}, Port: 30000}
+		test.packetInFrom(errUnsolicitedReply, test.remotekey, wrongAddr, &v4wire.Pong{
+			ReplyTok:   hash,
+			To:         testLocalAnnounced,
+			Expiration: futureExp,
+		})
+	})
+}
+
+func TestUDPv4_successfulPing(t *testing.T) {
+	test := newUDPTest(t)
+	added := make(chan *node, 1)
+	test.table.nodeAddedHook = func(n *node) { added <- n }
+	defer test.close()
+
+	// The remote side sends a ping packet to initiate the exchange.
+	go test.packetIn(nil, &v4wire.Ping{From: testRemote, To: testLocalAnnounced, Version: 4, Expiration: futureExp})
+
+	// The ping is replied to.
+	test.waitPacketOut(func(p *v4wire.Pong, to *net.UDPAddr, hash []byte) {
+		pinghash := test.sent[0][:32]
+		if !bytes.Equal(p.ReplyTok, pinghash) {
+			t.Errorf("got pong.ReplyTok %x, want %x", p.ReplyTok, pinghash)
+		}
+		wantTo := v4wire.Endpoint{
+			// The mirrored UDP address is the UDP packet sender
+			IP: test.remoteaddr.IP, UDP: uint16(test.remoteaddr.Port),
+			// The mirrored TCP port is the one from the ping packet
+			TCP: testRemote.TCP,
+		}
+		if !reflect.DeepEqual(p.To, wantTo) {
+			t.Errorf("got pong.To %v, want %v", p.To, wantTo)
+		}
+	})
+
+	// Remote is unknown, the table pings back.
+	test.waitPacketOut(func(p *v4wire.Ping, to *net.UDPAddr, hash []byte) {
+		if !reflect.DeepEqual(p.From, test.udp.ourEndpoint()) {
+			t.Errorf("got ping.From %#v, want %#v", p.From, test.udp.ourEndpoint())
+		}
+		wantTo := v4wire.Endpoint{
+			// The mirrored UDP address is the UDP packet sender.
+			IP:  test.remoteaddr.IP,
+			UDP: uint16(test.remoteaddr.Port),
+			TCP: 0,
+		}
+		if !reflect.DeepEqual(p.To, wantTo) {
+			t.Errorf("got ping.To %v, want %v", p.To, wantTo)
+		}
+		test.packetIn(nil, &v4wire.Pong{ReplyTok: hash, Expiration: futureExp})
+	})
+
+	// The node should be added to the table shortly after getting the
+	// pong packet.
+	select {
+	case n := <-added:
+		rid := encodePubkey(&test.remotekey.PublicKey).id()
+		if n.ID() != rid {
+			t.Errorf("node has wrong ID: got %v, want %v", n.ID(), rid)
+		}
+		if !n.IP().Equal(test.remoteaddr.IP) {
+			t.Errorf("node has wrong IP: got %v, want: %v", n.IP(), test.remoteaddr.IP)
+		}
+		if n.UDP() != test.remoteaddr.Port {
+			t.Errorf("node has wrong UDP port: got %v, want: %v", n.UDP(), test.remoteaddr.Port)
+		}
+		if n.TCP() != int(testRemote.TCP) {
+			t.Errorf("node has wrong TCP port: got %v, want: %v", n.TCP(), testRemote.TCP)
+		}
+	case <-time.After(2 * time.Second):
+		t.Errorf("node was not added within 2 seconds")
+	}
+}
+
+// This test checks that EIP-868 requests work.
+func TestUDPv4_EIP868(t *testing.T) {
+	test := newUDPTest(t)
+	defer test.close()
+
+	test.udp.localNode.Set(enr.WithEntry("foo", "bar"))
+	wantNode := test.udp.localNode.Node()
+
+	// ENR requests aren't allowed before endpoint proof.
+	test.packetIn(errUnknownNode, &v4wire.ENRRequest{Expiration: futureExp})
+
+	// Perform endpoint proof and check for sequence number in packet tail.
+	test.packetIn(nil, &v4wire.Ping{Expiration: futureExp})
+	test.waitPacketOut(func(p *v4wire.Pong, addr *net.UDPAddr, hash []byte) {
+		if p.ENRSeq != wantNode.Seq() {
+			t.Errorf("wrong sequence number in pong: %d, want %d", p.ENRSeq, wantNode.Seq())
+		}
+	})
+	test.waitPacketOut(func(p *v4wire.Ping, addr *net.UDPAddr, hash []byte) {
+		if p.ENRSeq != wantNode.Seq() {
+			t.Errorf("wrong sequence number in ping: %d, want %d", p.ENRSeq, wantNode.Seq())
+		}
+		test.packetIn(nil, &v4wire.Pong{Expiration: futureExp, ReplyTok: hash})
+	})
+
+	// Request should work now.
+	test.packetIn(nil, &v4wire.ENRRequest{Expiration: futureExp})
+	test.waitPacketOut(func(p *v4wire.ENRResponse, addr *net.UDPAddr, hash []byte) {
+		n, err := enode.New(enode.ValidSchemes, &p.Record)
+		if err != nil {
+			t.Fatalf("invalid record: %v", err)
+		}
+		if !reflect.DeepEqual(n, wantNode) {
+			t.Fatalf("wrong node in enrResponse: %v", n)
+		}
+	})
+}
+
+// This test verifies that a small network of nodes can boot up into a healthy state.
+func TestUDPv4_smallNetConvergence(t *testing.T) {
+	t.Parallel()
+
+	// Start the network.
+	nodes := make([]*UDPv4, 4)
+	for i := range nodes {
+		var cfg Config
+		if i > 0 {
+			bn := nodes[0].Self()
+			cfg.Bootnodes = []*enode.Node{bn}
+		}
+		nodes[i] = startLocalhostV4(t, cfg)
+		defer nodes[i].Close()
+	}
+
+	// Run through the iterator on all nodes until
+	// they have all found each other.
+	status := make(chan error, len(nodes))
+	for i := range nodes {
+		node := nodes[i]
+		go func() {
+			found := make(map[enode.ID]bool, len(nodes))
+			it := node.RandomNodes()
+			for it.Next() {
+				found[it.Node().ID()] = true
+				if len(found) == len(nodes) {
+					status <- nil
+					return
+				}
+			}
+			status <- fmt.Errorf("node %s didn't find all nodes", node.Self().ID().TerminalString())
+		}()
+	}
+
+	// Wait for all status reports.
+	timeout := time.NewTimer(30 * time.Second)
+	defer timeout.Stop()
+	for received := 0; received < len(nodes); {
+		select {
+		case <-timeout.C:
+			for _, node := range nodes {
+				node.Close()
+			}
+		case err := <-status:
+			received++
+			if err != nil {
+				t.Error("ERROR:", err)
+				return
+			}
+		}
+	}
+}
+
+func startLocalhostV4(t *testing.T, cfg Config) *UDPv4 {
+	t.Helper()
+
+	cfg.PrivateKey = newkey()
+	db, _ := enode.OpenDB("")
+	ln := enode.NewLocalNode(db, cfg.PrivateKey)
+
+	// Prefix logs with node ID.
+	lprefix := fmt.Sprintf("(%s)", ln.ID().TerminalString())
+	lfmt := log.TerminalFormat(false)
+	cfg.Log = testlog.Logger(t, log.LvlTrace)
+	cfg.Log.SetHandler(log.FuncHandler(func(r *log.Record) error {
+		t.Logf("%s %s", lprefix, lfmt.Format(r))
+		return nil
+	}))
+
+	// Listen.
+	socket, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IP{127, 0, 0, 1}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	realaddr := socket.LocalAddr().(*net.UDPAddr)
+	ln.SetStaticIP(realaddr.IP)
+	ln.SetFallbackUDP(realaddr.Port)
+	udp, err := ListenV4(socket, ln, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return udp
+}
+
+// dgramPipe is a fake UDP socket. It queues all sent datagrams.
+type dgramPipe struct {
+	mu      *sync.Mutex
+	cond    *sync.Cond
+	closing chan struct{}
+	closed  bool
+	queue   []dgram
+}
+
+type dgram struct {
+	to   net.UDPAddr
+	data []byte
+}
+
+func newpipe() *dgramPipe {
+	mu := new(sync.Mutex)
+	return &dgramPipe{
+		closing: make(chan struct{}),
+		cond:    &sync.Cond{L: mu},
+		mu:      mu,
+	}
+}
+
+// WriteToUDP queues a datagram.
+func (c *dgramPipe) WriteToUDP(b []byte, to *net.UDPAddr) (n int, err error) {
+	msg := make([]byte, len(b))
+	copy(msg, b)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return 0, errors.New("closed")
+	}
+	c.queue = append(c.queue, dgram{*to, b})
+	c.cond.Signal()
+	return len(b), nil
+}
+
+// ReadFromUDP just hangs until the pipe is closed.
+func (c *dgramPipe) ReadFromUDP(b []byte) (n int, addr *net.UDPAddr, err error) {
+	<-c.closing
+	return 0, nil, io.EOF
+}
+
+func (c *dgramPipe) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.closed {
+		close(c.closing)
+		c.closed = true
+	}
+	c.cond.Broadcast()
+	return nil
+}
+
+func (c *dgramPipe) LocalAddr() net.Addr {
+	return &net.UDPAddr{IP: testLocal.IP, Port: int(testLocal.UDP)}
+}
+
+func (c *dgramPipe) receive() (dgram, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var timedOut bool
+	timer := time.AfterFunc(3*time.Second, func() {
+		c.mu.Lock()
+		timedOut = true
+		c.mu.Unlock()
+		c.cond.Broadcast()
+	})
+	defer timer.Stop()
+
+	for len(c.queue) == 0 && !c.closed && !timedOut {
+		c.cond.Wait()
+	}
+	if c.closed {
+		return dgram{}, errClosed
+	}
+	if timedOut {
+		return dgram{}, errTimeout
+	}
+	p := c.queue[0]
+	copy(c.queue, c.queue[1:])
+	c.queue = c.queue[:len(c.queue)-1]
+	return p, nil
+}

--- a/p2p/discover/v4wire/v4wire.go
+++ b/p2p/discover/v4wire/v4wire.go
@@ -1,0 +1,293 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package v4wire implements the Discovery v4 Wire Protocol.
+package v4wire
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"errors"
+	"fmt"
+	"math/big"
+	"net"
+	"time"
+
+	"github.com/dominant-strategies/go-quai/common/math"
+	"github.com/dominant-strategies/go-quai/crypto"
+	"github.com/dominant-strategies/go-quai/p2p/enode"
+	"github.com/dominant-strategies/go-quai/p2p/enr"
+	"github.com/dominant-strategies/go-quai/rlp"
+)
+
+// RPC packet types
+const (
+	PingPacket = iota + 1 // zero is 'reserved'
+	PongPacket
+	FindnodePacket
+	NeighborsPacket
+	ENRRequestPacket
+	ENRResponsePacket
+)
+
+// RPC request structures
+type (
+	Ping struct {
+		Version    uint
+		From, To   Endpoint
+		Expiration uint64
+		ENRSeq     uint64 `rlp:"optional"` // Sequence number of local record, added by EIP-868.
+
+		// Ignore additional fields (for forward compatibility).
+		Rest []rlp.RawValue `rlp:"tail"`
+	}
+
+	// Pong is the reply to ping.
+	Pong struct {
+		// This field should mirror the UDP envelope address
+		// of the ping packet, which provides a way to discover the
+		// the external address (after NAT).
+		To         Endpoint
+		ReplyTok   []byte // This contains the hash of the ping packet.
+		Expiration uint64 // Absolute timestamp at which the packet becomes invalid.
+		ENRSeq     uint64 `rlp:"optional"` // Sequence number of local record, added by EIP-868.
+
+		// Ignore additional fields (for forward compatibility).
+		Rest []rlp.RawValue `rlp:"tail"`
+	}
+
+	// Findnode is a query for nodes close to the given target.
+	Findnode struct {
+		Target     Pubkey
+		Expiration uint64
+		// Ignore additional fields (for forward compatibility).
+		Rest []rlp.RawValue `rlp:"tail"`
+	}
+
+	// Neighbors is the reply to findnode.
+	Neighbors struct {
+		Nodes      []Node
+		Expiration uint64
+		// Ignore additional fields (for forward compatibility).
+		Rest []rlp.RawValue `rlp:"tail"`
+	}
+
+	// enrRequest queries for the remote node's record.
+	ENRRequest struct {
+		Expiration uint64
+		// Ignore additional fields (for forward compatibility).
+		Rest []rlp.RawValue `rlp:"tail"`
+	}
+
+	// enrResponse is the reply to enrRequest.
+	ENRResponse struct {
+		ReplyTok []byte // Hash of the enrRequest packet.
+		Record   enr.Record
+		// Ignore additional fields (for forward compatibility).
+		Rest []rlp.RawValue `rlp:"tail"`
+	}
+)
+
+// This number is the maximum number of neighbor nodes in a Neigbors packet.
+const MaxNeighbors = 12
+
+// This code computes the MaxNeighbors constant value.
+
+// func init() {
+// 	var maxNeighbors int
+// 	p := Neighbors{Expiration: ^uint64(0)}
+// 	maxSizeNode := Node{IP: make(net.IP, 16), UDP: ^uint16(0), TCP: ^uint16(0)}
+// 	for n := 0; ; n++ {
+// 		p.Nodes = append(p.Nodes, maxSizeNode)
+// 		size, _, err := rlp.EncodeToReader(p)
+// 		if err != nil {
+// 			// If this ever happens, it will be caught by the unit tests.
+// 			panic("cannot encode: " + err.Error())
+// 		}
+// 		if headSize+size+1 >= 1280 {
+// 			maxNeighbors = n
+// 			break
+// 		}
+// 	}
+// 	fmt.Println("maxNeighbors", maxNeighbors)
+// }
+
+// Pubkey represents an encoded 64-byte secp256k1 public key.
+type Pubkey [64]byte
+
+// ID returns the node ID corresponding to the public key.
+func (e Pubkey) ID() enode.ID {
+	return enode.ID(crypto.Keccak256Hash(e[:]))
+}
+
+// Node represents information about a node.
+type Node struct {
+	IP  net.IP // len 4 for IPv4 or 16 for IPv6
+	UDP uint16 // for discovery protocol
+	TCP uint16 // for RLPx protocol
+	ID  Pubkey
+}
+
+// Endpoint represents a network endpoint.
+type Endpoint struct {
+	IP  net.IP // len 4 for IPv4 or 16 for IPv6
+	UDP uint16 // for discovery protocol
+	TCP uint16 // for RLPx protocol
+}
+
+// NewEndpoint creates an endpoint.
+func NewEndpoint(addr *net.UDPAddr, tcpPort uint16) Endpoint {
+	ip := net.IP{}
+	if ip4 := addr.IP.To4(); ip4 != nil {
+		ip = ip4
+	} else if ip6 := addr.IP.To16(); ip6 != nil {
+		ip = ip6
+	}
+	return Endpoint{IP: ip, UDP: uint16(addr.Port), TCP: tcpPort}
+}
+
+type Packet interface {
+	// packet name and type for logging purposes.
+	Name() string
+	Kind() byte
+}
+
+func (req *Ping) Name() string { return "PING/v4" }
+func (req *Ping) Kind() byte   { return PingPacket }
+
+func (req *Pong) Name() string { return "PONG/v4" }
+func (req *Pong) Kind() byte   { return PongPacket }
+
+func (req *Findnode) Name() string { return "FINDNODE/v4" }
+func (req *Findnode) Kind() byte   { return FindnodePacket }
+
+func (req *Neighbors) Name() string { return "NEIGHBORS/v4" }
+func (req *Neighbors) Kind() byte   { return NeighborsPacket }
+
+func (req *ENRRequest) Name() string { return "ENRREQUEST/v4" }
+func (req *ENRRequest) Kind() byte   { return ENRRequestPacket }
+
+func (req *ENRResponse) Name() string { return "ENRRESPONSE/v4" }
+func (req *ENRResponse) Kind() byte   { return ENRResponsePacket }
+
+// Expired checks whether the given UNIX time stamp is in the past.
+func Expired(ts uint64) bool {
+	return time.Unix(int64(ts), 0).Before(time.Now())
+}
+
+// Encoder/decoder.
+
+const (
+	macSize  = 32
+	sigSize  = crypto.SignatureLength
+	headSize = macSize + sigSize // space of packet frame data
+)
+
+var (
+	ErrPacketTooSmall = errors.New("too small")
+	ErrBadHash        = errors.New("bad hash")
+	ErrBadPoint       = errors.New("invalid curve point")
+)
+
+var headSpace = make([]byte, headSize)
+
+// Decode reads a discovery v4 packet.
+func Decode(input []byte) (Packet, Pubkey, []byte, error) {
+	if len(input) < headSize+1 {
+		return nil, Pubkey{}, nil, ErrPacketTooSmall
+	}
+	hash, sig, sigdata := input[:macSize], input[macSize:headSize], input[headSize:]
+	shouldhash := crypto.Keccak256(input[macSize:])
+	if !bytes.Equal(hash, shouldhash) {
+		return nil, Pubkey{}, nil, ErrBadHash
+	}
+	fromKey, err := recoverNodeKey(crypto.Keccak256(input[headSize:]), sig)
+	if err != nil {
+		return nil, fromKey, hash, err
+	}
+
+	var req Packet
+	switch ptype := sigdata[0]; ptype {
+	case PingPacket:
+		req = new(Ping)
+	case PongPacket:
+		req = new(Pong)
+	case FindnodePacket:
+		req = new(Findnode)
+	case NeighborsPacket:
+		req = new(Neighbors)
+	case ENRRequestPacket:
+		req = new(ENRRequest)
+	case ENRResponsePacket:
+		req = new(ENRResponse)
+	default:
+		return nil, fromKey, hash, fmt.Errorf("unknown type: %d", ptype)
+	}
+	s := rlp.NewStream(bytes.NewReader(sigdata[1:]), 0)
+	err = s.Decode(req)
+	return req, fromKey, hash, err
+}
+
+// Encode encodes a discovery packet.
+func Encode(priv *ecdsa.PrivateKey, req Packet) (packet, hash []byte, err error) {
+	b := new(bytes.Buffer)
+	b.Write(headSpace)
+	b.WriteByte(req.Kind())
+	if err := rlp.Encode(b, req); err != nil {
+		return nil, nil, err
+	}
+	packet = b.Bytes()
+	sig, err := crypto.Sign(crypto.Keccak256(packet[headSize:]), priv)
+	if err != nil {
+		return nil, nil, err
+	}
+	copy(packet[macSize:], sig)
+	// Add the hash to the front. Note: this doesn't protect the packet in any way.
+	hash = crypto.Keccak256(packet[macSize:])
+	copy(packet, hash)
+	return packet, hash, nil
+}
+
+// recoverNodeKey computes the public key used to sign the given hash from the signature.
+func recoverNodeKey(hash, sig []byte) (key Pubkey, err error) {
+	pubkey, err := crypto.Ecrecover(hash, sig)
+	if err != nil {
+		return key, err
+	}
+	copy(key[:], pubkey[1:])
+	return key, nil
+}
+
+// EncodePubkey encodes a secp256k1 public key.
+func EncodePubkey(key *ecdsa.PublicKey) Pubkey {
+	var e Pubkey
+	math.ReadBits(key.X, e[:len(e)/2])
+	math.ReadBits(key.Y, e[len(e)/2:])
+	return e
+}
+
+// DecodePubkey reads an encoded secp256k1 public key.
+func DecodePubkey(curve elliptic.Curve, e Pubkey) (*ecdsa.PublicKey, error) {
+	p := &ecdsa.PublicKey{Curve: curve, X: new(big.Int), Y: new(big.Int)}
+	half := len(e) / 2
+	p.X.SetBytes(e[:half])
+	p.Y.SetBytes(e[half:])
+	if !p.Curve.IsOnCurve(p.X, p.Y) {
+		return nil, ErrBadPoint
+	}
+	return p, nil
+}

--- a/p2p/discover/v4wire/v4wire_test.go
+++ b/p2p/discover/v4wire/v4wire_test.go
@@ -1,0 +1,132 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package v4wire
+
+import (
+	"encoding/hex"
+	"net"
+	"reflect"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/dominant-strategies/go-quai/crypto"
+	"github.com/dominant-strategies/go-quai/rlp"
+)
+
+// EIP-8 test vectors.
+var testPackets = []struct {
+	input      string
+	wantPacket interface{}
+}{
+	{
+		input: "71dbda3a79554728d4f94411e42ee1f8b0d561c10e1e5f5893367948c6a7d70bb87b235fa28a77070271b6c164a2dce8c7e13a5739b53b5e96f2e5acb0e458a02902f5965d55ecbeb2ebb6cabb8b2b232896a36b737666c55265ad0a68412f250001ea04cb847f000001820cfa8215a8d790000000000000000000000000000000018208ae820d058443b9a355",
+		wantPacket: &Ping{
+			Version:    4,
+			From:       Endpoint{net.ParseIP("127.0.0.1").To4(), 3322, 5544},
+			To:         Endpoint{net.ParseIP("::1"), 2222, 3333},
+			Expiration: 1136239445,
+		},
+	},
+	{
+		input: "e9614ccfd9fc3e74360018522d30e1419a143407ffcce748de3e22116b7e8dc92ff74788c0b6663aaa3d67d641936511c8f8d6ad8698b820a7cf9e1be7155e9a241f556658c55428ec0563514365799a4be2be5a685a80971ddcfa80cb422cdd0101ec04cb847f000001820cfa8215a8d790000000000000000000000000000000018208ae820d058443b9a3550102",
+		wantPacket: &Ping{
+			Version:    4,
+			From:       Endpoint{net.ParseIP("127.0.0.1").To4(), 3322, 5544},
+			To:         Endpoint{net.ParseIP("::1"), 2222, 3333},
+			Expiration: 1136239445,
+			ENRSeq:     1,
+			Rest:       []rlp.RawValue{{0x02}},
+		},
+	},
+	{
+		input: "c7c44041b9f7c7e41934417ebac9a8e1a4c6298f74553f2fcfdcae6ed6fe53163eb3d2b52e39fe91831b8a927bf4fc222c3902202027e5e9eb812195f95d20061ef5cd31d502e47ecb61183f74a504fe04c51e73df81f25c4d506b26db4517490103f84eb840ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd31387574077f301b421bc84df7266c44e9e6d569fc56be00812904767bf5ccd1fc7f8443b9a35582999983999999280dc62cc8255c73471e0a61da0c89acdc0e035e260add7fc0c04ad9ebf3919644c91cb247affc82b69bd2ca235c71eab8e49737c937a2c396",
+		wantPacket: &Findnode{
+			Target:     hexPubkey("ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd31387574077f301b421bc84df7266c44e9e6d569fc56be00812904767bf5ccd1fc7f"),
+			Expiration: 1136239445,
+			Rest:       []rlp.RawValue{{0x82, 0x99, 0x99}, {0x83, 0x99, 0x99, 0x99}},
+		},
+	},
+	{
+		input: "c679fc8fe0b8b12f06577f2e802d34f6fa257e6137a995f6f4cbfc9ee50ed3710faf6e66f932c4c8d81d64343f429651328758b47d3dbc02c4042f0fff6946a50f4a49037a72bb550f3a7872363a83e1b9ee6469856c24eb4ef80b7535bcf99c0004f9015bf90150f84d846321163782115c82115db8403155e1427f85f10a5c9a7755877748041af1bcd8d474ec065eb33df57a97babf54bfd2103575fa829115d224c523596b401065a97f74010610fce76382c0bf32f84984010203040101b840312c55512422cf9b8a4097e9a6ad79402e87a15ae909a4bfefa22398f03d20951933beea1e4dfa6f968212385e829f04c2d314fc2d4e255e0d3bc08792b069dbf8599020010db83c4d001500000000abcdef12820d05820d05b84038643200b172dcfef857492156971f0e6aa2c538d8b74010f8e140811d53b98c765dd2d96126051913f44582e8c199ad7c6d6819e9a56483f637feaac9448aacf8599020010db885a308d313198a2e037073488203e78203e8b8408dcab8618c3253b558d459da53bd8fa68935a719aff8b811197101a4b2b47dd2d47295286fc00cc081bb542d760717d1bdd6bec2c37cd72eca367d6dd3b9df738443b9a355010203b525a138aa34383fec3d2719a0",
+		wantPacket: &Neighbors{
+			Nodes: []Node{
+				{
+					ID:  hexPubkey("3155e1427f85f10a5c9a7755877748041af1bcd8d474ec065eb33df57a97babf54bfd2103575fa829115d224c523596b401065a97f74010610fce76382c0bf32"),
+					IP:  net.ParseIP("99.33.22.55").To4(),
+					UDP: 4444,
+					TCP: 4445,
+				},
+				{
+					ID:  hexPubkey("312c55512422cf9b8a4097e9a6ad79402e87a15ae909a4bfefa22398f03d20951933beea1e4dfa6f968212385e829f04c2d314fc2d4e255e0d3bc08792b069db"),
+					IP:  net.ParseIP("1.2.3.4").To4(),
+					UDP: 1,
+					TCP: 1,
+				},
+				{
+					ID:  hexPubkey("38643200b172dcfef857492156971f0e6aa2c538d8b74010f8e140811d53b98c765dd2d96126051913f44582e8c199ad7c6d6819e9a56483f637feaac9448aac"),
+					IP:  net.ParseIP("2001:db8:3c4d:15::abcd:ef12"),
+					UDP: 3333,
+					TCP: 3333,
+				},
+				{
+					ID:  hexPubkey("8dcab8618c3253b558d459da53bd8fa68935a719aff8b811197101a4b2b47dd2d47295286fc00cc081bb542d760717d1bdd6bec2c37cd72eca367d6dd3b9df73"),
+					IP:  net.ParseIP("2001:db8:85a3:8d3:1319:8a2e:370:7348"),
+					UDP: 999,
+					TCP: 1000,
+				},
+			},
+			Expiration: 1136239445,
+			Rest:       []rlp.RawValue{{0x01}, {0x02}, {0x03}},
+		},
+	},
+}
+
+// This test checks that the decoder accepts packets according to EIP-8.
+func TestForwardCompatibility(t *testing.T) {
+	testkey, _ := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	wantNodeKey := EncodePubkey(&testkey.PublicKey)
+
+	for _, test := range testPackets {
+		input, err := hex.DecodeString(test.input)
+		if err != nil {
+			t.Fatalf("invalid hex: %s", test.input)
+		}
+		packet, nodekey, _, err := Decode(input)
+		if err != nil {
+			t.Errorf("did not accept packet %s\n%v", test.input, err)
+			continue
+		}
+		if !reflect.DeepEqual(packet, test.wantPacket) {
+			t.Errorf("got %s\nwant %s", spew.Sdump(packet), spew.Sdump(test.wantPacket))
+		}
+		if nodekey != wantNodeKey {
+			t.Errorf("got id %v\nwant id %v", nodekey, wantNodeKey)
+		}
+	}
+}
+
+func hexPubkey(h string) (ret Pubkey) {
+	b, err := hex.DecodeString(h)
+	if err != nil {
+		panic(err)
+	}
+	if len(b) != len(ret) {
+		panic("invalid length")
+	}
+	copy(ret[:], b)
+	return ret
+}

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -43,22 +43,7 @@ const (
 	totalNodesResponseLimit = 5  // applies in waitForNodes
 	nodesResponseItemLimit  = 3  // applies in sendNodes
 
-	respTimeoutV5       = 700 * time.Millisecond
-	respTimeout         = 500 * time.Millisecond
-	maxFindnodeFailures = 5                // nodes exceeding this limit are dropped
-	driftThreshold      = 10 * time.Second // Allowed clock drift before warning user
-	maxPacketSize       = 1280
-)
-
-// Errors
-var (
-	errExpired          = errors.New("expired")
-	errUnsolicitedReply = errors.New("unsolicited reply")
-	errUnknownNode      = errors.New("unknown node")
-	errTimeout          = errors.New("RPC timeout")
-	errClockWarp        = errors.New("reply deadline too far in the future")
-	errClosed           = errors.New("socket closed")
-	errLowPort          = errors.New("low port")
+	respTimeoutV5 = 700 * time.Millisecond
 )
 
 // codecV5 is implemented by v5wire.Codec (and testCodec).

--- a/p2p/discover/v5_udp_test.go
+++ b/p2p/discover/v5_udp_test.go
@@ -36,66 +36,6 @@ import (
 	"github.com/dominant-strategies/go-quai/rlp"
 )
 
-// This is the test network for the Lookup test.
-// The nodes were obtained by running lookupTestnet.mine with a random NodeID as target.
-var lookupTestnet = &preminedTestnet{
-	target: hexEncPubkey("5d485bdcbe9bc89314a10ae9231e429d33853e3a8fa2af39f5f827370a2e4185e344ace5d16237491dad41f278f1d3785210d29ace76cd627b9147ee340b1125"),
-	dists: [257][]*ecdsa.PrivateKey{
-		251: {
-			hexEncPrivkey("29738ba0c1a4397d6a65f292eee07f02df8e58d41594ba2be3cf84ce0fc58169"),
-			hexEncPrivkey("511b1686e4e58a917f7f848e9bf5539d206a68f5ad6b54b552c2399fe7d174ae"),
-			hexEncPrivkey("d09e5eaeec0fd596236faed210e55ef45112409a5aa7f3276d26646080dcfaeb"),
-			hexEncPrivkey("c1e20dbbf0d530e50573bd0a260b32ec15eb9190032b4633d44834afc8afe578"),
-			hexEncPrivkey("ed5f38f5702d92d306143e5d9154fb21819777da39af325ea359f453d179e80b"),
-		},
-		252: {
-			hexEncPrivkey("1c9b1cafbec00848d2c174b858219914b42a7d5c9359b1ca03fd650e8239ae94"),
-			hexEncPrivkey("e0e1e8db4a6f13c1ffdd3e96b72fa7012293ced187c9dcdcb9ba2af37a46fa10"),
-			hexEncPrivkey("3d53823e0a0295cb09f3e11d16c1b44d07dd37cec6f739b8df3a590189fe9fb9"),
-		},
-		253: {
-			hexEncPrivkey("2d0511ae9bf590166597eeab86b6f27b1ab761761eaea8965487b162f8703847"),
-			hexEncPrivkey("6cfbd7b8503073fc3dbdb746a7c672571648d3bd15197ccf7f7fef3d904f53a2"),
-			hexEncPrivkey("a30599b12827b69120633f15b98a7f6bc9fc2e9a0fd6ae2ebb767c0e64d743ab"),
-			hexEncPrivkey("14a98db9b46a831d67eff29f3b85b1b485bb12ae9796aea98d91be3dc78d8a91"),
-			hexEncPrivkey("2369ff1fc1ff8ca7d20b17e2673adc3365c3674377f21c5d9dafaff21fe12e24"),
-			hexEncPrivkey("9ae91101d6b5048607f41ec0f690ef5d09507928aded2410aabd9237aa2727d7"),
-			hexEncPrivkey("05e3c59090a3fd1ae697c09c574a36fcf9bedd0afa8fe3946f21117319ca4973"),
-			hexEncPrivkey("06f31c5ea632658f718a91a1b1b9ae4b7549d7b3bc61cbc2be5f4a439039f3ad"),
-		},
-		254: {
-			hexEncPrivkey("dec742079ec00ff4ec1284d7905bc3de2366f67a0769431fd16f80fd68c58a7c"),
-			hexEncPrivkey("ff02c8861fa12fbd129d2a95ea663492ef9c1e51de19dcfbbfe1c59894a28d2b"),
-			hexEncPrivkey("4dded9e4eefcbce4262be4fd9e8a773670ab0b5f448f286ec97dfc8cf681444a"),
-			hexEncPrivkey("750d931e2a8baa2c9268cb46b7cd851f4198018bed22f4dceb09dd334a2395f6"),
-			hexEncPrivkey("ce1435a956a98ffec484cd11489c4f165cf1606819ab6b521cee440f0c677e9e"),
-			hexEncPrivkey("996e7f8d1638be92d7328b4770f47e5420fc4bafecb4324fd33b1f5d9f403a75"),
-			hexEncPrivkey("ebdc44e77a6cc0eb622e58cf3bb903c3da4c91ca75b447b0168505d8fc308b9c"),
-			hexEncPrivkey("46bd1eddcf6431bea66fc19ebc45df191c1c7d6ed552dcdc7392885009c322f0"),
-		},
-		255: {
-			hexEncPrivkey("da8645f90826e57228d9ea72aff84500060ad111a5d62e4af831ed8e4b5acfb8"),
-			hexEncPrivkey("3c944c5d9af51d4c1d43f5d0f3a1a7ef65d5e82744d669b58b5fed242941a566"),
-			hexEncPrivkey("5ebcde76f1d579eebf6e43b0ffe9157e65ffaa391175d5b9aa988f47df3e33da"),
-			hexEncPrivkey("97f78253a7d1d796e4eaabce721febcc4550dd68fb11cc818378ba807a2cb7de"),
-			hexEncPrivkey("a38cd7dc9b4079d1c0406afd0fdb1165c285f2c44f946eca96fc67772c988c7d"),
-			hexEncPrivkey("d64cbb3ffdf712c372b7a22a176308ef8f91861398d5dbaf326fd89c6eaeef1c"),
-			hexEncPrivkey("d269609743ef29d6446e3355ec647e38d919c82a4eb5837e442efd7f4218944f"),
-			hexEncPrivkey("d8f7bcc4a530efde1d143717007179e0d9ace405ddaaf151c4d863753b7fd64c"),
-		},
-		256: {
-			hexEncPrivkey("8c5b422155d33ea8e9d46f71d1ad3e7b24cb40051413ffa1a81cff613d243ba9"),
-			hexEncPrivkey("937b1af801def4e8f5a3a8bd225a8bcff1db764e41d3e177f2e9376e8dd87233"),
-			hexEncPrivkey("120260dce739b6f71f171da6f65bc361b5fad51db74cf02d3e973347819a6518"),
-			hexEncPrivkey("1fa56cf25d4b46c2bf94e82355aa631717b63190785ac6bae545a88aadc304a9"),
-			hexEncPrivkey("3c38c503c0376f9b4adcbe935d5f4b890391741c764f61b03cd4d0d42deae002"),
-			hexEncPrivkey("3a54af3e9fa162bc8623cdf3e5d9b70bf30ade1d54cc3abea8659aba6cff471f"),
-			hexEncPrivkey("6799a02ea1999aefdcbcc4d3ff9544478be7365a328d0d0f37c26bd95ade0cda"),
-			hexEncPrivkey("e24a7bc9051058f918646b0f6e3d16884b2a55a15553b89bab910d55ebc36116"),
-		},
-	},
-}
-
 // Real sockets, real crypto: this test checks end-to-end connectivity for UDPv5.
 func TestUDPv5_lookupE2E(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
This reverts commit 251f715fbb43cfd513677ebdd3270ab388531256.

Commit 251f removed the v4wire which resulted in node not being able to peer with the bootnode. So reverting it back.