### PR TITLE
ETX nonce modification and zero address balance reset

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -213,12 +213,9 @@ func (p *StateProcessor) Process(block *types.Block, etxSet types.EtxSet) (types
 			}
 			prevZeroBal := prepareApplyETX(statedb, tx)
 			receipt, err = applyTransaction(msg, p.config, p.hc, nil, gp, statedb, blockNumber, blockHash, tx, usedGas, vmenv)
-			if err == nil {
-				statedb.AddBalance(common.ZeroAddr, prevZeroBal) // Add previous zero address balance to residual zero address balance, even if the transaction was unsuccessful (e.g. failed)
-			}
+			statedb.SetBalance(common.ZeroAddr, prevZeroBal) // Reset the balance to what it previously was. Residual balance will be lost
 
 			if err != nil {
-				statedb.SetBalance(common.ZeroAddr, prevZeroBal) // In the case of an error, reset the balance to what it previously was
 				return nil, nil, nil, 0, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
 			}
 
@@ -402,11 +399,7 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 	if tx.Type() == types.ExternalTxType {
 		prevZeroBal := prepareApplyETX(statedb, tx)
 		receipt, err := applyTransaction(msg, config, bc, author, gp, statedb, header.Number(), header.Hash(), tx, usedGas, vmenv)
-		if err == nil && receipt.Status == types.ReceiptStatusSuccessful {
-			statedb.AddBalance(common.ZeroAddr, prevZeroBal) // Add previous zero address balance to residual zero address balance
-		} else {
-			statedb.SetBalance(common.ZeroAddr, prevZeroBal) // In the case of an error, reset the balance to what it previously was (TODO: if not all gas is used, it may be considered residual and should be added here. Currently a failed external transaction removes all the sent coins from the supply.)
-		}
+		statedb.SetBalance(common.ZeroAddr, prevZeroBal) // Reset the balance to what it previously was (currently a failed external transaction removes all the sent coins from the supply and any residual balance is gone as well)
 		return receipt, err
 	}
 	return applyTransaction(msg, config, bc, author, gp, statedb, header.Number(), header.Hash(), tx, usedGas, vmenv)

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -94,7 +94,7 @@ func TestCreateETX(t *testing.T) {
 	temp = gasFeeCap.Bytes32()
 	data = append(data, temp[:]...)
 
-	inner_tx := types.InternalTx{ChainID: big.NewInt(1), Nonce: 0, GasTipCap: common.Big1, GasFeeCap: common.Big1, Gas: 100000, To: &toAddr, Value: big.NewInt(params.Ether), Data: data}
+	inner_tx := types.InternalToExternalTx{ChainID: big.NewInt(1), Nonce: 0, GasTipCap: common.Big1, GasFeeCap: common.Big1, Gas: 100000, To: &toAddr, Value: big.NewInt(params.Ether), ETXGasLimit: 21000, ETXGasPrice: common.Big1, ETXGasTip: common.Big1, ETXData: []byte{}, ETXAccessList: nil}
 	tx, err := types.SignTx(types.NewTx(&inner_tx), signer, testKey)
 	if err != nil {
 		t.Error(err.Error())

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -566,23 +566,18 @@ func (evm *EVM) CreateETX(toAddr common.Address, fromAddr common.Address, etxGas
 		return []byte{}, 0, fmt.Errorf("%x CreateETX error: %s\n", fromAddr, err.Error())
 	}
 
-	globalNonce, err := evm.StateDB.GetNonce(common.ZeroAddr)
+	nonce, err := evm.StateDB.GetNonce(fromAddr)
 	if err != nil {
 		return []byte{}, 0, fmt.Errorf("%x CreateETX error: %s\n", fromAddr, err.Error())
 	}
 
 	// create external transaction
-	etxInner := types.ExternalTx{Value: value, To: &toAddr, Sender: fromAddr, GasTipCap: etxGasTip, GasFeeCap: etxGasPrice, Gas: etxGasLimit, Data: etxData, AccessList: etxAccessList, Nonce: globalNonce}
+	etxInner := types.ExternalTx{Value: value, To: &toAddr, Sender: fromAddr, GasTipCap: etxGasTip, GasFeeCap: etxGasPrice, Gas: etxGasLimit, Data: etxData, AccessList: etxAccessList, Nonce: nonce}
 	etx := types.NewTx(&etxInner)
 
 	evm.ETXCacheLock.Lock()
 	evm.ETXCache = append(evm.ETXCache, etx)
 	evm.ETXCacheLock.Unlock()
-
-	if err := evm.StateDB.SetNonce(common.ZeroAddr, globalNonce+1); err != nil {
-
-		return []byte{}, 0, fmt.Errorf("%x CreateETX error: %s\n", fromAddr, err.Error())
-	}
 
 	return []byte{}, gas - params.ETXGas, nil
 }


### PR DESCRIPTION
ETX nonce is now the sender or contract nonce and zero address balance is reset after inbound ETX processing (residual is no longer stored)