### PR TITLE
Set default verbosity to info level

### DIFF
--- a/network.env.dist
+++ b/network.env.dist
@@ -111,7 +111,7 @@ BOOTNODE=false
 CORS=false
 
 # Verbosity variable
-VERBOSITY=3
+VERBOSITY=4
 
 # Syncmode variable
 SYNCMODE=full


### PR DESCRIPTION
@dominant-strategies/core-dev
Verbosity needs to be set to 4 (info level) to gain useful information about the progress of the node. The default verbosity just shows leveldb warnings that make it seem like the node isn't running.