### PR TITLE
Fix one tx per block

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1135,7 +1135,11 @@ func setTxPool(ctx *cli.Context, cfg *core.TxPoolConfig) {
 			if trimmed := strings.TrimSpace(account); !common.IsHexAddress(trimmed) {
 				Fatalf("Invalid account in --txpool.locals: %s", trimmed)
 			} else {
-				cfg.Locals = append(cfg.Locals, common.HexToAddress(account))
+				internal, err := common.HexToAddress(account).InternalAddress()
+				if err != nil {
+					Fatalf("Invalid account in --txpool.locals: %s", account)
+				}
+				cfg.Locals = append(cfg.Locals, *internal)
 			}
 		}
 	}

--- a/common/address.go
+++ b/common/address.go
@@ -17,6 +17,8 @@ type Address struct {
 	inner AddressData
 }
 
+type AddressBytes [20]byte
+
 type AddressData interface {
 	Bytes() []byte
 	Hash() Hash
@@ -44,7 +46,7 @@ func (a Address) InternalAddress() (*InternalAddress, error) {
 	return internal, nil
 }
 
-func (a Address) Equals(b Address) bool {
+func (a Address) Equal(b Address) bool {
 	if a.inner == nil && b.inner == nil {
 		return true
 	} else if a.inner == nil || b.inner == nil {
@@ -99,6 +101,15 @@ func (a Address) Bytes() []byte {
 		return []byte{}
 	}
 	return a.inner.Bytes()
+}
+
+// Bytes20 gets the bytes20 representation of the underlying address.
+func (a Address) Bytes20() (addr AddressBytes) {
+	if a.inner == nil {
+		return AddressBytes{}
+	}
+	copy(addr[:], a.Bytes()[:]) // this is not very performant
+	return addr
 }
 
 // Hash converts an address to a hash by left-padding it with zeros.

--- a/common/internal_address.go
+++ b/common/internal_address.go
@@ -13,8 +13,11 @@ import (
 
 type InternalAddress [AddressLength]byte
 
-// Bytes gets the string representation of the underlying address.
+// Bytes gets the bytes representation of the underlying address.
 func (a InternalAddress) Bytes() []byte { return a[:] }
+
+// Bytes20 gets the bytes20 representation of the underlying address.
+func (a InternalAddress) Bytes20() (addr AddressBytes) { copy(addr[:], a[:]); return addr } // this is not very performant
 
 // Hash converts an address to a hash by left-padding it with zeros.
 func (a InternalAddress) Hash() Hash { return BytesToHash(a[:]) }

--- a/core/core.go
+++ b/core/core.go
@@ -678,7 +678,7 @@ func (c *Core) AddLocal(tx *types.Transaction) error {
 	return c.sl.txPool.AddLocal(tx)
 }
 
-func (c *Core) TxPoolPending(enforceTips bool) (map[common.Address]types.Transactions, error) {
+func (c *Core) TxPoolPending(enforceTips bool) (map[common.AddressBytes]types.Transactions, error) {
 	return c.sl.txPool.TxPoolPending(enforceTips, nil)
 }
 
@@ -687,17 +687,25 @@ func (c *Core) Get(hash common.Hash) *types.Transaction {
 }
 
 func (c *Core) Nonce(addr common.Address) uint64 {
-	return c.sl.txPool.Nonce(addr)
+	internal, err := addr.InternalAddress()
+	if err != nil {
+		return 0
+	}
+	return c.sl.txPool.Nonce(*internal)
 }
 
 func (c *Core) Stats() (int, int) {
 	return c.sl.txPool.Stats()
 }
 
-func (c *Core) Content() (map[common.Address]types.Transactions, map[common.Address]types.Transactions) {
+func (c *Core) Content() (map[common.InternalAddress]types.Transactions, map[common.InternalAddress]types.Transactions) {
 	return c.sl.txPool.Content()
 }
 
 func (c *Core) ContentFrom(addr common.Address) (types.Transactions, types.Transactions) {
-	return c.sl.txPool.ContentFrom(addr)
+	internal, err := addr.InternalAddress()
+	if err != nil {
+		return nil, nil
+	}
+	return c.sl.txPool.ContentFrom(*internal)
 }

--- a/core/tx_journal.go
+++ b/core/tx_journal.go
@@ -129,7 +129,7 @@ func (journal *txJournal) insert(tx *types.Transaction) error {
 
 // rotate regenerates the transaction journal based on the current contents of
 // the transaction pool.
-func (journal *txJournal) rotate(all map[common.Address]types.Transactions) error {
+func (journal *txJournal) rotate(all map[common.InternalAddress]types.Transactions) error {
 	// Close the current journal (if any is open)
 	if journal.writer != nil {
 		if err := journal.writer.Close(); err != nil {

--- a/core/worker.go
+++ b/core/worker.go
@@ -430,7 +430,7 @@ func (w *worker) GeneratePendingHeader(block *types.Block) (*types.Header, error
 	start := time.Now()
 	// Set the coinbase if the worker is running or it's required
 	var coinbase common.Address
-	if w.coinbase.Equals(common.ZeroAddr) {
+	if w.coinbase.Equal(common.ZeroAddr) {
 		log.Error("Refusing to mine without etherbase")
 		return nil, errors.New("etherbase not found")
 	}
@@ -582,10 +582,10 @@ func (w *worker) mainLoop() {
 				if gp := w.current.gasPool; gp != nil && gp.Gas() < params.TxGas {
 					continue
 				}
-				txs := make(map[common.Address]types.Transactions)
+				txs := make(map[common.AddressBytes]types.Transactions)
 				for _, tx := range ev.Txs {
 					acc, _ := types.Sender(w.current.signer, tx)
-					txs[acc] = append(txs[acc], tx)
+					txs[acc.Bytes20()] = append(txs[acc.Bytes20()], tx)
 				}
 				txset := types.NewTransactionsByPriceAndNonce(w.current.signer, txs, w.current.header.BaseFee())
 				tcount := w.current.tcount
@@ -854,7 +854,7 @@ func (w *worker) prepareWork(genParams *generateParams, block *types.Block) (*en
 	header.SetParentEntropy(block.Header().ParentEntropy())
 
 	if w.isRunning() {
-		if w.coinbase.Equals(common.ZeroAddr) {
+		if w.coinbase.Equal(common.ZeroAddr) {
 			log.Error("Refusing to mine without etherbase")
 			return nil, errors.New("refusing to mine without etherbase")
 		}
@@ -910,11 +910,11 @@ func (w *worker) fillTransactions(interrupt *int32, env *environment, block *typ
 	if err != nil {
 		return
 	}
-	localTxs, remoteTxs := make(map[common.Address]types.Transactions), pending
+	localTxs, remoteTxs := make(map[common.AddressBytes]types.Transactions), pending
 	for _, account := range w.txPool.Locals() {
-		if txs := remoteTxs[account]; len(txs) > 0 {
-			delete(remoteTxs, account)
-			localTxs[account] = txs
+		if txs := remoteTxs[account.Bytes20()]; len(txs) > 0 {
+			delete(remoteTxs, account.Bytes20())
+			localTxs[account.Bytes20()] = txs
 		}
 	}
 	if len(localTxs) > 0 {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -267,7 +267,7 @@ func (b *QuaiAPIBackend) Stats() (pending int, queued int) {
 	return b.eth.core.Stats()
 }
 
-func (b *QuaiAPIBackend) TxPoolContent() (map[common.Address]types.Transactions, map[common.Address]types.Transactions) {
+func (b *QuaiAPIBackend) TxPoolContent() (map[common.InternalAddress]types.Transactions, map[common.InternalAddress]types.Transactions) {
 	return b.eth.core.Content()
 }
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -309,7 +309,7 @@ func (s *Ethereum) Etherbase() (eb common.Address, err error) {
 	etherbase := s.etherbase
 	s.lock.RUnlock()
 
-	if !etherbase.Equals(common.ZeroAddr) {
+	if !etherbase.Equal(common.ZeroAddr) {
 		return etherbase, nil
 	}
 
@@ -331,13 +331,17 @@ func (s *Ethereum) isLocalBlock(header *types.Header) bool {
 	s.lock.RLock()
 	etherbase := s.etherbase
 	s.lock.RUnlock()
-	if author == etherbase {
+	if author.Equal(etherbase) {
 		return true
+	}
+	internal, err := author.InternalAddress()
+	if err != nil {
+		log.Error("Failed to retrieve author internal address", "err", err)
 	}
 	// Check whether the given address is specified by `txpool.local`
 	// CLI flag.
 	for _, account := range s.config.TxPool.Locals {
-		if account == author {
+		if account == *internal {
 			return true
 		}
 	}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -81,7 +81,7 @@ type txPool interface {
 
 	// Pending should return pending transactions.
 	// The slice should be modifiable by the caller.
-	TxPoolPending(enforceTips bool, etxSet types.EtxSet) (map[common.Address]types.Transactions, error)
+	TxPoolPending(enforceTips bool, etxSet types.EtxSet) (map[common.AddressBytes]types.Transactions, error)
 
 	// SubscribeNewTxsEvent should return an event subscription of
 	// NewTxsEvent and send events to the given channel.

--- a/internal/quaiapi/api.go
+++ b/internal/quaiapi/api.go
@@ -1302,7 +1302,7 @@ func (s *PublicTransactionPoolAPI) GetTransactionReceipt(ctx context.Context, ha
 		fields["logs"] = [][]*types.Log{}
 	}
 	// If the ContractAddress is 20 0x0 bytes, assume it is not a contract creation
-	if !receipt.ContractAddress.Equals(common.ZeroAddr) {
+	if !receipt.ContractAddress.Equal(common.ZeroAddr) {
 		fields["contractAddress"] = receipt.ContractAddress
 	}
 	return fields, nil

--- a/internal/quaiapi/backend.go
+++ b/internal/quaiapi/backend.go
@@ -91,7 +91,7 @@ type Backend interface {
 	GetPoolTransaction(txHash common.Hash) *types.Transaction
 	GetPoolNonce(ctx context.Context, addr common.Address) (uint64, error)
 	Stats() (pending int, queued int)
-	TxPoolContent() (map[common.Address]types.Transactions, map[common.Address]types.Transactions)
+	TxPoolContent() (map[common.InternalAddress]types.Transactions, map[common.InternalAddress]types.Transactions)
 	TxPoolContentFrom(addr common.Address) (types.Transactions, types.Transactions)
 	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription
 


### PR DESCRIPTION
@dominant-strategies/core-dev
Tx pool now uses InternalAddress. Worker uses generic address bytes type. In addition, fixed a bug where the nonce wouldn't be incremented in certain tx fails.