### PR TITLE
bring pending report inline with others

### DIFF
--- a/quaistats/quaistats.go
+++ b/quaistats/quaistats.go
@@ -743,11 +743,11 @@ func (s *Service) reportPending(conn *connWrapper) error {
 	// Retrieve the pending count from the local blockchain
 	pending, _ := s.backend.Stats()
 	// Assemble the transaction stats and send it to the server
-	log.Trace("Sending pending transactions to quaistats", "count", pending)
+	log.Trace("Sending pending transactions to quaistats", "count", strconv.Itoa(pending))
 
 	stats := map[string]interface{}{
 		"id": s.node,
-		"stats": &pendStats{
+		"pending": &pendStats{
 			Pending: pending,
 		},
 	}


### PR DESCRIPTION
This is a very small change that simply makes the pending report more similar to the others for code-parity with `quai-stats-backend` . 

Dependent on: https://github.com/dominant-strategies/quai-stats-backend/pull/9 

Linear: https://linear.app/quai-network/issue/FS-64/implement-case-pending-in-servergo-for-the-stats-backend