### PR TITLE
Emit ETXs from EVM and rollup into coincident blocks

### DIFF
--- a/core/slice.go
+++ b/core/slice.go
@@ -548,6 +548,8 @@ func (sl *Slice) combinePendingHeader(header *types.Header, slPendingHeader *typ
 	slPendingHeader.SetGasLimit(header.GasLimit(index), index)
 	slPendingHeader.SetGasUsed(header.GasUsed(index), index)
 	slPendingHeader.SetTxHash(header.TxHash(index), index)
+	slPendingHeader.SetEtxHash(header.EtxHash(index), index)
+	slPendingHeader.SetManifestHash(header.ManifestHash(index), index)
 	slPendingHeader.SetReceiptHash(header.ReceiptHash(index), index)
 	slPendingHeader.SetRoot(header.Root(index), index)
 	slPendingHeader.SetDifficulty(header.Difficulty(index), index)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -250,7 +250,7 @@ func applyTransaction(msg types.Message, config *params.ChainConfig, bc ChainCon
 
 	// Create a new receipt for the transaction, storing the intermediate root and gas used
 	// by the tx.
-	receipt := &types.Receipt{Type: tx.Type(), PostState: root, CumulativeGasUsed: *usedGas}
+	receipt := &types.Receipt{Type: tx.Type(), PostState: root, CumulativeGasUsed: *usedGas, Etxs: result.Etxs}
 	if result.Failed() {
 		receipt.Status = types.ReceiptStatusFailed
 	} else {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -82,9 +82,10 @@ type Message interface {
 // ExecutionResult includes all output after executing given evm
 // message no matter the execution itself is successful or not.
 type ExecutionResult struct {
-	UsedGas    uint64 // Total used gas but include the refunded gas
-	Err        error  // Any error encountered during the execution(listed in core/vm/errors.go)
-	ReturnData []byte // Returned data from evm(function result or data supplied with revert opcode)
+	UsedGas    uint64               // Total used gas but include the refunded gas
+	Err        error                // Any error encountered during the execution(listed in core/vm/errors.go)
+	ReturnData []byte               // Returned data from evm(function result or data supplied with revert opcode)
+	Etxs       []*types.Transaction // External transactions generated from opETX
 }
 
 // Unwrap returns the internal evm error which allows us for further
@@ -334,13 +335,14 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		}
 		st.state.SetNonce(msg.From(), nonce+1)
 		ret, st.gas, vmerr = st.evm.Call(sender, st.to(), st.data, st.gas, st.value)
-		// At this point, the execution completed, so the ETX cache can be dumped and reset
-		st.evm.ETXCacheLock.Lock()
-		etxCache := st.evm.ETXCache
-		_ = etxCache // do something with the list of ETXs from this transaction
-		st.evm.ETXCache = make([]*types.ExternalTx, 0)
-		st.evm.ETXCacheLock.Unlock()
 	}
+
+	// At this point, the execution completed, so the ETX cache can be dumped and reset
+	var etxs []*types.Transaction
+	st.evm.ETXCacheLock.Lock()
+	copy(etxs, st.evm.ETXCache)
+	st.evm.ETXCache = make([]*types.Transaction, 0)
+	st.evm.ETXCacheLock.Unlock()
 
 	if !london {
 		// Before EIP-3529: refunds were capped to gasUsed / 2
@@ -359,6 +361,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		UsedGas:    st.gasUsed(),
 		Err:        vmerr,
 		ReturnData: ret,
+		Etxs:       etxs,
 	}, nil
 }
 

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -67,9 +67,10 @@ type Receipt struct {
 
 	// Inclusion information: These fields provide information about the inclusion of the
 	// transaction corresponding to this receipt.
-	BlockHash        common.Hash `json:"blockHash,omitempty"`
-	BlockNumber      *big.Int    `json:"blockNumber,omitempty"`
-	TransactionIndex uint        `json:"transactionIndex"`
+	BlockHash        common.Hash    `json:"blockHash,omitempty"`
+	BlockNumber      *big.Int       `json:"blockNumber,omitempty"`
+	TransactionIndex uint           `json:"transactionIndex"`
+	Etxs             []*Transaction `json:"etxs"`
 }
 
 type receiptMarshaling struct {

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -124,7 +124,7 @@ type EVM struct {
 	// applied in opCall*.
 	callGasTemp uint64
 
-	ETXCache     []*types.ExternalTx
+	ETXCache     []*types.Transaction
 	ETXCacheLock sync.RWMutex
 }
 
@@ -138,7 +138,7 @@ func NewEVM(blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig
 		Config:      config,
 		chainConfig: chainConfig,
 		chainRules:  chainConfig.Rules(blockCtx.BlockNumber),
-		ETXCache:    make([]*types.ExternalTx, 0),
+		ETXCache:    make([]*types.Transaction, 0),
 	}
 	evm.interpreter = NewEVMInterpreter(evm, config)
 	return evm

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -868,10 +868,11 @@ func opETX(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte
 	sender := scope.Contract.self.Address()
 
 	// create external transaction
-	etx := types.ExternalTx{Value: value.ToBig(), To: &toAddr, Sender: sender, GasTipCap: gasTipCap.ToBig(), GasFeeCap: gasFeeCap.ToBig(), Gas: gas, Data: data, AccessList: accessList, Nonce: nonce.Uint64()}
+	etxInner := types.ExternalTx{Value: value.ToBig(), To: &toAddr, Sender: sender, GasTipCap: gasTipCap.ToBig(), GasFeeCap: gasFeeCap.ToBig(), Gas: gas, Data: data, AccessList: accessList, Nonce: nonce.Uint64()}
+	etx := types.NewTx(&etxInner)
 
 	interpreter.evm.ETXCacheLock.Lock()
-	interpreter.evm.ETXCache = append(interpreter.evm.ETXCache, &etx)
+	interpreter.evm.ETXCache = append(interpreter.evm.ETXCache, etx)
 	interpreter.evm.ETXCacheLock.Unlock()
 
 	temp.SetOne() // following opCall protocol

--- a/core/worker.go
+++ b/core/worker.go
@@ -660,7 +660,11 @@ func (w *worker) commitTransaction(env *environment, tx *types.Transaction) ([]*
 
 		env.txs = append(env.txs, tx)
 		env.receipts = append(env.receipts, receipt)
-
+		if receipt.Status == types.ReceiptStatusSuccessful {
+			for _, etx := range receipt.Etxs {
+				env.etxs = append(env.etxs, etx)
+			}
+		}
 		return receipt.Logs, nil
 	}
 	return nil, errors.New("error finding transaction")


### PR DESCRIPTION
This PR depends on https://github.com/dominant-strategies/go-quai/pull/463. Only the last 3 commits are pertinent to this feature. I will remove the PR from draft state once https://github.com/dominant-strategies/go-quai/pull/463 merges.

This PR implements the ETX rollup. Future work will broadcast block bodies (with the ETX rollups) through a domclient for routing to the destination chain(s)