### PR TITLE
Modify header hash to instead hash SealHash+nonce

### DIFF
--- a/consensus/blake3pow/sealer.go
+++ b/consensus/blake3pow/sealer.go
@@ -38,7 +38,7 @@ func (blake3pow *Blake3pow) Seal(header *types.Header, results chan<- *types.Hea
 		select {
 		case results <- header:
 		default:
-			blake3pow.config.Log.Warn("Sealing result is not read by miner", "mode", "fake", "sealhash", blake3pow.SealHash(header))
+			blake3pow.config.Log.Warn("Sealing result is not read by miner", "mode", "fake", "sealhash", header.SealHash())
 		}
 		return nil
 	}
@@ -93,7 +93,7 @@ func (blake3pow *Blake3pow) Seal(header *types.Header, results chan<- *types.Hea
 			select {
 			case results <- result:
 			default:
-				blake3pow.config.Log.Warn("Sealing result is not read by miner", "mode", "local", "sealhash", blake3pow.SealHash(header))
+				blake3pow.config.Log.Warn("Sealing result is not read by miner", "mode", "local", "sealhash", header.SealHash())
 			}
 			close(abort)
 		case <-blake3pow.update:
@@ -318,7 +318,7 @@ func (s *remoteSealer) loop() {
 //	result[2], 32 bytes hex encoded boundary condition ("target"), 2^256/difficulty
 //	result[3], hex encoded header number
 func (s *remoteSealer) makeWork(header *types.Header) {
-	hash := s.blake3pow.SealHash(header)
+	hash := header.SealHash()
 	s.currentWork[0] = hash.Hex()
 	s.currentWork[1] = hexutil.EncodeBig(header.Number())
 	s.currentWork[2] = common.BytesToHash(new(big.Int).Div(big2e256, header.Difficulty()).Bytes()).Hex()

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -103,9 +103,6 @@ type Engine interface {
 	// than one result may also be returned depending on the consensus algorithm.
 	Seal(header *types.Header, results chan<- *types.Header, stop <-chan struct{}) error
 
-	// SealHash returns the hash of a block prior to it being sealed.
-	SealHash(header *types.Header) common.Hash
-
 	// CalcDifficulty is the difficulty adjustment algorithm. It returns the difficulty
 	// that a new block should have.
 	CalcDifficulty(chain ChainHeaderReader, parent *types.Header) *big.Int

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -33,6 +33,7 @@ import (
 	"github.com/dominant-strategies/go-quai/log"
 	"github.com/dominant-strategies/go-quai/params"
 	"github.com/dominant-strategies/go-quai/rlp"
+	"lukechampine.com/blake3"
 	mathutil "modernc.org/mathutil"
 )
 
@@ -57,6 +58,11 @@ func EncodeNonce(i uint64) BlockNonce {
 	var n BlockNonce
 	binary.BigEndian.PutUint64(n[:], i)
 	return n
+}
+
+// Bytes() returns the raw bytes of the block nonce
+func (n BlockNonce) Bytes() []byte {
+	return n[:]
 }
 
 // Uint64 returns the integer value of a block nonce.
@@ -562,10 +568,86 @@ func (h *Header) GasLimitArray() []uint64           { return h.gasLimit }
 func (h *Header) GasUsedArray() []uint64            { return h.gasUsed }
 func (h *Header) BaseFeeArray() []*big.Int          { return h.baseFee }
 
-// Hash returns the block hash of the header, which is simply the keccak256 hash of its
-// RLP encoding.
-func (h *Header) Hash() common.Hash {
-	return RlpHash(h)
+// headerData comprises all data fields of the header, excluding the nonce, so
+// that the nonce may be independently adjusted in the work algorithm.
+type sealData struct {
+	ParentHash    []common.Hash
+	UncleHash     []common.Hash
+	Coinbase      []common.Address
+	Root          []common.Hash
+	TxHash        []common.Hash
+	EtxHash       []common.Hash
+	EtxRollupHash []common.Hash
+	ManifestHash  []common.Hash
+	ReceiptHash   []common.Hash
+	Bloom         []Bloom
+	Number        []*big.Int
+	GasLimit      []uint64
+	GasUsed       []uint64
+	BaseFee       []*big.Int
+	Difficulty    *big.Int
+	Location      common.Location
+	Time          uint64
+	Extra         []byte
+	Nonce         BlockNonce
+}
+
+// SealHash returns the hash of a block prior to it being sealed.
+func (h *Header) SealHash() (hash common.Hash) {
+	hasher := blake3.New(32, nil)
+	hasher.Reset()
+	hdata := sealData{
+		ParentHash:    make([]common.Hash, common.HierarchyDepth),
+		UncleHash:     make([]common.Hash, common.HierarchyDepth),
+		Coinbase:      make([]common.Address, common.HierarchyDepth),
+		Root:          make([]common.Hash, common.HierarchyDepth),
+		TxHash:        make([]common.Hash, common.HierarchyDepth),
+		EtxHash:       make([]common.Hash, common.HierarchyDepth),
+		EtxRollupHash: make([]common.Hash, common.HierarchyDepth),
+		ManifestHash:  make([]common.Hash, common.HierarchyDepth),
+		ReceiptHash:   make([]common.Hash, common.HierarchyDepth),
+		Bloom:         make([]Bloom, common.HierarchyDepth),
+		Number:        make([]*big.Int, common.HierarchyDepth),
+		GasLimit:      make([]uint64, common.HierarchyDepth),
+		GasUsed:       make([]uint64, common.HierarchyDepth),
+		BaseFee:       make([]*big.Int, common.HierarchyDepth),
+		Difficulty:    h.Difficulty(),
+		Location:      h.Location(),
+		Time:          h.Time(),
+		Extra:         h.Extra(),
+	}
+	for i := 0; i < common.HierarchyDepth; i++ {
+		hdata.ParentHash[i] = h.ParentHash(i)
+		hdata.UncleHash[i] = h.UncleHash(i)
+		hdata.Coinbase[i] = h.Coinbase(i)
+		hdata.Root[i] = h.Root(i)
+		hdata.TxHash[i] = h.TxHash(i)
+		hdata.EtxHash[i] = h.EtxHash(i)
+		hdata.EtxRollupHash[i] = h.EtxRollupHash(i)
+		hdata.ManifestHash[i] = h.ManifestHash(i)
+		hdata.ReceiptHash[i] = h.ReceiptHash(i)
+		hdata.Bloom[i] = h.Bloom(i)
+		hdata.Number[i] = h.Number(i)
+		hdata.GasLimit[i] = h.GasLimit(i)
+		hdata.GasUsed[i] = h.GasUsed(i)
+		hdata.BaseFee[i] = h.BaseFee(i)
+	}
+	rlp.Encode(hasher, hdata)
+	hash.SetBytes(hasher.Sum(hash[:0]))
+	return hash
+}
+
+// Hash returns the nonce'd hash of the header. This is just the Blake3 hash of
+// SealHash suffixed with a nonce.
+func (h *Header) Hash() (hash common.Hash) {
+	hasher := blake3.New(32, nil)
+	hasher.Reset()
+	var hData [40]byte
+	copy(hData[:], h.Nonce().Bytes())
+	copy(hData[len(h.nonce):], h.SealHash().Bytes())
+	sum := blake3.Sum256(hData[:])
+	hash.SetBytes(sum[:])
+	return hash
 }
 
 // totalBitLen returns the cumulative BitLen for each element in a big.Int slice.

--- a/core/worker.go
+++ b/core/worker.go
@@ -471,12 +471,12 @@ func (w *worker) GeneratePendingHeader(block *types.Block) (*types.Header, error
 
 	task := &task{receipts: env.receipts, state: env.state, block: block, createdAt: time.Now()}
 	if w.CurrentInfo(block.Header()) {
-		log.Info("Commit new sealing work", "number", block.Number(), "sealhash", w.engine.SealHash(block.Header()),
+		log.Info("Commit new sealing work", "number", block.Number(), "sealhash", block.Header().SealHash(),
 			"uncles", len(env.uncles), "txs", env.tcount, "etxs", len(block.ExtTransactions()),
 			"gas", block.GasUsed(), "fees", totalFees(block, env.receipts),
 			"elapsed", common.PrettyDuration(time.Since(start)))
 	} else {
-		log.Debug("Commit new sealing work", "number", block.Number(), "sealhash", w.engine.SealHash(block.Header()),
+		log.Debug("Commit new sealing work", "number", block.Number(), "sealhash", block.Header().SealHash(),
 			"uncles", len(env.uncles), "txs", env.tcount, "etxs", len(block.ExtTransactions()),
 			"gas", block.GasUsed(), "fees", totalFees(block, env.receipts),
 			"elapsed", common.PrettyDuration(time.Since(start)))
@@ -500,7 +500,7 @@ func (w *worker) GeneratePendingHeader(block *types.Block) (*types.Header, error
 		w.newTaskHook(task)
 	}
 	// Reject duplicate sealing work due to resubmitting.
-	sealHash := w.engine.SealHash(task.block.Header())
+	sealHash := task.block.Header().SealHash()
 	if sealHash == prev {
 		log.Info("sealHash == prev, continuing with sending task to pending channel", "seal", sealHash, "prev", prev)
 	}
@@ -1003,7 +1003,7 @@ func (w *worker) commit(env *environment, interval func(), update bool, start ti
 		env.header = block.Header()
 		select {
 		case w.taskCh <- &task{receipts: env.receipts, state: env.state, block: block, createdAt: time.Now()}:
-			log.Info("Commit new sealing work", "number", block.Number(), "sealhash", w.engine.SealHash(block.Header()),
+			log.Info("Commit new sealing work", "number", block.Number(), "sealhash", block.Header().SealHash(),
 				"uncles", len(env.uncles), "txs", env.tcount, "etxs", len(block.ExtTransactions()),
 				"gas", block.GasUsed(), "fees", totalFees(block, env.receipts),
 				"elapsed", common.PrettyDuration(time.Since(start)))

--- a/params/config.go
+++ b/params/config.go
@@ -25,10 +25,10 @@ import (
 
 // Genesis hashes to enforce below configs on.
 var (
-	ColosseumGenesisHash = common.HexToHash("0xa5951ca01396546d238c8c900c86bd10894905a04c3f6902142345aabbff7947")
-	GardenGenesisHash    = common.HexToHash("0x3651b09b23cd8f76630d32ae2391d46dbd4d56f5d7b46e2787bf8aba47a2f74a")
-	OrchardGenesisHash   = common.HexToHash("0xb49b67aa6d88002118176c6d4d779346d7aee59786829939ee6ac61cc6fb78eb")
-	LocalGenesisHash     = common.HexToHash("0x4c4c6a48351375caa0009b9c36154a4c4b1a79c400464b98a7368dfd825b6b3e")
+	ColosseumGenesisHash = common.HexToHash("0xb67d2b3c0959cc566a6fe8c55cca2c1e5fa0b5e7d541a730d076730bf02d5155")
+	GardenGenesisHash    = common.HexToHash("0x779f1d7a78675498ba77bc5b47d54fd76033d6e8e89729216ecf365a71c8736c")
+	OrchardGenesisHash   = common.HexToHash("0xdc2c8f2c92e18ab8673b8b6291bc02350191f14161c4d881b741d3fb081996f7")
+	LocalGenesisHash     = common.HexToHash("0xe0858f853c8965341f99c1baf54aa3404f5e5480226e895c7489dfc77cb69deb")
 )
 
 var (


### PR DESCRIPTION
This change was desired so that miners do not have to hash the entire
header (which is quite large) for every solution. This makes mining more
efficient AND simplifies logic for GPU/ASIC implementations.