### PR TITLE
fix issue with makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,7 @@ endif
 
 stop:
 ifeq ($(shell uname -s), $(filter $(shell uname -s), Darwin Linux))
-	@if pgrep quai; then pkill -f ./build/bin/go-quai; fi
+	@-pkill -f ./build/bin/go-quai;
 	@while pgrep quai >/dev/null; do \
 		echo "Stopping all Quai Network nodes, please wait until terminated."; \
 		sleep 3; \


### PR DESCRIPTION
### Bug

It took me a while to understand what was going on here. I finally realized that the issue was as follows:
![image](https://user-images.githubusercontent.com/15804464/197281506-d43b6635-2164-4cdc-a0e2-305a261018a5.png)
`pkill` was actually shutting down the makefile process. I misdiagnosed this quite a few times before realizing that. 

Honestly, I may still be misunderstanding the issue. I had a pretty hard time finding good guides/docs on makefiles as a whole. I read through [one](https://www.grymoire.com/Unix/Make.html#Conditional_execution_in_Makefiles) and [two](https://web.mit.edu/gnu/doc/html/make_4.html) resources and just couldn't find a good explanation. 

What I can say is that the makefile was terminating early bc of the `pkill` and now it is no longer doing that. 

### Fix 

So [this unix stackexchange post](https://unix.stackexchange.com/questions/448880/makefile-kill-a-process-if-it-is-running) is what informed me how to change.  

The `if` structure for `pkill` was just not the best technique. 