### PR TITLE
Move genesis nonce to network.env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ include network.env
 
 # Build the base command
 # WARNING: WS_ADDR is a sensitive interface and should only be exposed to trusted networks
-BASE_CMD = nice -n -20 ./build/bin/go-quai --$(NETWORK) --syncmode $(SYNCMODE) --verbosity $(VERBOSITY)
+BASE_CMD = nice -n -20 ./build/bin/go-quai --$(NETWORK) --syncmode $(SYNCMODE) --verbosity $(VERBOSITY) --nonce $(NONCE)
 BASE_CMD += --http --http.vhosts=* --http.addr $(HTTP_ADDR) --http.api $(HTTP_API)
 BASE_CMD += --ws --ws.addr $(WS_ADDR) --ws.api $(WS_API)
 ifeq ($(ENABLE_ARCHIVE),true)

--- a/cmd/go-quai/main.go
+++ b/cmd/go-quai/main.go
@@ -117,6 +117,7 @@ var (
 		utils.OrchardFlag,
 		utils.GalenaFlag,
 		utils.LocalFlag,
+		utils.GenesisNonceFlag,
 		utils.VMEnableDebugFlag,
 		utils.NetworkIdFlag,
 		utils.QuaiStatsURLFlag,

--- a/cmd/go-quai/usage.go
+++ b/cmd/go-quai/usage.go
@@ -45,6 +45,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.OrchardFlag,
 			utils.GalenaFlag,
 			utils.LocalFlag,
+			utils.GenesisNonceFlag,
 			utils.SyncModeFlag,
 			utils.ExitWhenSyncedFlag,
 			utils.GCModeFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -150,6 +150,10 @@ var (
 		Name:  "local",
 		Usage: "Local network: localhost proof-of-work node, will not attempt to connect to bootnode or any public network",
 	}
+	GenesisNonceFlag = cli.Uint64Flag{
+		Name:  "nonce",
+		Usage: "Genesis block nonce (integer)",
+	}
 	DeveloperFlag = cli.BoolFlag{
 		Name:  "dev",
 		Usage: "Ephemeral proof-of-authority network with a pre-funded developer account, mining enabled",
@@ -1485,6 +1489,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		if cfg.NetworkId == 1 {
 			SetDNSDiscoveryDefaults(cfg, params.ColosseumGenesisHash)
 		}
+	}
+	if !ctx.GlobalBool(ColosseumFlag.Name) {
+		cfg.Genesis.Nonce = ctx.GlobalUint64(GenesisNonceFlag.Name)
 	}
 }
 

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -374,7 +374,7 @@ func DefaultColosseumGenesisBlock() *Genesis {
 func DefaultGardenGenesisBlock() *Genesis {
 	return &Genesis{
 		Config:     params.GardenChainConfig,
-		Nonce:      67,
+		Nonce:      0,
 		ExtraData:  hexutil.MustDecode("0x3535353535353535353535353535353535353535353535353535353535353535"),
 		GasLimit:   160000000,
 		Difficulty: big.NewInt(441092),
@@ -386,7 +386,7 @@ func DefaultGardenGenesisBlock() *Genesis {
 func DefaultOrchardGenesisBlock() *Genesis {
 	return &Genesis{
 		Config:     params.OrchardChainConfig,
-		Nonce:      68,
+		Nonce:      0,
 		ExtraData:  hexutil.MustDecode("0x3535353535353535353535353535353535353535353535353535353535353535"),
 		GasLimit:   80000000,
 		Difficulty: big.NewInt(4000000),
@@ -398,7 +398,7 @@ func DefaultOrchardGenesisBlock() *Genesis {
 func DefaultGalenaGenesisBlock() *Genesis {
 	return &Genesis{
 		Config:     params.GalenaChainConfig,
-		Nonce:      68,
+		Nonce:      0,
 		ExtraData:  hexutil.MustDecode("0x3535353535353535353535353535353535353535353535353535353535353535"),
 		GasLimit:   160000000,
 		Difficulty: big.NewInt(8800000000),
@@ -410,7 +410,7 @@ func DefaultGalenaGenesisBlock() *Genesis {
 func DefaultLocalGenesisBlock() *Genesis {
 	return &Genesis{
 		Config:     params.LocalChainConfig,
-		Nonce:      67,
+		Nonce:      0,
 		ExtraData:  hexutil.MustDecode("0x3535353535353535353535353535353535353535353535353535353535353535"),
 		GasLimit:   160000000,
 		Difficulty: big.NewInt(300000),

--- a/network.env.dist
+++ b/network.env.dist
@@ -91,6 +91,7 @@ ENABLE_ARCHIVE=false
 # network. At time of writing, no transport security is implemented, but this is
 # a trusted communication channel.
 NETWORK=colosseum
+NONCE=0 #Change this along with network
 HTTP_ADDR=0.0.0.0
 WS_ADDR=127.0.0.1
 WS_API=eth,net,web3,quai


### PR DESCRIPTION
@dominant-strategies/core-dev
In order to properly segregate networks, the genesis block nonce is now specified in network.env for all networks other than Colosseum (public testnet). If you do not add the correct nonce for the genesis block for the respective network your node will not run.