### PR TITLE
Display error upon genesis hash mismatch, and list the hashes

### DIFF
--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -84,6 +84,9 @@ func NewHeaderChain(db ethdb.Database, engine consensus.Engine, chainConfig *par
 	}
 
 	hc.genesisHeader = hc.GetHeaderByNumber(0)
+	if hc.genesisHeader.Hash() != chainConfig.GenesisHash {
+		return nil, fmt.Errorf("genesis block mismatch: have %x, want %x", hc.genesisHeader.Hash(), chainConfig.GenesisHash)
+	}
 	log.Info("Genesis", "Hash:", hc.genesisHeader.Hash())
 	if hc.genesisHeader == nil {
 		return nil, ErrNoGenesis


### PR DESCRIPTION
@dominant-strategies/core-dev
Eliminates the need to mess with print statements to figure out what the new genesis hash is.
Also alerts the user with the full hash print of what was expected vs given.