### PR TITLE
Revert pendingManifest cache and ask sub for manifest

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -107,7 +107,7 @@ func (c *Core) ConstructLocalBlock(header *types.Header) *types.Block {
 	return c.sl.ConstructLocalBlock(header)
 }
 
-func (c *Core) SubRelayPendingHeader(slPendingHeader types.PendingHeader, reorg bool) (types.BlockManifest, error) {
+func (c *Core) SubRelayPendingHeader(slPendingHeader types.PendingHeader, reorg bool) error {
 	return c.sl.SubRelayPendingHeader(slPendingHeader, reorg)
 }
 

--- a/core/core.go
+++ b/core/core.go
@@ -115,6 +115,10 @@ func (c *Core) GetPendingHeader() (*types.Header, error) {
 	return c.sl.GetPendingHeader()
 }
 
+func (c *Core) GetSubManifest(blockHash common.Hash) (types.BlockManifest, error) {
+	return c.sl.GetSubManifest(blockHash)
+}
+
 //---------------------//
 // HeaderChain methods //
 //---------------------//

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -94,8 +94,16 @@ func NewHeaderChain(db ethdb.Database, engine consensus.Engine, chainConfig *par
 
 func (hc *HeaderChain) CollectBlockManifest(h *types.Header) (types.BlockManifest, error) {
 	manifest := types.BlockManifest{}
-	// Terminate the search on coincidence or genesis
-	if hc.engine.HasCoincidentDifficulty(h) || h.NumberU64() == 0 {
+	// Terminate the search if we reached genesis
+	if h.NumberU64() == 0 {
+		if h.Hash() != hc.config.GenesisHash {
+			return nil, fmt.Errorf("manifest builds on incorrect genesis", "block0 hash: ", h.Hash())
+		} else {
+			return manifest, nil
+		}
+	}
+	// Terminate the search on coincidence
+	if hc.engine.HasCoincidentDifficulty(h) {
 		return manifest, nil
 	}
 	// Recursively get the ancestor manifest, until a coincident ancestor is found

--- a/core/slice.go
+++ b/core/slice.go
@@ -377,7 +377,7 @@ func (sl *Slice) GetPendingHeader() (*types.Header, error) {
 func (sl *Slice) GetSubManifest(blockHash common.Hash) (types.BlockManifest, error) {
 	header := sl.hc.GetHeaderByHash(blockHash)
 	if header == nil {
-		return nil, fmt.Errorf("block not found")
+		return nil, errors.New("block not found")
 	}
 	return sl.hc.CollectBlockManifest(header)
 }

--- a/core/slice.go
+++ b/core/slice.go
@@ -389,6 +389,15 @@ func (sl *Slice) SubRelayPendingHeader(pendingHeader types.PendingHeader, reorg 
 	sl.phCachemu.Lock()
 	defer sl.phCachemu.Unlock()
 
+	// Collect our manifest, so that the dom header can commit to it
+	if nodeCtx > common.PRIME_CTX {
+		manifest, err := sl.hc.CollectBlockManifest(pendingHeader.Header)
+		if err != nil {
+			log.Warn("Failed to get manifest for pending header", "parentHash: ", pendingHeader.Header.ParentHash(), "err: ", err)
+		}
+		pendingHeader.Header.SetManifestHash(manifest.Hash(), nodeCtx-1)
+	}
+
 	if nodeCtx == common.REGION_CTX {
 		sl.updatePhCacheFromDom(pendingHeader, common.NodeLocation.Region(), []int{common.PRIME_CTX}, reorg)
 		for i := range sl.subClients {

--- a/core/slice.go
+++ b/core/slice.go
@@ -237,7 +237,6 @@ func (sl *Slice) ConstructLocalBlock(header *types.Header) *types.Block {
 			}
 
 			block = types.NewBlockWithHeader(header).WithBody(txs, uncles, etxs, subBlockHashes)
-			block = block.WithSeal(header)
 		}
 	}
 	return block

--- a/core/slice.go
+++ b/core/slice.go
@@ -28,10 +28,6 @@ const (
 	pendingHeaderCacheLimit = 500
 	pendingHeaderGCTime     = 5
 
-	// pendingSubManifestLimit is the maximum number of manifests which may be
-	// stored in cache
-	pendingSubManifestLimit = 100
-
 	// Termini Index reference to the index of Termini struct that has the
 	// previous coincident block hash
 	terminiIndex = 3
@@ -62,8 +58,6 @@ type Slice struct {
 
 	pendingHeader common.Hash
 	phCache       map[common.Hash]types.PendingHeader
-
-	pendingSubManifests *lru.Cache
 }
 
 func NewSlice(db ethdb.Database, config *Config, txConfig *TxPoolConfig, isLocalBlock func(block *types.Header) bool, chainConfig *params.ChainConfig, domClientUrl string, subClientUrls []string, engine consensus.Engine, cacheConfig *CacheConfig, vmConfig vm.Config, genesis *Genesis) (*Slice, error) {
@@ -78,8 +72,6 @@ func NewSlice(db ethdb.Database, config *Config, txConfig *TxPoolConfig, isLocal
 
 	futureHeaders, _ := lru.New(maxFutureHeaders)
 	sl.futureHeaders = futureHeaders
-	pendingSubManifests, _ := lru.New(pendingSubManifestLimit)
-	sl.pendingSubManifests = pendingSubManifests
 
 	var err error
 	sl.hc, err = NewHeaderChain(db, engine, chainConfig, cacheConfig, vmConfig)
@@ -243,15 +235,6 @@ func (sl *Slice) ConstructLocalBlock(header *types.Header) *types.Block {
 			for i, blockHash := range pendingBlockBody.SubManifest {
 				subBlockHashes[i] = blockHash
 			}
-			if subBlockHashes.Hash() != header.ManifestHash() {
-				subManifest := sl.getPendingSubManifest(header.ManifestHash())
-				if subManifest != nil {
-					subBlockHashes = subManifest
-				} else {
-					log.Error("unable to find manifest for block", "hash: ", header.Hash())
-					return nil
-				}
-			}
 
 			block = types.NewBlockWithHeader(header).WithBody(txs, uncles, etxs, subBlockHashes)
 			block = block.WithSeal(header)
@@ -279,8 +262,7 @@ func (sl *Slice) updateCacheAndRelay(pendingHeader types.PendingHeader, location
 			return
 		}
 		for i := range sl.subClients {
-			subPendingManifest, _ := sl.subClients[i].SubRelayPendingHeader(context.Background(), sl.phCache[sl.pendingHeader], reorg)
-			sl.addPendingSubManifest(subPendingManifest)
+			sl.subClients[i].SubRelayPendingHeader(context.Background(), sl.phCache[sl.pendingHeader], reorg)
 		}
 	}
 }
@@ -393,39 +375,30 @@ func (sl *Slice) GetPendingHeader() (*types.Header, error) {
 	return sl.phCache[sl.pendingHeader].Header, nil
 }
 
-// SubRelayPendingHeader takes a pending header from the sender (ie dominant), updates the phCache with a composited header, relays result to subordinates, and returns the pending manifest for this block
-func (sl *Slice) SubRelayPendingHeader(pendingHeader types.PendingHeader, reorg bool) (types.BlockManifest, error) {
+// SubRelayPendingHeader takes a pending header from the sender (ie dominant), updates the phCache with a composited header and relays result to subordinates
+func (sl *Slice) SubRelayPendingHeader(pendingHeader types.PendingHeader, reorg bool) error {
 	nodeCtx := common.NodeLocation.Context()
 
 	sl.phCachemu.Lock()
 	defer sl.phCachemu.Unlock()
 
-	switch nodeCtx {
-	case common.ZONE_CTX:
-		sl.updatePhCacheFromDom(pendingHeader, common.NodeLocation.Zone(), []int{common.PRIME_CTX, common.REGION_CTX}, reorg)
-		sl.phCache[pendingHeader.Termini[common.NodeLocation.Zone()]].Header.SetLocation(common.NodeLocation)
-		if bestPh, exists := sl.phCache[sl.pendingHeader]; exists {
-			sl.miner.worker.pendingHeaderFeed.Send(bestPh.Header)
-		}
-	case common.REGION_CTX:
+	if nodeCtx == common.REGION_CTX {
 		sl.updatePhCacheFromDom(pendingHeader, common.NodeLocation.Region(), []int{common.PRIME_CTX}, reorg)
 		for i := range sl.subClients {
-			subPendingManifest, err := sl.subClients[i].SubRelayPendingHeader(context.Background(), sl.phCache[pendingHeader.Termini[common.NodeLocation.Region()]], reorg)
+			err := sl.subClients[i].SubRelayPendingHeader(context.Background(), sl.phCache[pendingHeader.Termini[common.NodeLocation.Region()]], reorg)
 			if err != nil {
 				log.Warn("SubRelayPendingHeader", "err:", err)
 			}
-			sl.addPendingSubManifest(subPendingManifest)
 		}
-	case common.PRIME_CTX:
-		log.Crit("prime node does not have a dom. sub-relay shouldn't be called.")
+	} else {
+		sl.updatePhCacheFromDom(pendingHeader, common.NodeLocation.Zone(), []int{common.PRIME_CTX, common.REGION_CTX}, reorg)
+		sl.phCache[pendingHeader.Termini[common.NodeLocation.Zone()]].Header.SetLocation(common.NodeLocation)
+		bestPh, exists := sl.phCache[sl.pendingHeader]
+		if exists {
+			sl.miner.worker.pendingHeaderFeed.Send(bestPh.Header)
+		}
 	}
-
-	// Calculate the manifest for this pending header, and return it so that the dom
-	manifest, err := sl.hc.ManifestForHeader(pendingHeader.Header)
-	if err != nil {
-		return nil, err
-	}
-	return manifest, nil
+	return nil
 }
 
 // updatePhCache takes in an externPendingHeader and updates the pending header on the same terminus if the number is greater
@@ -661,21 +634,6 @@ func (sl *Slice) loadLastState() error {
 	sl.phCache = rawdb.ReadPhCache(sl.sliceDb)
 	sl.pendingHeader = rawdb.ReadCurrentPendingHeaderHash(sl.sliceDb)
 	return nil
-}
-
-// addPendingSubManifest adds a pending subordinate block manifest to the cache
-func (sl *Slice) addPendingSubManifest(manifest types.BlockManifest) {
-	sl.pendingSubManifests.ContainsOrAdd(manifest.Hash(), manifest)
-}
-
-// getPendingSubManifest gets a pending subordinate block manifest associated with the given manifest hash
-func (sl *Slice) getPendingSubManifest(manifestHash common.Hash) types.BlockManifest {
-	if manifest, ok := sl.pendingSubManifests.Get(manifestHash); ok {
-		return manifest.(types.BlockManifest)
-	} else {
-		log.Warn("pending manifest not found: ", "hash: ", manifestHash)
-		return nil
-	}
 }
 
 // Stop stores the phCache and the sl.pendingHeader hash value to the db.

--- a/core/slice.go
+++ b/core/slice.go
@@ -374,6 +374,14 @@ func (sl *Slice) GetPendingHeader() (*types.Header, error) {
 	return sl.phCache[sl.pendingHeader].Header, nil
 }
 
+func (sl *Slice) GetSubManifest(blockHash common.Hash) (types.BlockManifest, error) {
+	header := sl.hc.GetHeaderByHash(blockHash)
+	if header == nil {
+		return nil, fmt.Errorf("block not found")
+	}
+	return sl.hc.CollectBlockManifest(header)
+}
+
 // SubRelayPendingHeader takes a pending header from the sender (ie dominant), updates the phCache with a composited header and relays result to subordinates
 func (sl *Slice) SubRelayPendingHeader(pendingHeader types.PendingHeader, reorg bool) error {
 	nodeCtx := common.NodeLocation.Context()

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -816,6 +816,7 @@ func (b *Block) WithBody(transactions []*Transaction, uncles []*Header, extTrans
 		subManifest:     make([]*common.Hash, len(subManifest)),
 	}
 	copy(block.transactions, transactions)
+	copy(block.extTransactions, extTransactions)
 	copy(block.subManifest, subManifest)
 	for i := range uncles {
 		block.uncles[i] = CopyHeader(uncles[i])

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -382,6 +382,10 @@ func (b *QuaiAPIBackend) GetPendingHeader() (*types.Header, error) {
 	return b.eth.core.GetPendingHeader()
 }
 
+func (b *QuaiAPIBackend) GetSubManifest(blockHash common.Hash) (types.BlockManifest, error) {
+	return b.eth.core.GetSubManifest(blockHash)
+}
+
 func (b *QuaiAPIBackend) SubscribeHeaderRootsEvent(ch chan<- types.HeaderRoots) event.Subscription {
 	return b.eth.core.SubscribeHeaderRoots(ch)
 }

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -374,7 +374,7 @@ func (b *QuaiAPIBackend) PendingBlockBody(hash common.Hash) *types.Body {
 	return b.eth.core.PendingBlockBody(hash)
 }
 
-func (b *QuaiAPIBackend) SubRelayPendingHeader(pendingHeader types.PendingHeader, reorg bool) (types.BlockManifest, error) {
+func (b *QuaiAPIBackend) SubRelayPendingHeader(pendingHeader types.PendingHeader, reorg bool) error {
 	return b.eth.core.SubRelayPendingHeader(pendingHeader, reorg)
 }
 

--- a/internal/quaiapi/backend.go
+++ b/internal/quaiapi/backend.go
@@ -77,7 +77,7 @@ type Backend interface {
 	InsertBlock(ctx context.Context, block *types.Block) (int, error)
 	PendingBlock() *types.Block
 	PendingBlockBody(hash common.Hash) *types.Body
-	SubRelayPendingHeader(pendingHeader types.PendingHeader, reorg bool) (types.BlockManifest, error)
+	SubRelayPendingHeader(pendingHeader types.PendingHeader, reorg bool) error
 	GetPendingHeader() (*types.Header, error)
 	PendingBlockAndReceipts() (*types.Block, types.Receipts)
 

--- a/internal/quaiapi/backend.go
+++ b/internal/quaiapi/backend.go
@@ -79,6 +79,7 @@ type Backend interface {
 	PendingBlockBody(hash common.Hash) *types.Body
 	SubRelayPendingHeader(pendingHeader types.PendingHeader, reorg bool) error
 	GetPendingHeader() (*types.Header, error)
+	GetSubManifest(blockHash common.Hash) (types.BlockManifest, error)
 	PendingBlockAndReceipts() (*types.Block, types.Receipts)
 
 	// Transaction pool API

--- a/internal/quaiapi/quai_api.go
+++ b/internal/quaiapi/quai_api.go
@@ -594,3 +594,15 @@ func (s *PublicBlockChainQuaiAPI) GetPendingHeader(ctx context.Context) (map[str
 	marshaledPh := RPCMarshalHeader(pendingHeader)
 	return marshaledPh, nil
 }
+
+func (s *PublicBlockChainQuaiAPI) GetSubManifest(ctx context.Context, raw json.RawMessage) (types.BlockManifest, error) {
+	var blockHash common.Hash
+	if err := json.Unmarshal(raw, &blockHash); err != nil {
+		return nil, err
+	}
+	manifest, err := s.b.GetSubManifest(blockHash)
+	if err != nil {
+		return nil, err
+	}
+	return manifest, nil
+}

--- a/internal/quaiapi/quai_api.go
+++ b/internal/quaiapi/quai_api.go
@@ -576,10 +576,10 @@ type SubRelay struct {
 	Reorg    bool
 }
 
-func (s *PublicBlockChainQuaiAPI) SubRelayPendingHeader(ctx context.Context, raw json.RawMessage) (types.BlockManifest, error) {
+func (s *PublicBlockChainQuaiAPI) SubRelayPendingHeader(ctx context.Context, raw json.RawMessage) error {
 	var subRelay SubRelay
 	if err := json.Unmarshal(raw, &subRelay); err != nil {
-		return nil, err
+		return err
 	}
 	pendingHeader := types.PendingHeader{Header: subRelay.Header, Termini: subRelay.Termini}
 	return s.b.SubRelayPendingHeader(pendingHeader, subRelay.Reorg)

--- a/quaiclient/quaiclient.go
+++ b/quaiclient/quaiclient.go
@@ -174,3 +174,16 @@ func (ec *Client) SubRelayPendingHeader(ctx context.Context, pendingHeader types
 	}
 	return nil
 }
+
+func (ec *Client) GetSubManifest(ctx context.Context, blockHash common.Hash) (types.BlockManifest, error) {
+	var raw json.RawMessage
+	err := ec.c.CallContext(ctx, &raw, "quai_getSubManifest", blockHash)
+	if err != nil {
+		return nil, err
+	}
+	var manifest types.BlockManifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		return nil, err
+	}
+	return manifest, nil
+}

--- a/quaiclient/quaiclient.go
+++ b/quaiclient/quaiclient.go
@@ -163,19 +163,14 @@ func (ec *Client) Append(ctx context.Context, header *types.Header, domTerminus 
 	return types.PendingHeader{Header: head, Termini: termini.Termini}, nil
 }
 
-func (ec *Client) SubRelayPendingHeader(ctx context.Context, pendingHeader types.PendingHeader, reorg bool) (types.BlockManifest, error) {
+func (ec *Client) SubRelayPendingHeader(ctx context.Context, pendingHeader types.PendingHeader, reorg bool) error {
 	data := map[string]interface{}{"Header": RPCMarshalHeader(pendingHeader.Header)}
 	data["Termini"] = pendingHeader.Termini
 	data["Reorg"] = reorg
 
-	var raw json.RawMessage
-	err := ec.c.CallContext(ctx, &raw, "quai_subRelayPendingHeader", data)
+	err := ec.c.CallContext(ctx, nil, "quai_subRelayPendingHeader", data)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	var subPendingManifest types.BlockManifest
-	if err := json.Unmarshal(raw, &subPendingManifest); err != nil {
-		return nil, err
-	}
-	return subPendingManifest, nil
+	return nil
 }


### PR DESCRIPTION
The original idea of caching pending manifests was flawed. This PR reverts that commit and implements a better solution: when `InsertChain()` is called for a block whose manifest we don't know, we ask our sub for the manifest and rewrite the block body with the correct manifest.