### PR TITLE
Say Goodbye to Rebasing Hassles

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,8 +1,5 @@
 name: Build and Deploy to Dev
-on:
-  pull_request:
-    types: [closed]
-    branches: [ "main" ]
+on: workflow_dispatch
 jobs:
   buildDeployDev:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/deploy-sandbox.yml
+++ b/.github/workflows/deploy-sandbox.yml
@@ -17,5 +17,5 @@ jobs:
       GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
     with:
       env: quai-sandbox
-      awk : sed -e "s/pre/rc/g" | read a; if [[ "$a" =~ "rc" ]];then echo $a | awk -F . '{print $1"."$2"."$3"."$4+1}';else echo $a; fi 
+      awk: sed -e "s/pre/rc/g" | read a; if [[ "$a" =~ "rc" ]];then echo $a | awk -F . '{print $1"."$2"."$3"."$4+1}';else echo $a; fi
       rails: '[[ ! "$VERSION" =~ "pre" ]]'


### PR DESCRIPTION
@dominant-strategies/core-dev
Great news! We're ditching the auto pre-release rev for every feature branch merged, and switching to a manual process instead. We heard you loud and clear – rebasing was getting annoying!

Perks of the change:

1. **No more rebasing nightmares**: Merge multiple PRs without having to deal with version rev'ing each time.
2. **Secrets are safe**: Manual actions have access to secrets, so the fork problem of #764 is solved.
3. **Flexibility FTW**: You decide when a pre-release rev is needed. More control, less hassle.