### PR TITLE
Remove toTransaction()

### DIFF
--- a/internal/quaiapi/api.go
+++ b/internal/quaiapi/api.go
@@ -1110,7 +1110,7 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 		}
 		res, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas()))
 		if err != nil {
-			return nil, 0, nil, fmt.Errorf("failed to apply transaction: %v err: %v", args.toTransaction().Hash(), err)
+			return nil, 0, nil, fmt.Errorf("failed to apply transaction: %v err: %v", msg, err)
 		}
 		if tracer.Equal(prevTracer) {
 			return accessList, res.UsedGas, res.Err, nil
@@ -1332,29 +1332,6 @@ func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 		log.Info("Submitted transaction", "hash", tx.Hash().Hex(), "from", from, "nonce", tx.Nonce(), "recipient", tx.To(), "value", tx.Value())
 	}
 	return tx.Hash(), nil
-}
-
-// SignTransactionResult represents a RLP encoded signed transaction.
-type SignTransactionResult struct {
-	Raw hexutil.Bytes      `json:"raw"`
-	Tx  *types.Transaction `json:"tx"`
-}
-
-// FillTransaction fills the defaults (nonce, gas, gasPrice or 1559 fields)
-// on a given unsigned transaction, and returns it to the caller for further
-// processing (signing + broadcast).
-func (s *PublicTransactionPoolAPI) FillTransaction(ctx context.Context, args TransactionArgs) (*SignTransactionResult, error) {
-	// Set some sanity defaults and terminate on failure
-	if err := args.setDefaults(ctx, s.b); err != nil {
-		return nil, err
-	}
-	// Assemble the transaction and obtain rlp
-	tx := args.toTransaction()
-	data, err := tx.MarshalBinary()
-	if err != nil {
-		return nil, err
-	}
-	return &SignTransactionResult{data, tx}, nil
 }
 
 // SendRawTransaction will add the signed transaction to the transaction pool.

--- a/internal/quaiapi/transaction_args.go
+++ b/internal/quaiapi/transaction_args.go
@@ -241,30 +241,3 @@ func (args *TransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int) (t
 	msg := types.NewMessage(addr, args.To, 0, value, gas, gasPrice, gasFeeCap, gasTipCap, data, accessList, false)
 	return msg, nil
 }
-
-// toTransaction converts the arguments to a transaction.
-// This assumes that setDefaults has been called.
-func (args *TransactionArgs) toTransaction() *types.Transaction {
-	al := types.AccessList{}
-	if args.AccessList != nil {
-		al = *args.AccessList
-	}
-	data := &types.InternalTx{
-		To:         args.To,
-		ChainID:    (*big.Int)(args.ChainID),
-		Nonce:      uint64(*args.Nonce),
-		Gas:        uint64(*args.Gas),
-		GasFeeCap:  (*big.Int)(args.MaxFeePerGas),
-		GasTipCap:  (*big.Int)(args.MaxPriorityFeePerGas),
-		Value:      (*big.Int)(args.Value),
-		Data:       args.data(),
-		AccessList: al,
-	}
-	return types.NewTx(data)
-}
-
-// ToTransaction converts the arguments to a transaction.
-// This assumes that setDefaults has been called.
-func (args *TransactionArgs) ToTransaction() *types.Transaction {
-	return args.toTransaction()
-}


### PR DESCRIPTION
toTransaction() and ToTransaction() are not used, and coerce every transaction to an Internal tx, so they should be removed. Fixes https://github.com/dominant-strategies/go-quai/issues/583