### PR TITLE
add startup script

### DIFF
--- a/startup-script.sh
+++ b/startup-script.sh
@@ -1,0 +1,48 @@
+#! /usr/bin/bash
+
+FUNCTION="rs"
+
+compile() {
+  echo -e $'\nCompiling...\n'
+  make go-quai
+}
+
+run_stats() {
+  echo -e '\nRunning stats...\n'
+  rm -rf ~/.quai
+  rm -rf nodelogs
+  make stop
+  make run-stats
+}
+
+help()
+{
+  # Display Help
+  echo -e "\nHelper script to run go-quai utilities locally.\n"
+  echo "Syntax: scriptTemplate [-|h|c|rs]"
+  echo "options:"
+  echo "-c     Compile go-quai."
+  echo "-s    Run stats."
+  echo "-h     Print this Help."
+  echo
+}
+
+while getopts 'csh:' OPTION; do
+  case "$OPTION" in
+    c)
+      compile
+      ;;
+    s)
+      run_stats
+      ;;
+    -h)
+      help
+      ;;
+    ?)
+      echo "OPTION: $OPTION"
+      echo "\nscript usage: $(basename \$0) [-h] for help" >&2
+      exit 1
+      ;;
+  esac
+done
+shift "$(($OPTIND -1))"

--- a/startup-script.sh
+++ b/startup-script.sh
@@ -9,7 +9,12 @@ compile() {
 
 run_stats() {
   echo -e '\nRunning stats...\n'
-  rm -rf ~/.quai
+  if [[ "$OSTYPE" == "darwin"* ]];
+  then
+    rm -rf ~/Library/quai
+  else
+    rm -rf ~/.quai
+  fi
   rm -rf nodelogs
   make stop
   make run-stats


### PR DESCRIPTION
This startup script includes flags to start stats and compile locally. 

Please request changes for any additional things you would like added or bug-fixed before merge. 

PSA: This only handles Linux. MacOS has not been tested. 


Linear: https://linear.app/quai-network/issue/FS-175/add-cleaner-startup-script-for-go-quai