### PR TITLE
Increase block reward by a factor of 1000

### DIFF
--- a/consensus/misc/rewards.go
+++ b/consensus/misc/rewards.go
@@ -15,6 +15,7 @@ import (
 // For each zone = Reward/(3*regions*zones*time-factor^2)
 func CalculateReward() *big.Int {
 	reward := big.NewInt(5e18)
+	reward.Mul(reward, big.NewInt(1000))
 	timeFactor := big.NewInt(10)
 	regions := big.NewInt(3)
 	zones := big.NewInt(3)


### PR DESCRIPTION
@dominant-strategies/core-dev
We need to increase the block reward to send more transactions. After mining 50 zone blocks with these changes, my balance was ~92.5, which is slightly less than 2 per zone block.
With https://github.com/dominant-strategies/go-quai/pull/770 we introduced a base fee ceiling of 1 gwei (10^9) per unit of gas. A normal 21k gas transaction will thus cost at least 0.000021 plus the amount sent. This means that the block reward from each zone block will allow us to send anywhere between 10k-100k transactions depending on the amount sent per transaction (and the miner tip, which can be set to 1). 
Note that if we want to send transactions to addresses who then send transactions to other addresses and so on, the amount sent initially would need to be on the order of 0.0002, which would cost approximately 2.2 per 10k transactions.
