### PR TITLE
bugfix: Skip manifest & rollup calc in Prime

### DIFF
--- a/core/worker.go
+++ b/core/worker.go
@@ -908,6 +908,7 @@ func (w *worker) adjustGasLimit(interrupt *int32, env *environment, parent *type
 }
 
 func (w *worker) FinalizeAssembleAndBroadcast(chain consensus.ChainHeaderReader, header *types.Header, parent *types.Block, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, etxs []*types.Transaction, subManifest types.BlockManifest, receipts []*types.Receipt) (*types.Block, error) {
+	nodeCtx := common.NodeLocation.Context()
 	block, err := w.engine.FinalizeAndAssemble(chain, header, state, txs, uncles, etxs, subManifest, receipts)
 	if err != nil {
 		return nil, err
@@ -919,7 +920,11 @@ func (w *worker) FinalizeAssembleAndBroadcast(chain consensus.ChainHeaderReader,
 	// complete the manifest for this pending header.
 	var manifest types.BlockManifest
 	var etxRollup types.Transactions
-	if w.engine.IsDomCoincident(parent.Header()) {
+	if nodeCtx == common.PRIME_CTX {
+		// Nothing to do for prime chain
+		manifest = types.BlockManifest{}
+		etxRollup = types.Transactions{}
+	} else if w.engine.IsDomCoincident(parent.Header()) {
 		manifest = types.BlockManifest{parent.Hash()}
 		etxRollup = parent.ExtTransactions()
 	} else {


### PR DESCRIPTION
Resolves https://github.com/dominant-strategies/go-quai/issues/723