### PR TITLE
Timedcache improvements

### DIFF
--- a/common/timedcache/timedcache.go
+++ b/common/timedcache/timedcache.go
@@ -1,6 +1,7 @@
 package timedcache
 
 import (
+	"sync"
 	"time"
 
 	lru "github.com/hashicorp/golang-lru"
@@ -26,6 +27,7 @@ func (te *timedEntry) expired() bool {
 type TimedCache struct {
 	ttl   int64     // Time (in seconds) each entry is allowed to live for
 	cache lru.Cache // Underlying size-limited LRU cache
+	lock  sync.RWMutex
 }
 
 // New creates a new cache with a given size and ttl. TTL defines the time in
@@ -36,6 +38,12 @@ func New(size int, ttl int) (*TimedCache, error) {
 		return &TimedCache{}, err
 	}
 	return &TimedCache{ttl: int64(ttl), cache: *cache}, nil
+}
+
+// calcExpireTime calculates the expiration time given a TTL relative to now.
+func calcExpireTime(ttl int64) int64 {
+	t := time.Now().Unix() + ttl
+	return t
 }
 
 // removeExpired removes any expired entries from the cache
@@ -51,22 +59,26 @@ func (tc *TimedCache) removeExpired() {
 
 // Purge is used to completely clear the cache.
 func (tc *TimedCache) Purge() {
+	tc.lock.Lock()
+	defer tc.lock.Unlock()
 	tc.cache.Purge()
 }
 
 // Add adds a value to the cache. Returns true if an eviction occurred.
 func (tc *TimedCache) Add(key, value interface{}) (evicted bool) {
+	tc.lock.Lock()
+	defer tc.lock.Unlock()
 	// First remove expired entries, so that LRU cache doesn't evict more than
 	// necessary, if there is not enough room to add this entry.
 	tc.removeExpired()
-	// Calculate expiration time
-	expiresAt := time.Now().Unix() + tc.Ttl()
 	// Wrap the entry and add it to the cache
-	return tc.cache.Add(key, timedEntry{expiresAt: expiresAt, value: value})
+	return tc.cache.Add(key, timedEntry{expiresAt: calcExpireTime(tc.ttl), value: value})
 }
 
 // Get looks up a key's value from the cache, removing it if it has expired.
 func (tc *TimedCache) Get(key interface{}) (value interface{}, ok bool) {
+	tc.lock.Lock()
+	defer tc.lock.Unlock()
 	val, ok := tc.cache.Get(key)
 	if ok {
 		v := val.(timedEntry)
@@ -91,6 +103,8 @@ func (tc *TimedCache) Contains(key interface{}) bool {
 // Peek returns the key value (or undefined if not found) without updating
 // the "recently used"-ness or ttl of the key.
 func (tc *TimedCache) Peek(key interface{}) (value interface{}, ok bool) {
+	tc.lock.Lock()
+	defer tc.lock.Unlock()
 	val, ok := tc.cache.Peek(key)
 	if ok {
 		v := val.(timedEntry)
@@ -109,42 +123,48 @@ func (tc *TimedCache) Peek(key interface{}) (value interface{}, ok bool) {
 // recent-ness, ttl, or deleting it for being stale, and if not, adds the value.
 // Returns whether found and whether an eviction occurred.
 func (tc *TimedCache) ContainsOrAdd(key, value interface{}) (ok, evicted bool) {
+	tc.lock.Lock()
+	defer tc.lock.Unlock()
 	// First remove expired entries, so that LRU cache doesn't evict more than
 	// necessary, if there is not enough room to add this entry.
 	tc.removeExpired()
-	// Calculate expiration time
-	expiresAt := time.Now().Unix() + tc.Ttl()
 	// Wrap the entry and add it to the cache
-	return tc.cache.ContainsOrAdd(key, timedEntry{expiresAt: expiresAt, value: value})
+	return tc.cache.ContainsOrAdd(key, timedEntry{expiresAt: calcExpireTime(tc.ttl), value: value})
 }
 
 // PeekOrAdd checks if a key is in the cache without updating the
 // recent-ness, ttl, or deleting it for being stale, and if not, adds the value.
 // Returns whether found and whether an eviction occurred.
 func (tc *TimedCache) PeekOrAdd(key, value interface{}) (previous interface{}, ok, evicted bool) {
+	tc.lock.Lock()
+	defer tc.lock.Unlock()
 	// First remove expired entries, so that LRU cache doesn't evict more than
 	// necessary, if there is not enough room to add this entry.
 	tc.removeExpired()
-	// Calculate expiration time
-	expiresAt := time.Now().Unix() + tc.Ttl()
 	// Wrap the entry and add it to the cache
-	return tc.cache.PeekOrAdd(key, timedEntry{expiresAt: expiresAt, value: value})
+	return tc.cache.PeekOrAdd(key, timedEntry{expiresAt: calcExpireTime(tc.ttl), value: value})
 }
 
 // Remove removes the provided key from the cache.
 func (tc *TimedCache) Remove(key interface{}) (present bool) {
+	tc.lock.Lock()
+	defer tc.lock.Unlock()
 	tc.removeExpired()
 	return tc.cache.Remove(key)
 }
 
 // Resize changes the cache size.
 func (tc *TimedCache) Resize(size int) (evicted int) {
+	tc.lock.Lock()
+	defer tc.lock.Unlock()
 	tc.removeExpired()
 	return tc.cache.Resize(size)
 }
 
 // RemoveOldest removes the oldest item from the cache.
 func (tc *TimedCache) RemoveOldest() (key, value interface{}, ok bool) {
+	tc.lock.Lock()
+	defer tc.lock.Unlock()
 	tc.removeExpired()
 	k, v, ok := tc.cache.RemoveOldest()
 	if ok {
@@ -155,6 +175,8 @@ func (tc *TimedCache) RemoveOldest() (key, value interface{}, ok bool) {
 
 // GetOldest returns the oldest entry
 func (tc *TimedCache) GetOldest() (key, value interface{}, ok bool) {
+	tc.lock.Lock()
+	defer tc.lock.Unlock()
 	tc.removeExpired()
 	k, v, ok := tc.cache.GetOldest()
 	if ok {
@@ -165,12 +187,16 @@ func (tc *TimedCache) GetOldest() (key, value interface{}, ok bool) {
 
 // Keys returns a slice of the keys in the cache, from oldest to newest.
 func (tc *TimedCache) Keys() []interface{} {
+	tc.lock.Lock()
+	defer tc.lock.Unlock()
 	tc.removeExpired()
 	return tc.cache.Keys()
 }
 
 // Len returns the number of items in the cache.
 func (tc *TimedCache) Len() int {
+	tc.lock.Lock()
+	defer tc.lock.Unlock()
 	tc.removeExpired()
 	return tc.cache.Len()
 }
@@ -178,5 +204,7 @@ func (tc *TimedCache) Len() int {
 // Ttl returns the number of seconds each item is allowed to live (except if
 // evicted to free up space)
 func (tc *TimedCache) Ttl() int64 {
+	tc.lock.RLock()
+	defer tc.lock.RUnlock()
 	return tc.ttl
 }

--- a/common/timedcache/timedcache.go
+++ b/common/timedcache/timedcache.go
@@ -1,5 +1,4 @@
-// Package types contains data types related to Ethereum consensus.
-package types
+package timedcache
 
 import (
 	"time"
@@ -31,7 +30,7 @@ type TimedCache struct {
 
 // New creates a new cache with a given size and ttl. TTL defines the time in
 // seconds an entry shall live, before being expired.
-func NewTimedCache(size int, ttl int) (*TimedCache, error) {
+func New(size int, ttl int) (*TimedCache, error) {
 	cache, err := lru.New(size)
 	if err != nil {
 		return &TimedCache{}, err

--- a/core/core.go
+++ b/core/core.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/common/timedcache"
 	"github.com/dominant-strategies/go-quai/consensus"
 	"github.com/dominant-strategies/go-quai/core/rawdb"
 	"github.com/dominant-strategies/go-quai/core/state"
@@ -32,7 +33,7 @@ type Core struct {
 	sl     *Slice
 	engine consensus.Engine
 
-	futureHeaders *types.TimedCache
+	futureHeaders *timedcache.TimedCache
 
 	quit chan struct{} // core quit channel
 }
@@ -49,7 +50,7 @@ func NewCore(db ethdb.Database, config *Config, isLocalBlock func(block *types.H
 		quit:   make(chan struct{}),
 	}
 
-	futureHeaders, _ := types.NewTimedCache(maxFutureHeaders, futureHeaderTtl)
+	futureHeaders, _ := timedcache.New(maxFutureHeaders, futureHeaderTtl)
 	c.futureHeaders = futureHeaders
 
 	go c.updateFutureHeaders()


### PR DESCRIPTION
This PR moves the timedcache to its own module, adds mutexes (and fixing some errors related to this), and implements an eviction callback mechanism needed for future work.