### PR TITLE
Added a ceiling to the basefee, configured in protocol_params.go

### DIFF
--- a/consensus/misc/eip1559.go
+++ b/consensus/misc/eip1559.go
@@ -51,8 +51,18 @@ func VerifyEip1559Header(config *params.ChainConfig, parent, header *types.Heade
 	return nil
 }
 
-// CalcBaseFee calculates the basefee of the header.
+// CalcBaseFee calculates the basefee of the header taking into account the basefee ceiling
 func CalcBaseFee(config *params.ChainConfig, parent *types.Header) *big.Int {
+	calculatedBaseFee := calcBaseFee(config, parent)
+	ceiling := big.NewInt(params.MaxBaseFee)
+	if calculatedBaseFee.Cmp(ceiling) > 0 {
+		return ceiling
+	}
+	return calculatedBaseFee
+}
+
+// calcBaseFee calculates the basefee of the header.
+func calcBaseFee(config *params.ChainConfig, parent *types.Header) *big.Int {
 	// If the current block is the first EIP-1559 block, return the InitialBaseFee.
 	if !config.IsLondon(parent.Number()) {
 		return new(big.Int).SetUint64(params.InitialBaseFee)

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -120,9 +120,10 @@ const (
 	// Introduced in Tangerine Whistle (Eip 150)
 	CreateBySelfdestructGas uint64 = 25000
 
-	BaseFeeChangeDenominator = 8 // Bounds the amount the base fee can change between blocks.
-	ElasticityMultiplier     = 2 // Bounds the maximum gas limit an EIP-1559 block may have.
-	InitialBaseFee           = 1 // Initial base fee for EIP-1559 blocks.
+	BaseFeeChangeDenominator = 8        // Bounds the amount the base fee can change between blocks.
+	ElasticityMultiplier     = 2        // Bounds the maximum gas limit an EIP-1559 block may have.
+	InitialBaseFee           = 1        // Initial base fee for EIP-1559 blocks.
+	MaxBaseFee               = 1 * GWei // Maximum base fee for EIP-1559 blocks.
 
 	MaxCodeSize = 24576 // Maximum bytecode to permit for a contract
 


### PR DESCRIPTION
@dominant-strategies/core-dev
This is just for testing. Should be removed in actual testnet