### PR TITLE
Add domclient route to relay ETXs up through slice

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -485,47 +485,47 @@ func (ma *MixedcaseAddress) Original() string {
 // zone[1,2] = [1, 2]
 type Location []byte
 
-func (l Location) Region() int {
-	if len(l) >= 1 {
-		return int(l[REGION_CTX-1])
+func (loc Location) Region() int {
+	if len(loc) >= 1 {
+		return int(loc[REGION_CTX-1])
 	} else {
 		return -1
 	}
 }
 
-func (l Location) HasRegion() bool {
-	return l.Region() >= 0
+func (loc Location) HasRegion() bool {
+	return loc.Region() >= 0
 }
 
-func (l Location) Zone() int {
-	if len(l) >= 2 {
-		return int(l[ZONE_CTX-1])
+func (loc Location) Zone() int {
+	if len(loc) >= 2 {
+		return int(loc[ZONE_CTX-1])
 	} else {
 		return -1
 	}
 }
 
-func (l Location) HasZone() bool {
-	return l.Zone() >= 0
+func (loc Location) HasZone() bool {
+	return loc.Zone() >= 0
 }
 
-func (l Location) AssertValid() {
-	if !l.HasRegion() && l.HasZone() {
+func (loc Location) AssertValid() {
+	if !loc.HasRegion() && loc.HasZone() {
 		log.Fatal("cannot specify zone without also specifying region.")
 	}
-	if l.Region() >= NumRegionsInPrime {
+	if loc.Region() >= NumRegionsInPrime {
 		log.Fatal("region index is not valid.")
 	}
-	if l.Zone() >= NumZonesInRegion {
+	if loc.Zone() >= NumZonesInRegion {
 		log.Fatal("zone index is not valid.")
 	}
 }
 
-func (l Location) Context() int {
-	l.AssertValid()
-	if l.Zone() >= 0 {
+func (loc Location) Context() int {
+	loc.AssertValid()
+	if loc.Zone() >= 0 {
 		return ZONE_CTX
-	} else if l.Region() >= 0 {
+	} else if loc.Region() >= 0 {
 		return REGION_CTX
 	} else {
 		return PRIME_CTX
@@ -533,21 +533,21 @@ func (l Location) Context() int {
 }
 
 // DomLocation returns the location of your dominant chain
-func (l Location) DomLocation() Location {
-	if len(l) < 1 {
+func (loc Location) DomLocation() Location {
+	if len(loc) < 1 {
 		return nil
 	} else {
-		return l[:len(l)-1]
+		return loc[:len(loc)-1]
 	}
 }
 
 // SubIndex returns the index of the subordinate chain for a given location
-func (l Location) SubIndex() int {
+func (loc Location) SubIndex() int {
 	switch NodeLocation.Context() {
 	case PRIME_CTX:
-		return l.Region()
+		return loc.Region()
 	case REGION_CTX:
-		return l.Zone()
+		return loc.Zone()
 	default:
 		return -1
 	}
@@ -561,31 +561,31 @@ func (l Location) SubIndex() int {
 // * if region-0 calls SubInSlice(Location{0,0}) the result will be
 //   Location{0,0}, i.e. zone-0-0's location, because region-0's subordinate in
 //   that slice is zone-0-0
-func (l Location) SubInSlice(slice Location) Location {
-	if len(slice) <= len(l) {
+func (loc Location) SubInSlice(slice Location) Location {
+	if len(slice) <= len(loc) {
 		log.Println("cannot determine sub location, because slice location is not deeper than self")
 		return nil
 	}
-	subLoc := append(l, slice[len(l)])
+	subLoc := append(loc, slice[len(loc)])
 	return subLoc
 }
 
-func (l Location) InSameSliceAs(cmp Location) bool {
+func (loc Location) InSameSliceAs(cmp Location) bool {
 	// Figure out which location is shorter
-	shorter := l
+	shorter := loc
 	longer := cmp
-	if len(l) > len(cmp) {
-		longer = l
+	if len(loc) > len(cmp) {
+		longer = loc
 		shorter = cmp
 	}
 	// Compare bytes up to the shorter depth
 	return shorter.Equal(longer[:len(shorter)])
 }
 
-func (l Location) Name() string {
-	regionNum := strconv.Itoa(l.Region())
-	zoneNum := strconv.Itoa(l.Zone())
-	switch l.Context() {
+func (loc Location) Name() string {
+	regionNum := strconv.Itoa(loc.Region())
+	zoneNum := strconv.Itoa(loc.Zone())
+	switch loc.Context() {
 	case PRIME_CTX:
 		return "prime"
 	case REGION_CTX:
@@ -598,9 +598,9 @@ func (l Location) Name() string {
 	}
 }
 
-func (l Location) ContainsAddress(a Address) bool {
+func (loc Location) ContainsAddress(a Address) bool {
 	prefix := a[0]
-	prefixRange, ok := locationToPrefixRange[l.Name()]
+	prefixRange, ok := locationToPrefixRange[loc.Name()]
 	if !ok {
 		log.Fatal("unable to get address prefix range for location")
 	}
@@ -608,22 +608,22 @@ func (l Location) ContainsAddress(a Address) bool {
 	return prefix >= prefixRange.lo && prefix <= prefixRange.hi
 }
 
-func (l Location) Equal(cmp Location) bool {
-	return bytes.Equal(l, cmp)
+func (loc Location) Equal(cmp Location) bool {
+	return bytes.Equal(loc, cmp)
 }
 
 // CommonDom identifies the highest context chain which exists in both locations
 // * zone-0-0 & zone-0-1 would share region-0 as their highest context common dom
 // * zone-0-0 & zone-1-0 would share Prime as their highest context common dom
-func (l Location) CommonDom(cmp Location) Location {
+func (loc Location) CommonDom(cmp Location) Location {
 	common := Location{}
-	shorterLen := len(l)
-	if len(l) > len(cmp) {
+	shorterLen := len(loc)
+	if len(loc) > len(cmp) {
 		shorterLen = len(cmp)
 	}
 	for i := 0; i < shorterLen; i++ {
-		if l[i] == cmp[i] {
-			common = append(common, l[i])
+		if loc[i] == cmp[i] {
+			common = append(common, loc[i])
 		} else {
 			break
 		}

--- a/core/bodydb.go
+++ b/core/bodydb.go
@@ -63,12 +63,12 @@ func NewBodyDb(db ethdb.Database, engine consensus.Engine, hc *HeaderChain, chai
 }
 
 // Append
-func (bc *BodyDb) Append(batch ethdb.Batch, block *types.Block) ([]*types.Log, error) {
+func (bc *BodyDb) Append(batch ethdb.Batch, block *types.Block, newInboundEtxs types.Transactions) ([]*types.Log, error) {
 	bc.chainmu.Lock()
 	defer bc.chainmu.Unlock()
 
 	// Process our block and retrieve external blocks.
-	logs, err := bc.processor.Apply(batch, block)
+	logs, err := bc.processor.Apply(batch, block, newInboundEtxs)
 	if err != nil {
 		return nil, err
 	}

--- a/core/core.go
+++ b/core/core.go
@@ -56,19 +56,24 @@ func (c *Core) InsertChain(blocks types.Blocks) (int, error) {
 				block = block.WithBody(oldBody.Transactions, oldBody.Uncles, oldBody.ExtTransactions, newSubManifest)
 			}
 		}
+
 		// Write the block body to the db.
 		rawdb.WritePendingBlockBody(c.sl.sliceDb, block.Header().Root(), block.Body())
 
 		// if the order of the block is less than the context
 		// add the rest of the blocks in the queue to the future blocks.
 		if !isCoincident && !domWait {
-			_, err := c.sl.Append(block.Header(), common.Hash{}, big.NewInt(0), false, true, block.ManifestHash())
+			_, newPendingEtxs, err := c.sl.Append(block.Header(), common.Hash{}, big.NewInt(0), false, true, block.ManifestHash())
 			if err != nil {
 				if err == consensus.ErrFutureBlock {
 					c.sl.addfutureHeader(block.Header())
 				}
 				log.Info("InsertChain", "err in Append core: ", err)
 				return i, err
+			}
+			// Let our dom know about the new ETXs we have pending
+			if err := c.sl.SendPendingEtxsToDom(block.Header(), newPendingEtxs); err != nil {
+				log.Error("failed to send ETXs to domclient", "block: ", block.Hash(), "err", err)
 			}
 		} else {
 			domWait = true
@@ -114,7 +119,7 @@ func (c *Core) Stop() {
 // Slice methods //
 //---------------//
 
-func (c *Core) Append(header *types.Header, domTerminus common.Hash, td *big.Int, domOrigin bool, reorg bool, manifestHash common.Hash) (types.PendingHeader, error) {
+func (c *Core) Append(header *types.Header, domTerminus common.Hash, td *big.Int, domOrigin bool, reorg bool, manifestHash common.Hash) (types.PendingHeader, []types.Transactions, error) {
 	return c.sl.Append(header, domTerminus, td, domOrigin, reorg, manifestHash)
 }
 
@@ -131,8 +136,16 @@ func (c *Core) GetPendingHeader() (*types.Header, error) {
 	return c.sl.GetPendingHeader()
 }
 
+func (c *Core) SendPendingEtxsToDom(header *types.Header, etxs []types.Transactions) error {
+	return c.sl.SendPendingEtxsToDom(header, etxs)
+}
+
 func (c *Core) GetSubManifest(blockHash common.Hash) (types.BlockManifest, error) {
 	return c.sl.GetSubManifest(blockHash)
+}
+
+func (c *Core) AddPendingEtxs(header *types.Header, etxs []types.Transactions) error {
+	return c.sl.AddPendingEtxs(header, etxs)
 }
 
 //---------------------//

--- a/core/core.go
+++ b/core/core.go
@@ -45,7 +45,7 @@ func (c *Core) InsertChain(blocks types.Blocks) (int, error) {
 		// block body is incorrect. If so, ask our sub for the correct manifest,
 		// update and rewrite the correct body.
 		if block.ManifestHash() != block.SubManifest().Hash() {
-			if subIdx := block.Location().SubLocation(); subIdx >= 0 {
+			if subIdx := block.Location().SubIndex(); subIdx >= 0 {
 				newSubManifest, err := c.sl.subClients[subIdx].GetSubManifest(context.Background(), block.Hash())
 				if err != nil {
 					return i, err

--- a/core/core.go
+++ b/core/core.go
@@ -63,7 +63,7 @@ func (c *Core) InsertChain(blocks types.Blocks) (int, error) {
 		// if the order of the block is less than the context
 		// add the rest of the blocks in the queue to the future blocks.
 		if !isCoincident && !domWait {
-			_, newPendingEtxs, err := c.sl.Append(block.Header(), common.Hash{}, big.NewInt(0), false, true, block.ManifestHash())
+			_, newPendingEtxs, err := c.sl.Append(block.Header(), common.Hash{}, big.NewInt(0), false, true, block.ManifestHash(), nil)
 			if err != nil {
 				if err == consensus.ErrFutureBlock {
 					c.sl.addfutureHeader(block.Header())
@@ -119,8 +119,8 @@ func (c *Core) Stop() {
 // Slice methods //
 //---------------//
 
-func (c *Core) Append(header *types.Header, domTerminus common.Hash, td *big.Int, domOrigin bool, reorg bool, manifestHash common.Hash) (types.PendingHeader, []types.Transactions, error) {
-	return c.sl.Append(header, domTerminus, td, domOrigin, reorg, manifestHash)
+func (c *Core) Append(header *types.Header, domTerminus common.Hash, td *big.Int, domOrigin bool, reorg bool, manifestHash common.Hash, newInboundEtxs types.Transactions) (types.PendingHeader, []types.Transactions, error) {
+	return c.sl.Append(header, domTerminus, td, domOrigin, reorg, manifestHash, newInboundEtxs)
 }
 
 // ConstructLocalBlock takes a header and construct the Block locally

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -148,7 +148,7 @@ func (hc *HeaderChain) CollectEtxRollup(b *types.Block) (types.Transactions, err
 }
 
 // Append
-func (hc *HeaderChain) Append(batch ethdb.Batch, block *types.Block, manifestHash common.Hash) error {
+func (hc *HeaderChain) Append(batch ethdb.Batch, block *types.Block, manifestHash common.Hash, newInboundEtxs types.Transactions) error {
 	h := block.Header()
 	log.Debug("HeaderChain Append:", "Block information: Hash:", block.Hash(), "block header hash:", h.Hash(), "Number:", block.NumberU64(), "Location:", h.Location, "Parent:", block.ParentHash())
 
@@ -174,7 +174,7 @@ func (hc *HeaderChain) Append(batch ethdb.Batch, block *types.Block, manifestHas
 	rawdb.WriteHeader(batch, block.Header())
 
 	// Append block else revert header append
-	logs, err := hc.bc.Append(batch, block)
+	logs, err := hc.bc.Append(batch, block, newInboundEtxs)
 	if err != nil {
 		return err
 	}

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -1137,3 +1137,71 @@ func ReadHeadBlock(db ethdb.Reader) *types.Block {
 	}
 	return ReadBlock(db, headBlockHash, *headBlockNumber)
 }
+
+// ReadEtxSetRLP retrieves the EtxSet corresponding to a given block, in RLP encoding.
+func ReadEtxSetRLP(db ethdb.Reader, hash common.Hash, number uint64) rlp.RawValue {
+	// First try to look up the data in ancient database. Extra hash
+	// comparison is necessary since ancient database only maintains
+	// the canonical data.
+	data, _ := db.Ancient(freezerEtxSetsTable, number)
+	if len(data) > 0 {
+		h, _ := db.Ancient(freezerHashTable, number)
+		if common.BytesToHash(h) == hash {
+			return data
+		}
+	}
+	// Then try to look up the data in leveldb.
+	data, _ = db.Get(etxSetKey(number, hash))
+	if len(data) > 0 {
+		return data
+	}
+	// In the background freezer is moving data from leveldb to flatten files.
+	// So during the first check for ancient db, the data is not yet in there,
+	// but when we reach into leveldb, the data was already moved. That would
+	// result in a not found error.
+	data, _ = db.Ancient(freezerEtxSetsTable, number)
+	if len(data) > 0 {
+		h, _ := db.Ancient(freezerHashTable, number)
+		if common.BytesToHash(h) == hash {
+			return data
+		}
+	}
+	return nil // Can't find the data anywhere.
+}
+
+// WriteEtxSetRLP stores the EtxSet corresponding to a given block, in RLP encoding.
+func WriteEtxSetRLP(db ethdb.KeyValueWriter, hash common.Hash, number uint64, rlp rlp.RawValue) {
+	if err := db.Put(etxSetKey(number, hash), rlp); err != nil {
+		log.Crit("Failed to store etx set", "err", err)
+	}
+}
+
+// ReadEtxSet retreives the EtxSet corresponding to a given block
+func ReadEtxSet(db ethdb.Reader, hash common.Hash, number uint64) *types.EtxSet {
+	data := ReadEtxSetRLP(db, hash, number)
+	if len(data) == 0 {
+		return nil
+	}
+	etxSet := new(types.EtxSet)
+	if err := rlp.Decode(bytes.NewReader(data), etxSet); err != nil {
+		log.Error("Invalid etx set RLP", "hash", hash, "err", err)
+		return nil
+	}
+	return etxSet
+}
+
+// WriteEtxSet retreives the EtxSet corresponding to a given block
+func WriteEtxSet(db ethdb.KeyValueWriter, hash common.Hash, number uint64, etxSet *types.EtxSet) {
+	data, err := rlp.EncodeToBytes(etxSet)
+	if err != nil {
+		log.Crit("Failed to RLP encode etx set", "err", err)
+	}
+	WriteEtxSetRLP(db, hash, number, data)
+}
+
+// DeleteEtxSet removes all EtxSet data associated with a block.
+func DeleteEtxSet(db ethdb.KeyValueWriter, hash common.Hash, number uint64) {
+	if err := db.Delete(etxSetKey(number, hash)); err != nil {
+		log.Crit("Failed to delete etx set", "err", err)
+	}
+}

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -100,7 +100,7 @@ func (db *nofreezedb) AncientSize(kind string) (uint64, error) {
 }
 
 // AppendAncient returns an error as we don't have a backing chain freezer.
-func (db *nofreezedb) AppendAncient(number uint64, hash, header, body, receipts, td []byte) error {
+func (db *nofreezedb) AppendAncient(number uint64, hash, header, body, receipts, td, etxSet []byte) error {
 	return errNotSupported
 }
 
@@ -393,7 +393,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 	}
 	// Inspect append-only file store then.
 	ancientSizes := []*common.StorageSize{&ancientHeadersSize, &ancientBodiesSize, &ancientReceiptsSize, &ancientHashesSize, &ancientTdsSize}
-	for i, category := range []string{freezerHeaderTable, freezerBodiesTable, freezerReceiptTable, freezerHashTable, freezerDifficultyTable} {
+	for i, category := range []string{freezerHeaderTable, freezerBodiesTable, freezerReceiptTable, freezerHashTable, freezerDifficultyTable, freezerEtxSetsTable} {
 		if size, err := db.AncientSize(category); err == nil {
 			*ancientSizes[i] += common.StorageSize(size)
 			total += common.StorageSize(size)

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -199,7 +199,7 @@ func (f *freezer) AncientSize(kind string) (uint64, error) {
 // Notably, this function is lock free but kind of thread-safe. All out-of-order
 // injection will be rejected. But if two injections with same number happen at
 // the same time, we can get into the trouble.
-func (f *freezer) AppendAncient(number uint64, hash, header, body, receipts, td []byte) (err error) {
+func (f *freezer) AppendAncient(number uint64, hash, header, body, receipts, td, etxSet []byte) (err error) {
 	if f.readonly {
 		return errReadOnly
 	}
@@ -237,6 +237,10 @@ func (f *freezer) AppendAncient(number uint64, hash, header, body, receipts, td 
 	}
 	if err := f.tables[freezerDifficultyTable].Append(f.frozen, td); err != nil {
 		log.Error("Failed to append ancient difficulty", "number", f.frozen, "hash", hash, "err", err)
+		return err
+	}
+	if err := f.tables[freezerEtxSetsTable].Append(f.frozen, etxSet); err != nil {
+		log.Error("Failed to append ancient etx set", "number", f.frozen, "hash", hash, "err", err)
 		return err
 	}
 	atomic.AddUint64(&f.frozen, 1) // Only modify atomically
@@ -377,9 +381,14 @@ func (f *freezer) freeze(db ethdb.KeyValueStore) {
 				log.Error("Total difficulty missing, can't freeze", "number", f.frozen, "hash", hash)
 				break
 			}
+			etxSet := ReadEtxSetRLP(nfdb, hash, f.frozen)
+			if len(td) == 0 {
+				log.Error("Total difficulty missing, can't freeze", "number", f.frozen, "hash", hash)
+				break
+			}
 			log.Trace("Deep froze ancient block", "number", f.frozen, "hash", hash)
 			// Inject all the components into the relevant data tables
-			if err := f.AppendAncient(f.frozen, hash[:], header, body, receipts, td); err != nil {
+			if err := f.AppendAncient(f.frozen, hash[:], header, body, receipts, td, etxSet); err != nil {
 				break
 			}
 			ancients = append(ancients, hash)

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -94,6 +94,7 @@ var (
 
 	blockBodyPrefix     = []byte("b") // blockBodyPrefix + num (uint64 big endian) + hash -> block body
 	blockReceiptsPrefix = []byte("r") // blockReceiptsPrefix + num (uint64 big endian) + hash -> block receipts
+	etxSetPrefix        = []byte("e") // etxSetPrefix + num (uint64 big endian) + hash -> EtxSet at block
 
 	txLookupPrefix        = []byte("l") // txLookupPrefix + hash -> transaction/receipt lookup metadata
 	bloomBitsPrefix       = []byte("B") // bloomBitsPrefix + bit (uint16 big endian) + section (uint64 big endian) + hash -> bloom bits
@@ -126,6 +127,9 @@ const (
 
 	// freezerDifficultyTable indicates the name of the freezer total difficulty table.
 	freezerDifficultyTable = "diffs"
+
+	// freezerEtxSetsTable indicates the name of the etx set table.
+	freezerEtxSetsTable = "etxSets"
 )
 
 // FreezerNoSnappy configures whether compression is disabled for the ancient-tables.
@@ -136,6 +140,7 @@ var FreezerNoSnappy = map[string]bool{
 	freezerBodiesTable:     false,
 	freezerReceiptTable:    false,
 	freezerDifficultyTable: true,
+	freezerEtxSetsTable:    false,
 }
 
 // LegacyTxLookupEntry is the legacy TxLookupEntry definition with some unnecessary
@@ -260,4 +265,9 @@ func IsCodeKey(key []byte) (bool, []byte) {
 // configKey = configPrefix + hash
 func configKey(hash common.Hash) []byte {
 	return append(configPrefix, hash.Bytes()...)
+}
+
+// etxSetKey = etxSetPrefix + num (uint64 big endian) + hash
+func etxSetKey(number uint64, hash common.Hash) []byte {
+	return append(append(etxSetPrefix, encodeBlockNumber(number)...), hash.Bytes()...)
 }

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -76,8 +76,8 @@ func (t *table) AncientSize(kind string) (uint64, error) {
 
 // AppendAncient is a noop passthrough that just forwards the request to the underlying
 // database.
-func (t *table) AppendAncient(number uint64, hash, header, body, receipts, td []byte) error {
-	return t.db.AppendAncient(number, hash, header, body, receipts, td)
+func (t *table) AppendAncient(number uint64, hash, header, body, receipts, td, etxSet []byte) error {
+	return t.db.AppendAncient(number, hash, header, body, receipts, td, etxSet)
 }
 
 // TruncateAncients is a noop passthrough that just forwards the request to the underlying

--- a/core/slice.go
+++ b/core/slice.go
@@ -161,7 +161,7 @@ func (sl *Slice) Append(header *types.Header, domTerminus common.Hash, td *big.I
 	var subPendingHeader types.PendingHeader
 	var newPendingEtxs []types.Transactions
 	if nodeCtx != common.ZONE_CTX {
-		subPendingHeader, newPendingEtxs, err = sl.subClients[location.SubLocation()].Append(context.Background(), block.Header(), domTerminus, td, true, reorg, block.ManifestHash())
+		subPendingHeader, newPendingEtxs, err = sl.subClients[location.SubIndex()].Append(context.Background(), block.Header(), domTerminus, td, true, reorg, block.ManifestHash())
 		if err != nil {
 			return sl.nilPendingHeader, nil, err
 		}
@@ -338,7 +338,7 @@ func (sl *Slice) pcrc(batch ethdb.Batch, header *types.Header, domTerminus commo
 
 	// Set the subtermini
 	if nodeCtx != common.ZONE_CTX {
-		newTermini[location.SubLocation()] = header.Hash()
+		newTermini[location.SubIndex()] = header.Hash()
 	}
 
 	// Set the terminus
@@ -362,7 +362,7 @@ func (sl *Slice) pcrc(batch ethdb.Batch, header *types.Header, domTerminus commo
 		return common.Hash{}, newTermini, nil
 	}
 
-	return termini[location.SubLocation()], newTermini, nil
+	return termini[location.SubIndex()], newTermini, nil
 }
 
 // HLCR Hierarchical Longest Chain Rule compares externTd to the currentHead Td and returns true if externTd is greater

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -276,7 +276,7 @@ func applyTransaction(msg types.Message, config *params.ChainConfig, bc ChainCon
 var lastWrite uint64
 
 // Apply State
-func (p *StateProcessor) Apply(batch ethdb.Batch, block *types.Block) ([]*types.Log, error) {
+func (p *StateProcessor) Apply(batch ethdb.Batch, block *types.Block, newInboundEtxs types.Transactions) ([]*types.Log, error) {
 	// Process our block and retrieve external blocks.
 	receipts, logs, statedb, usedGas, err := p.Process(block)
 	if err != nil {

--- a/core/types/etx_set.go
+++ b/core/types/etx_set.go
@@ -1,0 +1,44 @@
+package types
+
+import (
+	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/log"
+)
+
+const (
+	EtxExpirationAge = 8640 // With 10s blocks, ETX expire after ~24hrs
+)
+
+type EtxSetEntry struct {
+	availableAtBlock uint64
+}
+type EtxSet map[common.Hash]EtxSetEntry
+
+func NewEtxSet() EtxSet {
+	return make(EtxSet)
+}
+
+// updateInboundEtxs updates the set of inbound ETXs available to be mined into
+// a block in this location. This method adds any new ETXs to the set and
+// removes expired ETXs.
+func (set EtxSet) Update(newInboundEtxs Transactions, currentHeight uint64) {
+	// Add new ETX entries to the inbound set
+	for _, etx := range newInboundEtxs {
+		if etx.ToChain().Equal(common.NodeLocation) {
+			entry := EtxSetEntry{
+				availableAtBlock: currentHeight,
+			}
+			set[etx.Hash()] = entry
+		} else {
+			log.Error("skipping ETX belonging to other destination", "etxHash: ", etx.Hash(), "etxToChain: ", etx.ToChain())
+		}
+	}
+
+	// Remove expired ETXs
+	for txHash, entry := range set {
+		etxExpirationHeight := entry.availableAtBlock + EtxExpirationAge
+		if currentHeight > etxExpirationHeight {
+			delete(set, txHash)
+		}
+	}
+}

--- a/core/types/external_tx.go
+++ b/core/types/external_tx.go
@@ -55,18 +55,20 @@ func (tx *ExternalTx) copy() TxData {
 }
 
 // accessors for innerTx.
-func (tx *ExternalTx) txType() byte           { return ExternalTxType }
-func (tx *ExternalTx) chainID() *big.Int      { return nil }
-func (tx *ExternalTx) protected() bool        { return true }
-func (tx *ExternalTx) accessList() AccessList { return tx.AccessList }
-func (tx *ExternalTx) data() []byte           { return tx.Data }
-func (tx *ExternalTx) gas() uint64            { return tx.Gas }
-func (tx *ExternalTx) gasFeeCap() *big.Int    { return tx.GasFeeCap }
-func (tx *ExternalTx) gasTipCap() *big.Int    { return tx.GasTipCap }
-func (tx *ExternalTx) gasPrice() *big.Int     { return tx.GasFeeCap }
-func (tx *ExternalTx) value() *big.Int        { return tx.Value }
-func (tx *ExternalTx) nonce() uint64          { return tx.Nonce }
-func (tx *ExternalTx) to() *common.Address    { return tx.To }
+func (tx *ExternalTx) txType() byte                { return ExternalTxType }
+func (tx *ExternalTx) chainID() *big.Int           { return nil }
+func (tx *ExternalTx) protected() bool             { return true }
+func (tx *ExternalTx) accessList() AccessList      { return tx.AccessList }
+func (tx *ExternalTx) data() []byte                { return tx.Data }
+func (tx *ExternalTx) gas() uint64                 { return tx.Gas }
+func (tx *ExternalTx) gasFeeCap() *big.Int         { return tx.GasFeeCap }
+func (tx *ExternalTx) gasTipCap() *big.Int         { return tx.GasTipCap }
+func (tx *ExternalTx) gasPrice() *big.Int          { return tx.GasFeeCap }
+func (tx *ExternalTx) value() *big.Int             { return tx.Value }
+func (tx *ExternalTx) nonce() uint64               { return tx.Nonce }
+func (tx *ExternalTx) to() *common.Address         { return tx.To }
+func (tx *ExternalTx) toChain() *common.Location   { return tx.To.Location() }
+func (tx *ExternalTx) fromChain() *common.Location { return tx.Sender.Location() }
 
 func (tx *ExternalTx) rawSignatureValues() (v, r, s *big.Int) {
 	// Signature values are ignored for external transactions

--- a/core/types/internal_tx.go
+++ b/core/types/internal_tx.go
@@ -82,18 +82,20 @@ func (tx *InternalTx) copy() TxData {
 }
 
 // accessors for innerTx.
-func (tx *InternalTx) txType() byte           { return InternalTxType }
-func (tx *InternalTx) chainID() *big.Int      { return tx.ChainID }
-func (tx *InternalTx) protected() bool        { return true }
-func (tx *InternalTx) accessList() AccessList { return tx.AccessList }
-func (tx *InternalTx) data() []byte           { return tx.Data }
-func (tx *InternalTx) gas() uint64            { return tx.Gas }
-func (tx *InternalTx) gasFeeCap() *big.Int    { return tx.GasFeeCap }
-func (tx *InternalTx) gasTipCap() *big.Int    { return tx.GasTipCap }
-func (tx *InternalTx) gasPrice() *big.Int     { return tx.GasFeeCap }
-func (tx *InternalTx) value() *big.Int        { return tx.Value }
-func (tx *InternalTx) nonce() uint64          { return tx.Nonce }
-func (tx *InternalTx) to() *common.Address    { return tx.To }
+func (tx *InternalTx) txType() byte                { return InternalTxType }
+func (tx *InternalTx) chainID() *big.Int           { return tx.ChainID }
+func (tx *InternalTx) protected() bool             { return true }
+func (tx *InternalTx) accessList() AccessList      { return tx.AccessList }
+func (tx *InternalTx) data() []byte                { return tx.Data }
+func (tx *InternalTx) gas() uint64                 { return tx.Gas }
+func (tx *InternalTx) gasFeeCap() *big.Int         { return tx.GasFeeCap }
+func (tx *InternalTx) gasTipCap() *big.Int         { return tx.GasTipCap }
+func (tx *InternalTx) gasPrice() *big.Int          { return tx.GasFeeCap }
+func (tx *InternalTx) value() *big.Int             { return tx.Value }
+func (tx *InternalTx) nonce() uint64               { return tx.Nonce }
+func (tx *InternalTx) to() *common.Address         { return tx.To }
+func (tx *InternalTx) toChain() *common.Location   { return tx.To.Location() }
+func (tx *InternalTx) fromChain() *common.Location { return tx.toChain() }
 
 func (tx *InternalTx) rawSignatureValues() (v, r, s *big.Int) {
 	return tx.V, tx.R, tx.S

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -418,6 +418,44 @@ func (s Transactions) EncodeIndex(i int, w *bytes.Buffer) {
 	tx.encodeTyped(w)
 }
 
+// FilterByLocation returns the subset of transactions with a 'to' address which
+// belongs the given chain location
+func (s Transactions) FilterToLocation(l common.Location) Transactions {
+	filteredList := Transactions{}
+	for _, tx := range s {
+		toChain := tx.ToChain()
+		if l.Equal(toChain) {
+			filteredList = append(filteredList, tx)
+		}
+	}
+	return filteredList
+}
+
+// FilterToSlice returns the subset of transactions with a 'to' address which
+// belongs to the given slice location, at or above the given minimum context
+func (s Transactions) FilterToSlice(slice common.Location, minCtx int) Transactions {
+	filteredList := Transactions{}
+	for _, tx := range s {
+		toChain := tx.ToChain()
+		if toChain.InSameSliceAs(slice) {
+			filteredList = append(filteredList, tx)
+		}
+	}
+	return filteredList
+}
+
+// FilterConfirmationCtx returns the subset of transactions who can be confirmed
+// at the given context
+func (s Transactions) FilterConfirmationCtx(ctx int) Transactions {
+	filteredList := Transactions{}
+	for _, tx := range s {
+		if tx.ConfirmationCtx() == ctx {
+			filteredList = append(filteredList, tx)
+		}
+	}
+	return filteredList
+}
+
 // TxDifference returns a new set which is the difference between a and b.
 func TxDifference(a, b Transactions) Transactions {
 	keep := make(Transactions, 0, len(a))

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -354,8 +354,8 @@ func (b *QuaiAPIBackend) SyncProgress() quai.SyncProgress {
 	return b.eth.Downloader().Progress()
 }
 
-func (b *QuaiAPIBackend) Append(header *types.Header, domTerminus common.Hash, td *big.Int, domOrigin bool, reorg bool, manifestHash common.Hash) (types.PendingHeader, []types.Transactions, error) {
-	return b.eth.core.Append(header, domTerminus, td, domOrigin, reorg, manifestHash)
+func (b *QuaiAPIBackend) Append(header *types.Header, domTerminus common.Hash, td *big.Int, domOrigin bool, reorg bool, manifestHash common.Hash, newInboundEtxs types.Transactions) (types.PendingHeader, []types.Transactions, error) {
+	return b.eth.core.Append(header, domTerminus, td, domOrigin, reorg, manifestHash, newInboundEtxs)
 }
 
 func (b *QuaiAPIBackend) ConstructLocalBlock(header *types.Header) *types.Block {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -354,7 +354,7 @@ func (b *QuaiAPIBackend) SyncProgress() quai.SyncProgress {
 	return b.eth.Downloader().Progress()
 }
 
-func (b *QuaiAPIBackend) Append(header *types.Header, domTerminus common.Hash, td *big.Int, domOrigin bool, reorg bool, manifestHash common.Hash) (types.PendingHeader, error) {
+func (b *QuaiAPIBackend) Append(header *types.Header, domTerminus common.Hash, td *big.Int, domOrigin bool, reorg bool, manifestHash common.Hash) (types.PendingHeader, []types.Transactions, error) {
 	return b.eth.core.Append(header, domTerminus, td, domOrigin, reorg, manifestHash)
 }
 
@@ -382,8 +382,16 @@ func (b *QuaiAPIBackend) GetPendingHeader() (*types.Header, error) {
 	return b.eth.core.GetPendingHeader()
 }
 
+func (b *QuaiAPIBackend) SendPendingEtxsToDom(header *types.Header, etxs []types.Transactions) error {
+	return b.eth.core.SendPendingEtxsToDom(header, etxs)
+}
+
 func (b *QuaiAPIBackend) GetSubManifest(blockHash common.Hash) (types.BlockManifest, error) {
 	return b.eth.core.GetSubManifest(blockHash)
+}
+
+func (b *QuaiAPIBackend) AddPendingEtxs(header *types.Header, etxs []types.Transactions) error {
+	return b.eth.core.AddPendingEtxs(header, etxs)
 }
 
 func (b *QuaiAPIBackend) SubscribeHeaderRootsEvent(ch chan<- types.HeaderRoots) event.Subscription {

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -17,7 +17,9 @@
 // Package ethdb defines the interfaces for an Ethereum data store.
 package ethdb
 
-import "io"
+import (
+	"io"
+)
 
 // KeyValueReader wraps the Has and Get method of a backing data store.
 type KeyValueReader interface {
@@ -87,7 +89,7 @@ type AncientReader interface {
 type AncientWriter interface {
 	// AppendAncient injects all binary blobs belong to block at the end of the
 	// append-only immutable table files.
-	AppendAncient(number uint64, hash, header, body, receipt, td []byte) error
+	AppendAncient(number uint64, hash, header, body, receipt, td, etxSet []byte) error
 
 	// TruncateAncients discards all but the first n ancient data from the ancient store.
 	TruncateAncients(n uint64) error

--- a/internal/quaiapi/backend.go
+++ b/internal/quaiapi/backend.go
@@ -72,7 +72,7 @@ type Backend interface {
 	SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription
 	SubscribeChainSideEvent(ch chan<- core.ChainSideEvent) event.Subscription
 
-	Append(header *types.Header, domTerminus common.Hash, td *big.Int, domOrigin bool, reorg bool, manifestHash common.Hash) (types.PendingHeader, error)
+	Append(header *types.Header, domTerminus common.Hash, td *big.Int, domOrigin bool, reorg bool, manifestHash common.Hash) (types.PendingHeader, []types.Transactions, error)
 	ConstructLocalBlock(header *types.Header) *types.Block
 	InsertBlock(ctx context.Context, block *types.Block) (int, error)
 	PendingBlock() *types.Block
@@ -80,6 +80,7 @@ type Backend interface {
 	SubRelayPendingHeader(pendingHeader types.PendingHeader, reorg bool) error
 	GetPendingHeader() (*types.Header, error)
 	GetSubManifest(blockHash common.Hash) (types.BlockManifest, error)
+	AddPendingEtxs(header *types.Header, etxs []types.Transactions) error
 	PendingBlockAndReceipts() (*types.Block, types.Receipts)
 
 	// Transaction pool API

--- a/internal/quaiapi/backend.go
+++ b/internal/quaiapi/backend.go
@@ -72,7 +72,7 @@ type Backend interface {
 	SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription
 	SubscribeChainSideEvent(ch chan<- core.ChainSideEvent) event.Subscription
 
-	Append(header *types.Header, domTerminus common.Hash, td *big.Int, domOrigin bool, reorg bool, manifestHash common.Hash) (types.PendingHeader, []types.Transactions, error)
+	Append(header *types.Header, domTerminus common.Hash, td *big.Int, domOrigin bool, reorg bool, manifestHash common.Hash, newInboundEtxs types.Transactions) (types.PendingHeader, []types.Transactions, error)
 	ConstructLocalBlock(header *types.Header) *types.Block
 	InsertBlock(ctx context.Context, block *types.Block) (int, error)
 	PendingBlock() *types.Block

--- a/internal/quaiapi/quai_api.go
+++ b/internal/quaiapi/quai_api.go
@@ -568,11 +568,12 @@ func (s *PublicBlockChainQuaiAPI) ReceiveMinedHeader(ctx context.Context, raw js
 }
 
 type tdBlock struct {
-	Td           *big.Int    `json:"td"`
-	DomTerminus  common.Hash `json:"domTerminus"`
-	DomOrigin    bool        `json:"domOrigin"`
-	Reorg        bool        `json:"reorg"`
-	ManifestHash common.Hash `json:"manifestHash"`
+	Td             *big.Int           `json:"td"`
+	DomTerminus    common.Hash        `json:"domTerminus"`
+	DomOrigin      bool               `json:"domOrigin"`
+	Reorg          bool               `json:"reorg"`
+	ManifestHash   common.Hash        `json:"manifestHash"`
+	NewInboundEtxs types.Transactions `json:"newInboundEtxs"`
 }
 
 func (s *PublicBlockChainQuaiAPI) Append(ctx context.Context, raw json.RawMessage) (map[string]interface{}, error) {
@@ -586,7 +587,7 @@ func (s *PublicBlockChainQuaiAPI) Append(ctx context.Context, raw json.RawMessag
 		return nil, err
 	}
 
-	pendingHeader, pendingEtxs, err := s.b.Append(head, body.DomTerminus, body.Td, body.DomOrigin, body.Reorg, body.ManifestHash)
+	pendingHeader, pendingEtxs, err := s.b.Append(head, body.DomTerminus, body.Td, body.DomOrigin, body.Reorg, body.ManifestHash, body.NewInboundEtxs)
 	if err != nil {
 		return nil, err
 	}

--- a/quaiclient/quaiclient.go
+++ b/quaiclient/quaiclient.go
@@ -124,29 +124,21 @@ func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 	return result
 }
 
-// RPCMarshalTdHeader converts the header and order as input to PCRC.
-func RPCMarshalTdHeader(header *types.Header, domTerminus common.Hash, td *big.Int, domOrigin bool, reorg bool, manifestHash common.Hash) (map[string]interface{}, error) {
+type Termini struct {
+	Termini []common.Hash `json:"termini"`
+}
+
+func (ec *Client) Append(ctx context.Context, header *types.Header, domTerminus common.Hash, td *big.Int, domOrigin bool, reorg bool, manifestHash common.Hash, newInboundEtxs types.Transactions) (types.PendingHeader, []types.Transactions, error) {
 	fields := RPCMarshalHeader(header)
 	fields["td"] = td
 	fields["domTerminus"] = domTerminus
 	fields["domOrigin"] = domOrigin
 	fields["reorg"] = reorg
 	fields["manifestHash"] = manifestHash
-	return fields, nil
-}
-
-type Termini struct {
-	Termini []common.Hash `json:"termini"`
-}
-
-func (ec *Client) Append(ctx context.Context, header *types.Header, domTerminus common.Hash, td *big.Int, domOrigin bool, reorg bool, manifestHash common.Hash) (types.PendingHeader, []types.Transactions, error) {
-	data, err := RPCMarshalTdHeader(header, domTerminus, td, domOrigin, reorg, manifestHash)
-	if err != nil {
-		return types.PendingHeader{}, nil, err
-	}
+	fields["newInboundEtxs"] = newInboundEtxs
 
 	var raw json.RawMessage
-	err = ec.c.CallContext(ctx, &raw, "quai_append", data)
+	err := ec.c.CallContext(ctx, &raw, "quai_append", fields)
 	if err != nil {
 		return types.PendingHeader{}, nil, err
 	}


### PR DESCRIPTION
This patch implements logic relating to ETX collection, relaying, and referencing within a slice. Namely:
* Send newly emitted ETXs to our dom (rolling up when appropriate)
* Use subordinate manifest to collect the 'spendable set' of ETXs
* Share the correct set of referencable ETXs with our subordinates for inclusion in blocks

Note: this effectively saturates a full node with the necessary pending ETX data. To support running just a slice, we will need to implement broadcast & propagation logic to ensure these pending ETXs make it to those nodes.