### PR TITLE
Bugfix: Contract creation should be assumed when there is tx data and "to" is nil or zero

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -307,7 +307,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	homestead := st.evm.ChainConfig().IsHomestead(st.evm.Context.BlockNumber)
 	istanbul := st.evm.ChainConfig().IsIstanbul(st.evm.Context.BlockNumber)
 	london := st.evm.ChainConfig().IsLondon(st.evm.Context.BlockNumber)
-	contractCreation := msg.To() == nil
+	contractCreation := len(msg.Data()) > 0 && (msg.To().Equals(common.ZeroAddr) || msg.To() == nil)
 
 	// Check clauses 4-5, subtract intrinsic gas if everything is correct
 	gas, err := IntrinsicGas(st.data, st.msg.AccessList(), contractCreation, homestead, istanbul)


### PR DESCRIPTION
An internal address or external address is an array of 20 bytes. In Go, an array of 20 bytes will automatically be instantiated as 0x0000000000000000000000000000000000000000 at runtime. Currently, go-quai checks if the pointer to an address is 'nil' to determine if a transaction creates a contract. While a nil pointer is different than a non-nil pointer, a "nil" 20-byte array is no different than an array with 20 zeros. Therefore, I propose we accept both nil and the zero "to" addresses in a contract creation transaction, with the requirement that the data field is non-zero (so value transfers can still go to the zero address). Token transfers are unaffected.