### PR TITLE
Changed min peers to one

### DIFF
--- a/eth/sync.go
+++ b/eth/sync.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	forceSyncCycle      = 10 * time.Second // Time interval to force syncs, even if few peers are available
-	defaultMinSyncPeers = 5                // Amount of peers desired to start syncing
+	defaultMinSyncPeers = 1                // Amount of peers desired to start syncing
 
 	// This is the target size for the packs of transactions sent by txsyncLoop64.
 	// A pack can get larger than this if a single transactions exceeds this size.


### PR DESCRIPTION
Minimum number of peers to start syncing is changed from 5 to 1. An issue has been created
https://github.com/dominant-strategies/go-quai/issues/537 to document this change.