### PR TITLE
Implement cross chain transaction emission & rollups

### DIFF
--- a/core/bodydb.go
+++ b/core/bodydb.go
@@ -62,7 +62,7 @@ func NewBodyDb(db ethdb.Database, engine consensus.Engine, hc *HeaderChain, chai
 	return bc, nil
 }
 
-// Append
+// Append appends a block and returns all logs and ETXs emitted from the block's transactions
 func (bc *BodyDb) Append(batch ethdb.Batch, block *types.Block) ([]*types.Log, error) {
 	bc.chainmu.Lock()
 	defer bc.chainmu.Unlock()

--- a/core/core.go
+++ b/core/core.go
@@ -46,7 +46,7 @@ func (c *Core) InsertChain(blocks types.Blocks) (int, error) {
 		// if the order of the block is less than the context
 		// add the rest of the blocks in the queue to the future blocks.
 		if !isCoincident && !domWait {
-			_, err := c.sl.Append(block.Header(), common.Hash{}, big.NewInt(0), false, true, block.ManifestHash())
+			_, err := c.sl.Append(block.Header(), common.Hash{}, big.NewInt(0), false, true, block.ManifestHash(), block.ExtTransactions())
 			if err != nil {
 				if err == consensus.ErrFutureBlock {
 					c.sl.addfutureHeader(block.Header())
@@ -98,8 +98,8 @@ func (c *Core) Stop() {
 // Slice methods //
 //---------------//
 
-func (c *Core) Append(header *types.Header, domTerminus common.Hash, td *big.Int, domOrigin bool, reorg bool, manifestHash common.Hash) (types.PendingHeader, error) {
-	return c.sl.Append(header, domTerminus, td, domOrigin, reorg, manifestHash)
+func (c *Core) Append(header *types.Header, domTerminus common.Hash, td *big.Int, domOrigin bool, reorg bool, manifestHash common.Hash, rollupEtxs types.Transactions) (types.PendingHeader, error) {
+	return c.sl.Append(header, domTerminus, td, domOrigin, reorg, manifestHash, rollupEtxs)
 }
 
 // ConstructLocalBlock takes a header and construct the Block locally

--- a/core/slice.go
+++ b/core/slice.go
@@ -122,7 +122,7 @@ func NewSlice(db ethdb.Database, config *Config, txConfig *TxPoolConfig, isLocal
 
 // Append takes a proposed header and constructs a local block and attempts to hierarchically append it to the block graph.
 // If this is called from a dominant context a domTerminus must be provided else a common.Hash{} should be used and domOrigin should be set to true.
-func (sl *Slice) Append(header *types.Header, domTerminus common.Hash, td *big.Int, domOrigin bool, reorg bool, manifestHash common.Hash) (types.PendingHeader, error) {
+func (sl *Slice) Append(header *types.Header, domTerminus common.Hash, td *big.Int, domOrigin bool, reorg bool, manifestHash common.Hash, rollupEtxs types.Transactions) (types.PendingHeader, error) {
 	nodeCtx := common.NodeLocation.Context()
 	location := header.Location()
 
@@ -145,7 +145,7 @@ func (sl *Slice) Append(header *types.Header, domTerminus common.Hash, td *big.I
 	}
 
 	// Append the new block
-	err = sl.hc.Append(batch, block, manifestHash)
+	err = sl.hc.Append(batch, block, manifestHash, rollupEtxs)
 	if err != nil {
 		return sl.nilPendingHeader, err
 	}
@@ -159,6 +159,9 @@ func (sl *Slice) Append(header *types.Header, domTerminus common.Hash, td *big.I
 		// HLCR
 		reorg = sl.hlcr(td)
 	}
+
+	// Any ETXs not emitted by our context must be from the subordinate rollup.
+	// Extract this rollup list and pass to our sub to validate
 
 	// Call my sub to append the block
 	var subPendingHeader types.PendingHeader
@@ -509,7 +512,7 @@ func (sl *Slice) genesisInit(genesis *Genesis) error {
 				location := block.Header().Location()
 				if nodeCtx == common.PRIME_CTX {
 					rawdb.WritePendingBlockBody(sl.sliceDb, block.Root(), block.Body())
-					_, err := sl.Append(block.Header(), genesisHash, block.Difficulty(), false, false, block.ManifestHash())
+					_, err := sl.Append(block.Header(), genesisHash, block.Difficulty(), false, false, block.ManifestHash(), block.ExtTransactions())
 					if err != nil {
 						log.Warn("Failed to append block", "hash:", block.Hash(), "Number:", block.Number(), "Location:", block.Header().Location(), "error:", err)
 					}
@@ -609,9 +612,18 @@ func (sl *Slice) procfutureHeaders() {
 			return headers[i].NumberU64() < headers[j].NumberU64()
 		})
 
-		for i := range headers {
+		for _, h := range headers {
 			var nilHash common.Hash
-			sl.Append(headers[i], nilHash, big.NewInt(0), false, false, headers[i].ManifestHash())
+			block := sl.hc.GetBlock(h.Hash(), h.NumberU64())
+			// Rollup ETXs exist at the front of the list. The second half of the list
+			// contains ETXs emitted from our context
+			var rollupEtxs types.Transactions
+			for _, etx := range block.ExtTransactions() {
+				if !etx.To().IsInChainScope() {
+					rollupEtxs = append(rollupEtxs, etx)
+				}
+			}
+			sl.Append(h, nilHash, big.NewInt(0), false, false, h.ManifestHash(), rollupEtxs)
 		}
 	}
 }

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -242,7 +242,7 @@ func applyTransaction(msg types.Message, config *params.ChainConfig, bc ChainCon
 
 	// Create a new receipt for the transaction, storing the intermediate root and gas used
 	// by the tx.
-	receipt := &types.Receipt{Type: tx.Type(), PostState: root, CumulativeGasUsed: *usedGas}
+	receipt := &types.Receipt{Type: tx.Type(), PostState: root, CumulativeGasUsed: *usedGas, Etxs: result.Etxs}
 	if result.Failed() {
 		receipt.Status = types.ReceiptStatusFailed
 	} else {

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -67,9 +67,10 @@ type Receipt struct {
 
 	// Inclusion information: These fields provide information about the inclusion of the
 	// transaction corresponding to this receipt.
-	BlockHash        common.Hash `json:"blockHash,omitempty"`
-	BlockNumber      *big.Int    `json:"blockNumber,omitempty"`
-	TransactionIndex uint        `json:"transactionIndex"`
+	BlockHash        common.Hash    `json:"blockHash,omitempty"`
+	BlockNumber      *big.Int       `json:"blockNumber,omitempty"`
+	TransactionIndex uint           `json:"transactionIndex"`
+	Etxs             []*Transaction `json:"etxs"`
 }
 
 type receiptMarshaling struct {

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -123,7 +123,7 @@ type EVM struct {
 	// applied in opCall*.
 	callGasTemp uint64
 
-	ETXCache     []*types.ExternalTx
+	ETXCache     []*types.Transaction
 	ETXCacheLock sync.RWMutex
 }
 
@@ -137,7 +137,7 @@ func NewEVM(blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig
 		Config:      config,
 		chainConfig: chainConfig,
 		chainRules:  chainConfig.Rules(blockCtx.BlockNumber),
-		ETXCache:    make([]*types.ExternalTx, 0),
+		ETXCache:    make([]*types.Transaction, 0),
 	}
 	evm.interpreter = NewEVMInterpreter(evm, config)
 	return evm

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -824,10 +824,11 @@ func opETX(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte
 	sender := scope.Contract.self.Address()
 
 	// create external transaction
-	etx := types.ExternalTx{Value: value.ToBig(), To: &toAddr, Sender: sender, GasTipCap: gasTipCap.ToBig(), GasFeeCap: gasFeeCap.ToBig(), Gas: gas, Data: data, AccessList: accessList, Nonce: nonce.Uint64()}
+	etxInner := types.ExternalTx{Value: value.ToBig(), To: &toAddr, Sender: sender, GasTipCap: gasTipCap.ToBig(), GasFeeCap: gasFeeCap.ToBig(), Gas: gas, Data: data, AccessList: accessList, Nonce: nonce.Uint64()}
+	etx := types.NewTx(&etxInner)
 
 	interpreter.evm.ETXCacheLock.Lock()
-	interpreter.evm.ETXCache = append(interpreter.evm.ETXCache, &etx)
+	interpreter.evm.ETXCache = append(interpreter.evm.ETXCache, etx)
 	interpreter.evm.ETXCacheLock.Unlock()
 
 	temp.SetOne() // following opCall protocol

--- a/core/worker.go
+++ b/core/worker.go
@@ -660,7 +660,11 @@ func (w *worker) commitTransaction(env *environment, tx *types.Transaction) ([]*
 
 		env.txs = append(env.txs, tx)
 		env.receipts = append(env.receipts, receipt)
-
+		if receipt.Status == types.ReceiptStatusSuccessful {
+			for _, etx := range receipt.Etxs {
+				env.etxs = append(env.etxs, etx)
+			}
+		}
 		return receipt.Logs, nil
 	}
 	return nil, errors.New("error finding transaction")

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -354,8 +354,8 @@ func (b *QuaiAPIBackend) SyncProgress() quai.SyncProgress {
 	return b.eth.Downloader().Progress()
 }
 
-func (b *QuaiAPIBackend) Append(header *types.Header, domTerminus common.Hash, td *big.Int, domOrigin bool, reorg bool, manifestHash common.Hash) (types.PendingHeader, error) {
-	return b.eth.core.Append(header, domTerminus, td, domOrigin, reorg, manifestHash)
+func (b *QuaiAPIBackend) Append(header *types.Header, domTerminus common.Hash, td *big.Int, domOrigin bool, reorg bool, manifestHash common.Hash, rollupEtxs types.Transactions) (types.PendingHeader, error) {
+	return b.eth.core.Append(header, domTerminus, td, domOrigin, reorg, manifestHash, rollupEtxs)
 }
 
 func (b *QuaiAPIBackend) ConstructLocalBlock(header *types.Header) *types.Block {

--- a/internal/quaiapi/backend.go
+++ b/internal/quaiapi/backend.go
@@ -72,7 +72,7 @@ type Backend interface {
 	SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription
 	SubscribeChainSideEvent(ch chan<- core.ChainSideEvent) event.Subscription
 
-	Append(header *types.Header, domTerminus common.Hash, td *big.Int, domOrigin bool, reorg bool, manifestHash common.Hash) (types.PendingHeader, error)
+	Append(header *types.Header, domTerminus common.Hash, td *big.Int, domOrigin bool, reorg bool, manifestHash common.Hash, rollupEtxs types.Transactions) (types.PendingHeader, error)
 	ConstructLocalBlock(header *types.Header) *types.Block
 	InsertBlock(ctx context.Context, block *types.Block) (int, error)
 	PendingBlock() *types.Block

--- a/internal/quaiapi/quai_api.go
+++ b/internal/quaiapi/quai_api.go
@@ -540,11 +540,12 @@ func (s *PublicBlockChainQuaiAPI) ReceiveMinedHeader(ctx context.Context, raw js
 }
 
 type tdBlock struct {
-	Td           *big.Int    `json:"td"`
-	DomTerminus  common.Hash `json:"domTerminus"`
-	DomOrigin    bool        `json:"domOrigin"`
-	Reorg        bool        `json:"reorg"`
-	ManifestHash common.Hash `json:"manifestHash"`
+	Td           *big.Int           `json:"td"`
+	DomTerminus  common.Hash        `json:"domTerminus"`
+	DomOrigin    bool               `json:"domOrigin"`
+	Reorg        bool               `json:"reorg"`
+	ManifestHash common.Hash        `json:"manifestHash"`
+	RollupEtxs   types.Transactions `json:"rollupEtxs"`
 }
 
 func (s *PublicBlockChainQuaiAPI) Append(ctx context.Context, raw json.RawMessage) (map[string]interface{}, error) {
@@ -557,8 +558,7 @@ func (s *PublicBlockChainQuaiAPI) Append(ctx context.Context, raw json.RawMessag
 	if err := json.Unmarshal(raw, &body); err != nil {
 		return nil, err
 	}
-
-	pendingHeader, err := s.b.Append(head, body.DomTerminus, body.Td, body.DomOrigin, body.Reorg, body.ManifestHash)
+	pendingHeader, err := s.b.Append(head, body.DomTerminus, body.Td, body.DomOrigin, body.Reorg, body.ManifestHash, body.RollupEtxs)
 	if err != nil {
 		return nil, err
 	}

--- a/quaiclient/quaiclient.go
+++ b/quaiclient/quaiclient.go
@@ -125,13 +125,14 @@ func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 }
 
 // RPCMarshalTdHeader converts the header and order as input to PCRC.
-func RPCMarshalTdHeader(header *types.Header, domTerminus common.Hash, td *big.Int, domOrigin bool, reorg bool, manifestHash common.Hash) (map[string]interface{}, error) {
+func RPCMarshalTdHeader(header *types.Header, domTerminus common.Hash, td *big.Int, domOrigin bool, reorg bool, manifestHash common.Hash, rollupEtxs types.Transactions) (map[string]interface{}, error) {
 	fields := RPCMarshalHeader(header)
 	fields["td"] = td
 	fields["domTerminus"] = domTerminus
 	fields["domOrigin"] = domOrigin
 	fields["reorg"] = reorg
 	fields["manifestHash"] = manifestHash
+	fields["rollupEtxs"] = rollupEtxs
 	return fields, nil
 }
 
@@ -139,8 +140,8 @@ type Termini struct {
 	Termini []common.Hash `json:"termini"`
 }
 
-func (ec *Client) Append(ctx context.Context, header *types.Header, domTerminus common.Hash, td *big.Int, domOrigin bool, reorg bool, manifestHash common.Hash) (types.PendingHeader, error) {
-	data, err := RPCMarshalTdHeader(header, domTerminus, td, domOrigin, reorg, manifestHash)
+func (ec *Client) Append(ctx context.Context, header *types.Header, domTerminus common.Hash, td *big.Int, domOrigin bool, reorg bool, manifestHash common.Hash, rollupEtxs types.Transactions) (types.PendingHeader, error) {
+	data, err := RPCMarshalTdHeader(header, domTerminus, td, domOrigin, reorg, manifestHash, rollupEtxs)
 	if err != nil {
 		return types.PendingHeader{}, err
 	}


### PR DESCRIPTION
This PR still needs to check that the second half of the ETX list in a region body matches the expected list of ETXs emitted from the region... but its getting close.

Additionally, this just sends the full list of rolled up ETXs to the sub to be verified, which is painfully inefficient. A subtree proof would be better.