### PR TITLE
Fix etx validation

### DIFF
--- a/core/evm.go
+++ b/core/evm.go
@@ -74,6 +74,7 @@ func NewEVMTxContext(msg Message) vm.TxContext {
 		ETXGasLimit:   msg.ETXGasLimit(),
 		ETXGasPrice:   msg.ETXGasPrice(),
 		ETXGasTip:     msg.ETXGasTip(),
+		TXGasTip:      msg.GasTipCap(),
 		ETXData:       msg.ETXData(),
 		ETXAccessList: msg.ETXAccessList(),
 	}

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -866,6 +866,14 @@ func opETX(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte
 		fmt.Printf("%x opETX error: %s\n", scope.Contract.self.Address(), err.Error())
 		return nil, nil
 	}
+	// Fail if ETX gas price or tip are not valid
+	if err := interpreter.evm.ValidateETXGasPriceAndTip(sender, interpreter.evm.ETXGasPrice, interpreter.evm.ETXGasTip); err != nil {
+		temp.Clear()
+		stack.push(&temp)
+		fmt.Printf("%x opETX error: %s\n", scope.Contract.self.Address(), err.Error())
+		return nil, nil // following opCall protocol
+	}
+
 	fee := uint256.NewInt(0)
 	fee.Add(&gasTipCap, &gasFeeCap)
 	fee.Mul(fee, &etxGasLimit)


### PR DESCRIPTION
@dominant-strategies/core-dev
ETX miner tip per unit gas must now be at least double the originating transaction miner tip per unit gas. In addition, I added fee validation checks to opETX which was left out before.