### PR TITLE
Add showcolors flag to enable/disable colored log prints for non-TTYs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,10 @@ ifeq ($(QUAI_STATS),true)
 	BASE_CMD += --quaistats ${STATS_NAME}:${STATS_PASS}@${STATS_HOST}
 endif
 
+ifeq ($(SHOW_COLORS),true)
+	BASE_CMD += --showcolors
+endif
+
 # Build suburl strings for slice specific subclient groups
 # WARNING: Only connect to dom/sub clients over a trusted network.
 ifeq ($(REGION),2)

--- a/cmd/go-quai/main.go
+++ b/cmd/go-quai/main.go
@@ -120,6 +120,7 @@ var (
 		utils.GpoPercentileFlag,
 		utils.GpoMaxGasPriceFlag,
 		utils.GpoIgnoreGasPriceFlag,
+		utils.ShowColorsFlag,
 		configFileFlag,
 		utils.RegionFlag,
 		utils.ZoneFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -599,6 +599,13 @@ var (
 		Usage: "Password to authorize access to the database",
 		Value: metrics.DefaultConfig.InfluxDBPassword,
 	}
+
+	// Output flags
+	ShowColorsFlag = cli.BoolFlag{
+		Name:  "showcolors",
+		Usage: "Enable colorized logging",
+	}
+
 	// Tags are part of every measurement sent to InfluxDB. Queries on tags are faster in InfluxDB.
 	// For example `host` tag could be used so that we can group all nodes and average a measurement
 	// across all of them, but also so that we can select a specific node and inspect its measurements.

--- a/log/logger.go
+++ b/log/logger.go
@@ -17,13 +17,7 @@ type Logger = *logrus.Logger
 var Log Logger = logrus.New()
 
 func init() {
-	Log.Formatter = &logrus.TextFormatter{
-		ForceColors:      true,
-		PadLevelText:     true,
-		FullTimestamp:    true,
-		TimestampFormat:  "01-02|15:04:05",
-		CallerPrettyfier: callerPrettyfier,
-	}
+
 }
 
 func ConfigureLogger(ctx *cli.Context) {
@@ -39,13 +33,21 @@ func ConfigureLogger(ctx *cli.Context) {
 
 	if ctx.GlobalIsSet("zone") {
 		zoneNum := ctx.GlobalString("zone")
-		log_filename = filepath.Join(log_filename, "zone-" + regionNum + "-" + zoneNum)
+		log_filename = filepath.Join(log_filename, "zone-"+regionNum+"-"+zoneNum)
 	} else if ctx.GlobalIsSet("region") {
-		log_filename = filepath.Join(log_filename, "region-" + regionNum)
+		log_filename = filepath.Join(log_filename, "region-"+regionNum)
 	} else {
 		log_filename = filepath.Join(log_filename, "prime")
 	}
 	log_filename += ".log"
+
+	Log.Formatter = &logrus.TextFormatter{
+		ForceColors:      ctx.GlobalBool("showcolors"),
+		PadLevelText:     true,
+		FullTimestamp:    true,
+		TimestampFormat:  "01-02|15:04:05",
+		CallerPrettyfier: callerPrettyfier,
+	}
 
 	Log.SetOutput(&lumberjack.Logger{
 		Filename:   log_filename,

--- a/network.env.dist
+++ b/network.env.dist
@@ -122,3 +122,6 @@ STATS_NAME=
 STATS_PASS=
 STATS_HOST=
 ENABLE_PPROF=false
+
+# Output format variables
+SHOW_COLORS=true


### PR DESCRIPTION
@dominant-strategies/core-dev
This helps when looking at logs in non TTY environments such as GCP log viewer or vim.