### PR TITLE
Add verbosity to network.env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ include network.env
 
 # Build the base command
 # WARNING: WS_ADDR is a sensitive interface and should only be exposed to trusted networks
-BASE_CMD = ./build/bin/go-quai --$(NETWORK) --syncmode full --verbosity 3
+BASE_CMD = ./build/bin/go-quai --$(NETWORK) --syncmode full --verbosity $(VERBOSITY)
 BASE_CMD += --http --http.vhosts=* --http.addr $(HTTP_ADDR) --http.api $(HTTP_API)
 BASE_CMD += --ws --ws.addr $(WS_ADDR) --ws.api $(WS_API)
 ifeq ($(ENABLE_ARCHIVE),true)

--- a/network.env.dist
+++ b/network.env.dist
@@ -112,3 +112,6 @@ HTTP_CORSDOMAIN="*"
 WS_ORIG="*"
 BOOTNODE=false
 CORS=false
+
+# Verbosity variable
+VERBOSITY=3


### PR DESCRIPTION
@Djadih has inspired me to also make modifications to the Makefile. This PR now takes in a required `VERBOSITY` network.env variable.