### PR TITLE
Miner and thread removal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,6 @@ endif
 ifeq ($(CORS),true)
 	BASE_CMD += --ws.origins=$(WS_ORIG) --http.corsdomain=$(HTTP_CORSDOMAIN)
 endif
-ifeq ($(QUAI_MINING),true)
-	BASE_CMD += --mine --miner.threads $(THREADS)
-endif
 ifeq ($(QUAI_STATS),true)
 	BASE_CMD += --quaistats ${STATS_NAME}:${STATS_PASS}@${STATS_HOST}
 endif

--- a/cmd/go-quai/main.go
+++ b/cmd/go-quai/main.go
@@ -92,16 +92,8 @@ var (
 		utils.ListenPortFlag,
 		utils.MaxPeersFlag,
 		utils.MaxPendingPeersFlag,
-		utils.MiningEnabledFlag,
-		utils.MinerThreadsFlag,
-		utils.MinerNotifyFlag,
-		utils.LegacyMinerGasTargetFlag,
-		utils.MinerGasLimitFlag,
 		utils.MinerGasPriceFlag,
 		utils.MinerEtherbaseFlag,
-		utils.MinerExtraDataFlag,
-		utils.MinerRecommitIntervalFlag,
-		utils.MinerNoVerfiyFlag,
 		utils.NATFlag,
 		utils.NoDiscoverFlag,
 		utils.DiscoveryV5Flag,
@@ -126,7 +118,6 @@ var (
 		utils.GpoPercentileFlag,
 		utils.GpoMaxGasPriceFlag,
 		utils.GpoIgnoreGasPriceFlag,
-		utils.MinerNotifyFullFlag,
 		configFileFlag,
 		utils.RegionFlag,
 		utils.ZoneFlag,
@@ -193,8 +184,6 @@ func init() {
 		licenseCommand,
 		// See config.go
 		dumpConfigCommand,
-		// See cmd/utils/flags_legacy.go
-		utils.ShowDeprecated,
 		// See snapshot.go
 		snapshotCommand,
 	}
@@ -315,7 +304,7 @@ func startNode(ctx *cli.Context, stack *node.Node, backend quaiapi.Backend) {
 	}
 
 	// Start auxiliary services if enabled
-	if ctx.GlobalBool(utils.MiningEnabledFlag.Name) || ctx.GlobalBool(utils.DeveloperFlag.Name) {
+	if ctx.GlobalBool(utils.DeveloperFlag.Name) {
 
 		var err error
 		ethBackend, ok := backend.(*eth.QuaiAPIBackend)
@@ -327,11 +316,6 @@ func startNode(ctx *cli.Context, stack *node.Node, backend quaiapi.Backend) {
 			// Set the gas price to the limits from the CLI and start mining
 			gasprice := utils.GlobalBig(ctx, utils.MinerGasPriceFlag.Name)
 			ethBackend.TxPool().SetGasPrice(gasprice)
-		}
-		// start mining
-		threads := ctx.GlobalInt(utils.MinerThreadsFlag.Name)
-		if err := ethBackend.StartMining(threads); err != nil {
-			utils.Fatalf("Failed to start mining: %v", err)
 		}
 	}
 }

--- a/cmd/go-quai/usage.go
+++ b/cmd/go-quai/usage.go
@@ -146,16 +146,8 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 	{
 		Name: "MINER",
 		Flags: []cli.Flag{
-			utils.MiningEnabledFlag,
-			utils.MinerThreadsFlag,
-			utils.MinerNotifyFlag,
-			utils.MinerNotifyFullFlag,
 			utils.MinerGasPriceFlag,
-			utils.MinerGasLimitFlag,
 			utils.MinerEtherbaseFlag,
-			utils.MinerExtraDataFlag,
-			utils.MinerRecommitIntervalFlag,
-			utils.MinerNoVerfiyFlag,
 		},
 	},
 	{
@@ -194,7 +186,6 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.LegacyRPCCORSDomainFlag,
 			utils.LegacyRPCVirtualHostsFlag,
 			utils.LegacyRPCApiFlag,
-			utils.LegacyMinerGasTargetFlag,
 		},
 	},
 	{
@@ -230,9 +221,6 @@ func init() {
 				}
 			}
 			deprecated := make(map[string]struct{})
-			for _, flag := range utils.DeprecatedFlags {
-				deprecated[flag.String()] = struct{}{}
-			}
 			// Only add uncategorized flags if they are not deprecated
 			var uncategorized []cli.Flag
 			for _, flag := range data.(*cli.App).Flags {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -333,28 +333,6 @@ var (
 		Usage: "Enable recording the SHA3/keccak preimages of trie keys",
 	}
 	// Miner settings
-	MiningEnabledFlag = cli.BoolFlag{
-		Name:  "mine",
-		Usage: "Enable mining",
-	}
-	MinerThreadsFlag = cli.IntFlag{
-		Name:  "miner.threads",
-		Usage: "Number of CPU threads to use for mining",
-		Value: 0,
-	}
-	MinerNotifyFlag = cli.StringFlag{
-		Name:  "miner.notify",
-		Usage: "Comma separated HTTP URL list to notify of new work packages",
-	}
-	MinerNotifyFullFlag = cli.BoolFlag{
-		Name:  "miner.notify.full",
-		Usage: "Notify with pending block headers instead of work packages",
-	}
-	MinerGasLimitFlag = cli.Uint64Flag{
-		Name:  "miner.gaslimit",
-		Usage: "Target gas ceiling for mined blocks",
-		Value: ethconfig.Defaults.Miner.GasCeil,
-	}
 	MinerGasPriceFlag = BigFlag{
 		Name:  "miner.gasprice",
 		Usage: "Minimum gas price for mining a transaction",
@@ -364,19 +342,6 @@ var (
 		Name:  "miner.etherbase",
 		Usage: "Public address for block mining rewards (default = first account)",
 		Value: "0",
-	}
-	MinerExtraDataFlag = cli.StringFlag{
-		Name:  "miner.extradata",
-		Usage: "Block extra data set by the miner (default = client version)",
-	}
-	MinerRecommitIntervalFlag = cli.DurationFlag{
-		Name:  "miner.recommit",
-		Usage: "Time interval to recreate the block being mined",
-		Value: ethconfig.Defaults.Miner.Recommit,
-	}
-	MinerNoVerfiyFlag = cli.BoolFlag{
-		Name:  "miner.noverify",
-		Usage: "Disable remote sealing verification",
 	}
 	// Account settings
 	UnlockedAccountFlag = cli.StringFlag{
@@ -1200,31 +1165,6 @@ func setBlake3pow(ctx *cli.Context, cfg *ethconfig.Config) {
 	}
 }
 
-func setMiner(ctx *cli.Context, cfg *core.Config) {
-	if ctx.GlobalIsSet(MinerNotifyFlag.Name) {
-		cfg.Notify = strings.Split(ctx.GlobalString(MinerNotifyFlag.Name), ",")
-	}
-	cfg.NotifyFull = ctx.GlobalBool(MinerNotifyFullFlag.Name)
-	if ctx.GlobalIsSet(MinerExtraDataFlag.Name) {
-		cfg.ExtraData = []byte(ctx.GlobalString(MinerExtraDataFlag.Name))
-	}
-	if ctx.GlobalIsSet(MinerGasLimitFlag.Name) {
-		cfg.GasCeil = ctx.GlobalUint64(MinerGasLimitFlag.Name)
-	}
-	if ctx.GlobalIsSet(MinerGasPriceFlag.Name) {
-		cfg.GasPrice = GlobalBig(ctx, MinerGasPriceFlag.Name)
-	}
-	if ctx.GlobalIsSet(MinerRecommitIntervalFlag.Name) {
-		cfg.Recommit = ctx.GlobalDuration(MinerRecommitIntervalFlag.Name)
-	}
-	if ctx.GlobalIsSet(MinerNoVerfiyFlag.Name) {
-		cfg.Noverify = ctx.GlobalBool(MinerNoVerfiyFlag.Name)
-	}
-	if ctx.GlobalIsSet(LegacyMinerGasTargetFlag.Name) {
-		log.Warn("The generic --miner.gastarget flag is deprecated and will be removed in the future!")
-	}
-}
-
 func setWhitelist(ctx *cli.Context, cfg *ethconfig.Config) {
 	whitelist := ctx.GlobalString(WhitelistFlag.Name)
 	if whitelist == "" {
@@ -1322,7 +1262,6 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	setGPO(ctx, &cfg.GPO, ctx.GlobalString(SyncModeFlag.Name) == "light")
 	setTxPool(ctx, &cfg.TxPool)
 	setBlake3pow(ctx, cfg)
-	setMiner(ctx, &cfg.Miner)
 	setWhitelist(ctx, cfg)
 
 	// set the dominant chain websocket url

--- a/cmd/utils/flags_legacy.go
+++ b/cmd/utils/flags_legacy.go
@@ -17,26 +17,11 @@
 package utils
 
 import (
-	"fmt"
 	"strings"
 
-	"github.com/dominant-strategies/go-quai/eth/ethconfig"
 	"github.com/dominant-strategies/go-quai/node"
 	"gopkg.in/urfave/cli.v1"
 )
-
-var ShowDeprecated = cli.Command{
-	Action:      showDeprecated,
-	Name:        "show-deprecated-flags",
-	Usage:       "Show flags that have been deprecated",
-	ArgsUsage:   " ",
-	Category:    "MISCELLANEOUS COMMANDS",
-	Description: "Show flags that have been deprecated and will soon be removed",
-}
-
-var DeprecatedFlags = []cli.Flag{
-	LegacyMinerGasTargetFlag,
-}
 
 var (
 	// (Deprecated May 2020, shown in aliased flags section)
@@ -69,22 +54,4 @@ var (
 		Usage: "API's offered over the HTTP-RPC interface (deprecated and will be removed June 2021, use --http.api)",
 		Value: "",
 	}
-	// (Deprecated July 2021, shown in aliased flags section)
-	LegacyMinerGasTargetFlag = cli.Uint64Flag{
-		Name:  "miner.gastarget",
-		Usage: "Target gas floor for mined blocks (deprecated)",
-		Value: ethconfig.Defaults.Miner.GasFloor,
-	}
 )
-
-// showDeprecated displays deprecated flags that will be soon removed from the codebase.
-func showDeprecated(*cli.Context) {
-	fmt.Println("--------------------------------------------------------------------")
-	fmt.Println("The following flags are deprecated and will be removed in the future!")
-	fmt.Println("--------------------------------------------------------------------")
-	fmt.Println()
-	for _, flag := range DeprecatedFlags {
-		fmt.Println(flag.String())
-	}
-	fmt.Println()
-}

--- a/eth/api.go
+++ b/eth/api.go
@@ -24,7 +24,6 @@ import (
 	"io"
 	"math/big"
 	"os"
-	"runtime"
 	"strings"
 	"time"
 
@@ -91,24 +90,6 @@ type PrivateMinerAPI struct {
 // NewPrivateMinerAPI create a new RPC service which controls the miner of this node.
 func NewPrivateMinerAPI(e *Ethereum) *PrivateMinerAPI {
 	return &PrivateMinerAPI{e: e}
-}
-
-// Start starts the miner with the given number of threads. If threads is nil,
-// the number of workers started is equal to the number of logical CPUs that are
-// usable by this process. If mining is already running, this method adjust the
-// number of threads allowed to use and updates the minimum price required by the
-// transaction pool.
-func (api *PrivateMinerAPI) Start(threads *int) error {
-	if threads == nil {
-		return api.e.StartMining(runtime.NumCPU())
-	}
-	return api.e.StartMining(*threads)
-}
-
-// Stop terminates the miner, both at the consensus engine level as well as at
-// the block creation level.
-func (api *PrivateMinerAPI) Stop() {
-	api.e.StopMining()
 }
 
 // SetExtra sets the extra data string that is included when this miner mines a block.

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -405,14 +405,6 @@ func (b *QuaiAPIBackend) CurrentHeader() *types.Header {
 	return b.eth.core.CurrentHeader()
 }
 
-func (b *QuaiAPIBackend) Miner() *core.Miner {
-	return b.eth.core.Miner()
-}
-
-func (b *QuaiAPIBackend) StartMining(threads int) error {
-	return b.eth.StartMining(threads)
-}
-
 func (b *QuaiAPIBackend) StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, checkLive bool) (*state.StateDB, error) {
 	nodeCtx := common.NodeLocation.Context()
 	if nodeCtx != common.ZONE_CTX {

--- a/network.env.dist
+++ b/network.env.dist
@@ -100,9 +100,6 @@ HTTP_API=eth,net,web3,quai
 #Mining Variables
 QUAI_MINING=true
 
-#Number of CPU threads
-THREADS=1
-
 #Bootnode Specific Variables
 #Should only be used by bootnode operators, i.e. team developers
 HTTP_CORSDOMAIN="*"


### PR DESCRIPTION
@dominant-strategies/core-dev
Removes unused references to mining threads in the network.env and the makefile. Removes mining functionality from the node in favor of using cpu and gpu miner.