### PR TITLE
Address out-of-scope error is properly returned from EVM and execution halts

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/dominant-strategies/go-quai/common/math"
-	"github.com/dominant-strategies/go-quai/core/state"
 	"github.com/dominant-strategies/go-quai/log"
 )
 
@@ -268,10 +267,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 
 		switch {
 		case err != nil:
-			if err != state.ErrInvalidScope {
-				return nil, err
-			}
-			pc++ // ErrInvalidScope is ignored and execution continues
+			return nil, err
 		case operation.reverts:
 			return res, ErrExecutionReverted
 		case operation.halts:


### PR DESCRIPTION
Fixes https://github.com/dominant-strategies/go-quai/issues/650 except for dependency mapping