### PR TITLE
added a github action to lint PR's

### DIFF
--- a/.github/workflows/lint-on-pr.yml
+++ b/.github/workflows/lint-on-pr.yml
@@ -1,0 +1,24 @@
+name: Lint on PR
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - uses: actions/setup-go@v4
+      with:
+        go-version: '1.19'
+
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: latest 


### PR DESCRIPTION
This github action uses https://golangci-lint.run/

Maybe we are interested in installing this locally and running it in pre-commit hooks as well?