### PR TITLE
Implement domclient ETX router

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -56,6 +56,10 @@ func (c *Core) InsertChain(blocks types.Blocks) (int, error) {
 				block = block.WithBody(oldBody.Transactions, oldBody.Uncles, oldBody.ExtTransactions, newSubManifest)
 			}
 		}
+		// Route ETXs to the network
+		if err := c.sl.RouteEtxs(block.Hash(), isCoincident, block.ExtTransactions()); err != nil {
+			log.Error("etx router failed", "block hash: ", block.Hash(), "err", err)
+		}
 		// Write the block body to the db.
 		rawdb.WritePendingBlockBody(c.sl.sliceDb, block.Header().Root(), block.Body())
 
@@ -131,8 +135,16 @@ func (c *Core) GetPendingHeader() (*types.Header, error) {
 	return c.sl.GetPendingHeader()
 }
 
+func (c *Core) RouteEtxs(blockHash common.Hash, isCoincident bool, etxs []*types.Transaction) error {
+	return c.sl.RouteEtxs(blockHash, isCoincident, etxs)
+}
+
 func (c *Core) GetSubManifest(blockHash common.Hash) (types.BlockManifest, error) {
 	return c.sl.GetSubManifest(blockHash)
+}
+
+func (c *Core) AddPendingInboundEtxs(blockHash common.Hash, originCtx int, etxs []*types.Transaction) error {
+	return c.sl.AddPendingInboundEtxs(blockHash, originCtx, etxs)
 }
 
 //---------------------//

--- a/core/events.go
+++ b/core/events.go
@@ -24,6 +24,13 @@ import (
 // NewTxsEvent is posted when a batch of transactions enter the transaction pool.
 type NewTxsEvent struct{ Txs []*types.Transaction }
 
+// NewEtxsEvent is posted when block emits a batch of etxs
+type NewEtxsEvent struct {
+	BlockHash     common.Hash
+	OriginContext int // Which context originated these ETXs
+	Etxs          []*types.Transaction
+}
+
 // NewMinedBlockEvent is posted when a block has been imported.
 type NewMinedBlockEvent struct{ Block *types.Block }
 

--- a/core/slice.go
+++ b/core/slice.go
@@ -374,12 +374,22 @@ func (sl *Slice) GetPendingHeader() (*types.Header, error) {
 	return sl.phCache[sl.pendingHeader].Header, nil
 }
 
+// RouteEtxs gives etxs from a block to the dom to be routed to other chains
+func (sl *Slice) RouteEtxs(blockHash common.Hash, isCoincident bool, etxs []*types.Transaction) error {
+	return sl.domClient.RouteEtxs(context.Background(), blockHash, isCoincident, etxs)
+}
+
 func (sl *Slice) GetSubManifest(blockHash common.Hash) (types.BlockManifest, error) {
 	header := sl.hc.GetHeaderByHash(blockHash)
 	if header == nil {
 		return nil, errors.New("block not found")
 	}
 	return sl.hc.CollectBlockManifest(header)
+}
+
+func (sl *Slice) AddPendingInboundEtxs(blockHash common.Hash, originCtx int, etxs []*types.Transaction) error {
+	log.Info("received pending ETXs", "blockHash: ", blockHash)
+	return nil
 }
 
 // SubRelayPendingHeader takes a pending header from the sender (ie dominant), updates the phCache with a composited header and relays result to subordinates

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -382,6 +382,10 @@ func (b *QuaiAPIBackend) GetPendingHeader() (*types.Header, error) {
 	return b.eth.core.GetPendingHeader()
 }
 
+func (b *QuaiAPIBackend) RouteEtxs(blockHash common.Hash, isCoincident bool, etxs []*types.Transaction) error {
+	return b.eth.core.RouteEtxs(blockHash, isCoincident, etxs)
+}
+
 func (b *QuaiAPIBackend) GetSubManifest(blockHash common.Hash) (types.BlockManifest, error) {
 	return b.eth.core.GetSubManifest(blockHash)
 }

--- a/eth/handler_eth.go
+++ b/eth/handler_eth.go
@@ -89,6 +89,9 @@ func (h *ethHandler) Handle(peer *eth.Peer, packet eth.Packet) error {
 	case *eth.NewBlockPacket:
 		return h.handleBlockBroadcast(peer, packet.Block)
 
+	case *eth.NewEtxsPacket:
+		return h.handleNewEtxs(peer, packet.BlockHash, packet.OriginCtx, packet.Etxs)
+
 	case *eth.NewPooledTransactionHashesPacket:
 		return h.txFetcher.Notify(peer.ID(), *packet)
 
@@ -200,4 +203,10 @@ func (h *ethHandler) handleBlockBroadcast(peer *eth.Peer, block *types.Block) er
 		h.chainSync.handlePeerEvent(peer)
 	}
 	return nil
+}
+
+// handleNewEtxs is invoked from a peer's message handler when it transmits a
+// ETX broadcast for the local node to process.
+func (h *ethHandler) handleNewEtxs(peer *eth.Peer, blockHash common.Hash, originCtx int, etxs []*types.Transaction) error {
+	return h.core.AddPendingInboundEtxs(blockHash, originCtx, etxs)
 }

--- a/eth/protocols/eth/handler.go
+++ b/eth/protocols/eth/handler.go
@@ -191,6 +191,7 @@ var eth65 = map[uint64]msgHandler{
 var eth66 = map[uint64]msgHandler{
 	NewBlockHashesMsg:             handleNewBlockhashes,
 	NewBlockMsg:                   handleNewBlock,
+	NewEtxsMsg:                    handleNewEtxs,
 	TransactionsMsg:               handleTransactions,
 	NewPooledTransactionHashesMsg: handleNewPooledTransactionHashes,
 	// eth66 messages with request-id

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -320,6 +320,15 @@ func handleNewBlock(backend Backend, msg Decoder, peer *Peer) error {
 	return backend.Handle(peer, ann)
 }
 
+func handleNewEtxs(backend Backend, msg Decoder, peer *Peer) error {
+	// Retrieve and decode the propagated block
+	ann := new(NewEtxsPacket)
+	if err := msg.Decode(ann); err != nil {
+		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	return backend.Handle(peer, ann)
+}
+
 func handleBlockHeaders(backend Backend, msg Decoder, peer *Peer) error {
 	// A batch of headers arrived to one of our previous requests
 	res := new(BlockHeadersPacket)

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -329,6 +329,15 @@ func (p *Peer) SendNewBlock(block *types.Block) error {
 	})
 }
 
+// SendNewEtxs propagates a set of external transactions to a remote peer.
+func (p *Peer) SendNewEtxs(blockHash common.Hash, originCtx int, etxs []*types.Transaction) error {
+	return p2p.Send(p.rw, NewEtxsMsg, &NewEtxsPacket{
+		BlockHash: blockHash,
+		OriginCtx: originCtx,
+		Etxs:      etxs,
+	})
+}
+
 // AsyncSendNewBlock queues an entire block for propagation to a remote peer. If
 // the peer's broadcast queue is full, the event is silently dropped.
 func (p *Peer) AsyncSendNewBlock(block *types.Block) {

--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -62,6 +62,7 @@ const (
 	NodeDataMsg        = 0x0e
 	GetReceiptsMsg     = 0x0f
 	ReceiptsMsg        = 0x10
+	NewEtxsMsg         = 0x11
 
 	// Protocol messages overloaded in eth/65
 	NewPooledTransactionHashesMsg = 0x08
@@ -181,6 +182,13 @@ type BlockHeadersPacket66 struct {
 // NewBlockPacket is the network packet for the block propagation message.
 type NewBlockPacket struct {
 	Block *types.Block
+}
+
+// NewEtxsPacket is the network packet for the etx propagation message.
+type NewEtxsPacket struct {
+	BlockHash common.Hash
+	OriginCtx int
+	Etxs      []*types.Transaction
 }
 
 // sanityCheck verifies that the values are reasonable, as a DoS protection
@@ -339,6 +347,9 @@ func (*BlockBodiesPacket) Kind() byte   { return BlockBodiesMsg }
 
 func (*NewBlockPacket) Name() string { return "NewBlock" }
 func (*NewBlockPacket) Kind() byte   { return NewBlockMsg }
+
+func (*NewEtxsPacket) Name() string { return "NewEtxs" }
+func (*NewEtxsPacket) Kind() byte   { return NewEtxsMsg }
 
 func (*GetNodeDataPacket) Name() string { return "GetNodeData" }
 func (*GetNodeDataPacket) Kind() byte   { return GetNodeDataMsg }

--- a/internal/quaiapi/backend.go
+++ b/internal/quaiapi/backend.go
@@ -80,6 +80,7 @@ type Backend interface {
 	SubRelayPendingHeader(pendingHeader types.PendingHeader, reorg bool) error
 	GetPendingHeader() (*types.Header, error)
 	GetSubManifest(blockHash common.Hash) (types.BlockManifest, error)
+	RouteEtxs(blockHash common.Hash, isCoincident bool, etxs []*types.Transaction) error
 	PendingBlockAndReceipts() (*types.Block, types.Receipts)
 
 	// Transaction pool API

--- a/quaiclient/quaiclient.go
+++ b/quaiclient/quaiclient.go
@@ -187,3 +187,16 @@ func (ec *Client) GetSubManifest(ctx context.Context, blockHash common.Hash) (ty
 	}
 	return manifest, nil
 }
+
+func (ec *Client) RouteEtxs(ctx context.Context, blockHash common.Hash, isCoincident bool, etxs []*types.Transaction) error {
+	data := make(map[string]interface{})
+	data["BlockHash"] = blockHash
+	data["IsCoincident"] = isCoincident
+	data["Etxs"] = etxs
+	var raw json.RawMessage
+	err := ec.c.CallContext(ctx, &raw, "quai_routeExtBlock", data)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
This PR adds a routing path through our dominant node to relay pending ETXs to the rest of the network. The routing logic is as follows:
* when we find a block, give the pending ETXs to our domclient for routing
* dom client always routes to the peer network
* iff the block is coincident, the dom additionally relays to his own domclient if he has one (i.e. a region node)
* upon receiving a set of pending ETXs from the peer network, a node will also share those pending ETXs with subordinate clients

By doing this, ETXs will propagate the network before becoming spendable (via coincident blocks). In future work, destination nodes should save these pending ETXs and mark them "spendable" once the assosciated blockhash appears in a coincident block manifest.