### PR TITLE
Bugfix: Check if selected case is nonzero before typecasting to interface

### DIFF
--- a/event/feed.go
+++ b/event/feed.go
@@ -18,8 +18,9 @@ package event
 
 import (
 	"errors"
-	sync "github.com/sasha-s/go-deadlock"
 	"reflect"
+
+	sync "github.com/sasha-s/go-deadlock"
 )
 
 var errBadChannel = errors.New("event: Subscribe argument does not have sendable channel type")
@@ -181,11 +182,13 @@ func (f *Feed) Send(value interface{}) (nsent int) {
 		}
 		chosen, recv, _ := reflect.Select(sendCases)
 		if chosen == 0 /* <-f.removeSub */ {
-			index := f.sendCases.find(recv.Interface())
-			f.sendCases = f.sendCases.delete(index)
-			if index >= 0 && index < len(cases) {
-				// Shrink 'cases' too because the removed case was still active.
-				cases = f.sendCases[:len(cases)-1]
+			if recv.IsValid() {
+				index := f.sendCases.find(recv.Interface())
+				f.sendCases = f.sendCases.delete(index)
+				if index >= 0 && index < len(cases) {
+					// Shrink 'cases' too because the removed case was still active.
+					cases = f.sendCases[:len(cases)-1]
+				}
 			}
 		} else {
 			cases = cases.deactivate(chosen)


### PR DESCRIPTION
This fixes a bug in https://github.com/dominant-strategies/go-quai/commit/a2b5099afbd1946c8baf319a9fea2e50587df423
However this is just a patch, the underlying logical bug hasn't been fixed yet.
Issue: 
```
[37mDEBUG  [0m[05-19|09:22:50]log/logger.go:86 PhCache update:                          inSlice:=true Ph Number:=[1 1 2] Termini:=0x4c35b1216decc6aa2431fa2d2a1c68f15d70f83a309041ed1bfef5ad6592a3d4 
panic: reflect: call of reflect.Value.Interface on zero Value

goroutine 5438 [running]:
reflect.valueInterface({0x0?, 0x0?, 0x14000394350?}, 0x60?)
    reflect/value.go:1435 +0x100
reflect.Value.Interface(...)
    reflect/value.go:1430
github.com/dominant-strategies/go-quai/event.(*Feed).Send(0x14000394318, {0x102ce9560?, 0x1400cea9600?})
    github.com/dominant-strategies/go-quai/event/feed.go:184 +0x4f0
github.com/dominant-strategies/go-quai/core.(*Slice).relayPh(0x14000162780, 0x0?, 0x0?, 0x1, {0x1400a69fb80?, {0x140003ab180?, 0x0?, 0x0?}}, 0x0, {0x14008b0ad50, ...})
    github.com/dominant-strategies/go-quai/core/slice.go:286 +0x254
created by github.com/dominant-strategies/go-quai/core.(*Slice).Append
    github.com/dominant-strategies/go-quai/core/slice.go:244 +0xff0
```

@wizeguyy 
@dominant-strategies/core-dev
