### PR TITLE
Implemented GetHeaderByNumber, and removed problematic checking of block timestamp

### DIFF
--- a/core/types/gen_header_json.go
+++ b/core/types/gen_header_json.go
@@ -140,9 +140,6 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 	if dec.BaseFee == nil {
 		return errors.New("missing required field 'baseFee' for Header")
 	}
-	if dec.Time == 0 {
-		return errors.New("missing required field 'timestamp' for Header")
-	}
 	if dec.Extra == nil {
 		return errors.New("missing required field 'extraData' for Header")
 	}

--- a/internal/quaiapi/quai_api.go
+++ b/internal/quaiapi/quai_api.go
@@ -232,6 +232,24 @@ func (s *PublicBlockChainQuaiAPI) GetProof(ctx context.Context, address common.A
 	}, state.Error()
 }
 
+// GetHeaderByNumber returns the requested canonical block header.
+// * When blockNr is -1 the chain head is returned.
+// * When blockNr is -2 the pending chain head is returned.
+func (s *PublicBlockChainQuaiAPI) GetHeaderByNumber(ctx context.Context, number rpc.BlockNumber) (map[string]interface{}, error) {
+	header, err := s.b.HeaderByNumber(ctx, number)
+	if header != nil && err == nil {
+		response := s.rpcMarshalHeader(ctx, header)
+		if number == rpc.PendingBlockNumber {
+			// Pending header need to nil out a few fields
+			for _, field := range []string{"hash", "nonce", "miner"} {
+				response[field] = nil
+			}
+		}
+		return response, err
+	}
+	return nil, err
+}
+
 // GetHeaderByHash returns the requested header by hash.
 func (s *PublicBlockChainQuaiAPI) GetHeaderHashByNumber(ctx context.Context, number rpc.BlockNumber) common.Hash {
 	header, err := s.b.HeaderByNumber(ctx, number)


### PR DESCRIPTION
- Implements GetHeaderByNumber in Quai namespace.
- Fix for https://github.com/dominant-strategies/go-quai/issues/639.