### PR TITLE
add the chain to block stats reporting

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1488,11 +1488,11 @@ func RegisterEthService(stack *node.Node, cfg *ethconfig.Config) (quaiapi.Backen
 	return backend.APIBackend, backend
 }
 
-// RegisterQuaiStatsService configures the Ethereum Stats daemon and adds it to
+// RegisterQuaiStatsService configures the Quai Stats daemon and adds it to
 // the given node.
 func RegisterQuaiStatsService(stack *node.Node, backend quaiapi.Backend, url string) {
 	if err := quaistats.New(stack, backend, backend.Engine(), url); err != nil {
-		Fatalf("Failed to register the Ethereum Stats service: %v", err)
+		Fatalf("Failed to register the Quai Stats service: %v", err)
 	}
 }
 

--- a/quaistats/quaistats.go
+++ b/quaistats/quaistats.go
@@ -583,6 +583,7 @@ type blockStats struct {
 	TxHash     common.Hash    `json:"transactionsRoot"`
 	Root       common.Hash    `json:"stateRoot"`
 	Uncles     uncleStats     `json:"uncles"`
+	Chain      []int          `json:"chain"`
 }
 
 // txStats is the information to report about individual transactions.
@@ -672,6 +673,7 @@ func (s *Service) assembleBlockStats(block *types.Block) *blockStats {
 		TxHash:     header.TxHash(),
 		Root:       header.Root(),
 		Uncles:     uncles,
+		Chain:      IntArrayLocation(common.NodeLocation),
 	}
 }
 

--- a/quaistats/quaistats.go
+++ b/quaistats/quaistats.go
@@ -675,6 +675,17 @@ func (s *Service) assembleBlockStats(block *types.Block) *blockStats {
 	}
 }
 
+func IntArrayLocation(l common.Location) []int {
+	switch l.Context() {
+	case common.REGION_CTX:
+		return []int{l.Region()}
+	case common.ZONE_CTX:
+		return []int{l.Region(), l.Zone()}
+	default:
+		return []int{}
+	}
+}
+
 // reportHistory retrieves the most recent batch of blocks and reports it to the
 // stats server.
 func (s *Service) reportHistory(conn *connWrapper, list []uint64) error {


### PR DESCRIPTION
The primary question I have for reviewers is what the thoughts are the on the https://github.com/dominant-strategies/go-quai/pull/466/commits/322a70d3878b32889e1b1c8bc30e2c4800c46ae8 commit. 

I added that because I wanted to marshal the location array, but did not want to get a [base-64 encoded string](https://pkg.go.dev/encoding/json#Marshal) that would have to be later de-encoded before insertion into the postgres db for the stats-manager. 


Stats-Backend PR dependency: https://github.com/dominant-strategies/quai-stats-backend/pull/10
Linear: https://linear.app/quai-network/issue/FS-173/add-chain-to-block