### PR TITLE
Revert "Use shasha-s/go-deadlock for deadlock detection"

### DIFF
--- a/build/update-license.go
+++ b/build/update-license.go
@@ -50,10 +50,9 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"text/template"
 	"time"
-
-	sync "github.com/sasha-s/go-deadlock"
 )
 
 var (

--- a/cmd/go-quai/test_cmd.go
+++ b/cmd/go-quai/test_cmd.go
@@ -26,13 +26,12 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"testing"
 	"text/template"
 	"time"
-
-	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/docker/docker/pkg/reexec"
 )

--- a/common/prque/lazyqueue_test.go
+++ b/common/prque/lazyqueue_test.go
@@ -18,7 +18,7 @@ package prque
 
 import (
 	"math/rand"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"testing"
 	"time"
 

--- a/common/timedcache/timedcache.go
+++ b/common/timedcache/timedcache.go
@@ -1,7 +1,7 @@
 package timedcache
 
 import (
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"time"
 
 	lru "github.com/hashicorp/golang-lru"

--- a/consensus/blake3pow/blake3pow.go
+++ b/consensus/blake3pow/blake3pow.go
@@ -3,9 +3,8 @@ package blake3pow
 import (
 	"math/big"
 	"math/rand"
+	"sync"
 	"time"
-
-	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/dominant-strategies/go-quai/common/hexutil"

--- a/consensus/blake3pow/blake3pow_test.go
+++ b/consensus/blake3pow/blake3pow_test.go
@@ -5,10 +5,9 @@ import (
 	"math/big"
 	"math/rand"
 	"os"
+	"sync"
 	"testing"
 	"time"
-
-	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/dominant-strategies/go-quai/common/hexutil"

--- a/consensus/blake3pow/sealer.go
+++ b/consensus/blake3pow/sealer.go
@@ -11,7 +11,7 @@ import (
 	"math/rand"
 	"net/http"
 	"runtime"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"time"
 
 	"github.com/dominant-strategies/go-quai/common"

--- a/core/bloombits/matcher.go
+++ b/core/bloombits/matcher.go
@@ -22,7 +22,7 @@ import (
 	"errors"
 	"math"
 	"sort"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"sync/atomic"
 	"time"
 

--- a/core/bloombits/scheduler.go
+++ b/core/bloombits/scheduler.go
@@ -17,7 +17,7 @@
 package bloombits
 
 import (
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 )
 
 // request represents a bloom retrieval task to prioritize and pull from the local

--- a/core/bloombits/scheduler_test.go
+++ b/core/bloombits/scheduler_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"math/big"
 	"math/rand"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"

--- a/core/bodydb.go
+++ b/core/bodydb.go
@@ -1,7 +1,7 @@
 package core
 
 import (
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"time"
 
 	"github.com/dominant-strategies/go-quai/common"

--- a/core/chain_indexer.go
+++ b/core/chain_indexer.go
@@ -20,10 +20,9 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"time"
-
-	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/dominant-strategies/go-quai/core/rawdb"

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -3,9 +3,9 @@ package core
 import (
 	"errors"
 	"fmt"
-	sync "github.com/sasha-s/go-deadlock"
 	"io"
 	"math/big"
+	"sync"
 	"sync/atomic"
 	"time"
 

--- a/core/rawdb/chain_iterator_test.go
+++ b/core/rawdb/chain_iterator_test.go
@@ -20,7 +20,7 @@ import (
 	"math/big"
 	"reflect"
 	"sort"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"testing"
 
 	"github.com/dominant-strategies/go-quai/common"

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -22,10 +22,9 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"time"
-
-	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/dominant-strategies/go-quai/ethdb"

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -23,7 +23,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"sync/atomic"
 
 	"github.com/dominant-strategies/go-quai/common"

--- a/core/rawdb/freezer_table_test.go
+++ b/core/rawdb/freezer_table_test.go
@@ -24,7 +24,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"testing"
 	"time"
 

--- a/core/slice.go
+++ b/core/slice.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"sync"
 	"time"
 
 	"github.com/dominant-strategies/go-quai/common"
@@ -20,7 +21,6 @@ import (
 	"github.com/dominant-strategies/go-quai/quaiclient"
 	"github.com/dominant-strategies/go-quai/trie"
 	lru "github.com/hashicorp/golang-lru"
-	sync "github.com/sasha-s/go-deadlock"
 )
 
 const (

--- a/core/state/snapshot/conversion.go
+++ b/core/state/snapshot/conversion.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"math"
 	"runtime"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"time"
 
 	"github.com/dominant-strategies/go-quai/common"

--- a/core/state/snapshot/difflayer.go
+++ b/core/state/snapshot/difflayer.go
@@ -22,7 +22,7 @@ import (
 	"math"
 	"math/rand"
 	"sort"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"sync/atomic"
 	"time"
 

--- a/core/state/snapshot/disklayer.go
+++ b/core/state/snapshot/disklayer.go
@@ -18,7 +18,7 @@ package snapshot
 
 import (
 	"bytes"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 
 	"github.com/VictoriaMetrics/fastcache"
 	"github.com/dominant-strategies/go-quai/common"

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -21,9 +21,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"sync"
 	"sync/atomic"
-
-	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/dominant-strategies/go-quai/core/rawdb"

--- a/core/state/trie_prefetcher.go
+++ b/core/state/trie_prefetcher.go
@@ -17,7 +17,7 @@
 package state
 
 import (
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/dominant-strategies/go-quai/log"

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -20,9 +20,8 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"sync"
 	"time"
-
-	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/dominant-strategies/go-quai/common/prque"

--- a/core/tx_noncer.go
+++ b/core/tx_noncer.go
@@ -18,7 +18,7 @@ package core
 
 import (
 	lru "github.com/hashicorp/golang-lru"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/dominant-strategies/go-quai/core/state"

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"math/big"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/dominant-strategies/go-quai/common"
@@ -33,7 +34,6 @@ import (
 	"github.com/dominant-strategies/go-quai/log"
 	"github.com/dominant-strategies/go-quai/metrics"
 	"github.com/dominant-strategies/go-quai/params"
-	sync "github.com/sasha-s/go-deadlock"
 )
 
 const (

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -19,10 +19,9 @@ package vm
 import (
 	"fmt"
 	"math/big"
+	"sync"
 	"sync/atomic"
 	"time"
-
-	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/dominant-strategies/go-quai/core/types"

--- a/core/worker.go
+++ b/core/worker.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -21,7 +22,6 @@ import (
 	"github.com/dominant-strategies/go-quai/params"
 	"github.com/dominant-strategies/go-quai/trie"
 	lru "github.com/hashicorp/golang-lru"
-	sync "github.com/sasha-s/go-deadlock"
 )
 
 const (

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -22,10 +22,9 @@ import (
 	"fmt"
 	"math/big"
 	"net/http"
+	"sync"
 	"sync/atomic"
 	"time"
-
-	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/dominant-strategies/go-quai/consensus"

--- a/eth/downloader/api.go
+++ b/eth/downloader/api.go
@@ -18,8 +18,7 @@ package downloader
 
 import (
 	"context"
-
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 
 	interfaces "github.com/dominant-strategies/go-quai"
 	"github.com/dominant-strategies/go-quai/event"

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -20,12 +20,6 @@ package downloader
 import (
 	"errors"
 	"fmt"
-	"math/big"
-	"sync/atomic"
-	"time"
-
-	sync "github.com/sasha-s/go-deadlock"
-
 	quai "github.com/dominant-strategies/go-quai"
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/dominant-strategies/go-quai/consensus"
@@ -36,6 +30,10 @@ import (
 	"github.com/dominant-strategies/go-quai/event"
 	"github.com/dominant-strategies/go-quai/log"
 	"github.com/dominant-strategies/go-quai/metrics"
+	"math/big"
+	"sync"
+	"sync/atomic"
+	"time"
 )
 
 var (

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -21,11 +21,10 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
-
-	sync "github.com/sasha-s/go-deadlock"
 
 	quai "github.com/dominant-strategies/go-quai"
 	"github.com/dominant-strategies/go-quai/common"

--- a/eth/downloader/peer.go
+++ b/eth/downloader/peer.go
@@ -23,10 +23,9 @@ import (
 	"errors"
 	"math/big"
 	"sort"
+	"sync"
 	"sync/atomic"
 	"time"
-
-	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/dominant-strategies/go-quai/eth/protocols/eth"

--- a/eth/downloader/queue_test.go
+++ b/eth/downloader/queue_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"math/big"
 	"math/rand"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"testing"
 	"time"
 

--- a/eth/downloader/resultstore.go
+++ b/eth/downloader/resultstore.go
@@ -18,7 +18,7 @@ package downloader
 
 import (
 	"fmt"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"sync/atomic"
 
 	"github.com/dominant-strategies/go-quai/common"

--- a/eth/downloader/testchain_test.go
+++ b/eth/downloader/testchain_test.go
@@ -19,7 +19,7 @@ package downloader
 import (
 	"fmt"
 	"math/big"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/dominant-strategies/go-quai/consensus/blake3pow"

--- a/eth/fetcher/block_fetcher_test.go
+++ b/eth/fetcher/block_fetcher_test.go
@@ -19,7 +19,7 @@ package fetcher
 import (
 	"errors"
 	"math/big"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -22,9 +22,8 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"sync"
 	"time"
-
-	sync "github.com/sasha-s/go-deadlock"
 
 	quai "github.com/dominant-strategies/go-quai"
 	"github.com/dominant-strategies/go-quai/common"

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -21,9 +21,8 @@ package filters
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
-
-	sync "github.com/sasha-s/go-deadlock"
 
 	quai "github.com/dominant-strategies/go-quai"
 	"github.com/dominant-strategies/go-quai/common"

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"math/big"
 	"sort"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/dominant-strategies/go-quai/core/types"

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"math"
 	"math/rand"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -33,7 +34,6 @@ import (
 	"github.com/dominant-strategies/go-quai/event"
 	"github.com/dominant-strategies/go-quai/log"
 	"github.com/dominant-strategies/go-quai/p2p"
-	sync "github.com/sasha-s/go-deadlock"
 )
 
 const (

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -19,9 +19,7 @@ package eth
 import (
 	"math/big"
 	"sort"
-	sync "github.com/sasha-s/go-deadlock"
-
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/dominant-strategies/go-quai/consensus/blake3pow"

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -18,9 +18,8 @@ package eth
 
 import (
 	"math/big"
+	"sync"
 	"time"
-
-	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/dominant-strategies/go-quai/eth/protocols/eth"
 )

--- a/eth/peerset.go
+++ b/eth/peerset.go
@@ -19,7 +19,7 @@ package eth
 import (
 	"errors"
 	"math/big"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/dominant-strategies/go-quai/eth/protocols/eth"

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -20,9 +20,8 @@ import (
 	"errors"
 	"math/big"
 	"math/rand"
+	"sync"
 	"time"
-
-	sync "github.com/sasha-s/go-deadlock"
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/dominant-strategies/go-quai/common"

--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"time"
 
 	"github.com/dominant-strategies/go-quai/common"

--- a/ethdb/memorydb/memorydb.go
+++ b/ethdb/memorydb/memorydb.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"sort"
 	"strings"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/dominant-strategies/go-quai/ethdb"

--- a/event/event.go
+++ b/event/event.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"time"
 )
 

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -18,7 +18,7 @@ package event
 
 import (
 	"math/rand"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"testing"
 	"time"
 )

--- a/event/example_scope_test.go
+++ b/event/example_scope_test.go
@@ -18,7 +18,7 @@ package event_test
 
 import (
 	"fmt"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 
 	"github.com/dominant-strategies/go-quai/event"
 )

--- a/event/feed.go
+++ b/event/feed.go
@@ -19,7 +19,7 @@ package event
 import (
 	"errors"
 	"reflect"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 )
 
 var errBadChannel = errors.New("event: Subscribe argument does not have sendable channel type")

--- a/event/feed_test.go
+++ b/event/feed_test.go
@@ -19,7 +19,7 @@ package event
 import (
 	"fmt"
 	"reflect"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"testing"
 	"time"
 )

--- a/event/subscription.go
+++ b/event/subscription.go
@@ -18,7 +18,7 @@ package event
 
 import (
 	"context"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"time"
 
 	"github.com/dominant-strategies/go-quai/common/mclock"

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/docker/docker v1.4.2-0.20180625184442-8e610b2b55bf
 	github.com/dominant-strategies/bn256 v0.0.0-20220930122411-fbf930a7493d
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5
+	github.com/go-stack/stack v1.8.1
 	github.com/golang/snappy v0.0.3
 	github.com/google/gofuzz v1.1.1-0.20200604201612-c04b05f3adfa
 	github.com/gorilla/websocket v1.4.2
@@ -29,7 +30,6 @@ require (
 	github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7
 	github.com/prometheus/tsdb v0.7.1
 	github.com/rs/cors v1.7.0
-	github.com/sasha-s/go-deadlock v0.3.1
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.7.0
@@ -55,7 +55,6 @@ require (
 	github.com/mattn/go-ieproxy v0.0.0-20190702010315-6dee0af9227d // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/naoina/go-stringutil v0.1.0 // indirect
-	github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -115,7 +115,10 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-ole/go-ole v1.2.5 h1:t4MGB5xEDZvXI+0rMjjsfBsD7yAgp/s9ZDkL1JndXwY=
 github.com/go-ole/go-ole v1.2.5/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-stack/stack v1.8.1 h1:ntEHSVwIt7PNXNpgPmVfMrNhLtgjlmnZha2kOpuRiDw=
+github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=
 github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
@@ -261,8 +264,6 @@ github.com/paulbellamy/ratecounter v0.2.0/go.mod h1:Hfx1hDpSGoqxkVVpBi/IlYD7kChl
 github.com/peterh/liner v1.0.1-0.20180619022028-8c1271fcf47f/go.mod h1:xIteQHvHuaLYG9IFj6mSxM0fCKrs34IrEQUhOYuGPHc=
 github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7 h1:oYW+YCJ1pachXTQmzR3rNLYGGz4g/UgFcjb28p/viDM=
 github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7/go.mod h1:CRroGNssyjTd/qIG2FyxByd2S8JEAZXBl4qUrZf8GS0=
-github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 h1:q2e307iGHPdTGp0hoxKjt1H5pDo6utceo3dQVK3I5XQ=
-github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5/go.mod h1:jvVRKCrJTQWu0XVbaOlby/2lO20uSCHEMzzplHXte1o=
 github.com/philhofer/fwd v1.0.0/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -290,8 +291,6 @@ github.com/retailnext/hllpp v1.0.1-0.20180308014038-101a6d2f8b52/go.mod h1:RDpi1
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
-github.com/sasha-s/go-deadlock v0.3.1 h1:sqv7fDNShgjcaxkO0JNcOAlr8B9+cV5Ey/OB71efZx0=
-github.com/sasha-s/go-deadlock v0.3.1/go.mod h1:F73l+cr82YSh10GxyRI6qZiCgK64VaZjwesgfQ1/iLM=
 github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=

--- a/internal/debug/api.go
+++ b/internal/debug/api.go
@@ -31,9 +31,8 @@ import (
 	"runtime/debug"
 	"runtime/pprof"
 	"strings"
+	"sync"
 	"time"
-
-	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/dominant-strategies/go-quai/log"
 )

--- a/internal/quaiapi/addrlock.go
+++ b/internal/quaiapi/addrlock.go
@@ -17,7 +17,7 @@
 package quaiapi
 
 import (
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 
 	"github.com/dominant-strategies/go-quai/common"
 )

--- a/internal/testlog/testlog.go
+++ b/internal/testlog/testlog.go
@@ -18,7 +18,7 @@
 package testlog
 
 import (
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"testing"
 
 	"github.com/dominant-strategies/go-quai/log"

--- a/metrics/ewma.go
+++ b/metrics/ewma.go
@@ -2,7 +2,7 @@ package metrics
 
 import (
 	"math"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"sync/atomic"
 	"time"
 )

--- a/metrics/exp/exp.go
+++ b/metrics/exp/exp.go
@@ -6,7 +6,7 @@ import (
 	"expvar"
 	"fmt"
 	"net/http"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 
 	"github.com/dominant-strategies/go-quai/log"
 	"github.com/dominant-strategies/go-quai/metrics"

--- a/metrics/gauge_float64.go
+++ b/metrics/gauge_float64.go
@@ -1,6 +1,6 @@
 package metrics
 
-import sync "github.com/sasha-s/go-deadlock"
+import "sync"
 
 // GaugeFloat64s hold a float64 value that can be set arbitrarily.
 type GaugeFloat64 interface {

--- a/metrics/meter.go
+++ b/metrics/meter.go
@@ -1,7 +1,7 @@
 package metrics
 
 import (
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"sync/atomic"
 	"time"
 )

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"testing"
 	"time"
 )

--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 )
 
 // DuplicateMetric is the error returned by Registry.Register when a metric

--- a/metrics/resetting_timer.go
+++ b/metrics/resetting_timer.go
@@ -3,7 +3,7 @@ package metrics
 import (
 	"math"
 	"sort"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"time"
 )
 

--- a/metrics/sample.go
+++ b/metrics/sample.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"math/rand"
 	"sort"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"time"
 )
 

--- a/metrics/timer.go
+++ b/metrics/timer.go
@@ -1,7 +1,7 @@
 package metrics
 
 import (
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"time"
 )
 

--- a/node/config.go
+++ b/node/config.go
@@ -23,8 +23,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/dominant-strategies/go-quai/crypto"

--- a/node/node.go
+++ b/node/node.go
@@ -24,7 +24,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 
 	"github.com/dominant-strategies/go-quai/core/rawdb"
 	"github.com/dominant-strategies/go-quai/ethdb"

--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	mrand "math/rand"
 	"net"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"time"
 
 	"github.com/dominant-strategies/go-quai/common/mclock"

--- a/p2p/dial_test.go
+++ b/p2p/dial_test.go
@@ -23,7 +23,7 @@ import (
 	"math/rand"
 	"net"
 	"reflect"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"testing"
 	"time"
 

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -29,9 +29,8 @@ import (
 	mrand "math/rand"
 	"net"
 	"sort"
+	"sync"
 	"time"
-
-	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/dominant-strategies/go-quai/log"

--- a/p2p/discover/table_util_test.go
+++ b/p2p/discover/table_util_test.go
@@ -25,7 +25,7 @@ import (
 	"math/rand"
 	"net"
 	"sort"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 
 	"github.com/dominant-strategies/go-quai/crypto"
 	"github.com/dominant-strategies/go-quai/log"

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -26,7 +26,7 @@ import (
 	"fmt"
 	"io"
 	"net"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"time"
 
 	"github.com/dominant-strategies/go-quai/crypto"

--- a/p2p/discover/v4_udp_test.go
+++ b/p2p/discover/v4_udp_test.go
@@ -27,10 +27,9 @@ import (
 	"math/rand"
 	"net"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
-
-	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/dominant-strategies/go-quai/internal/testlog"
 	"github.com/dominant-strategies/go-quai/log"

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -26,7 +26,7 @@ import (
 	"io"
 	"math"
 	"net"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"time"
 
 	"github.com/dominant-strategies/go-quai/common/mclock"

--- a/p2p/dnsdisc/client.go
+++ b/p2p/dnsdisc/client.go
@@ -23,7 +23,7 @@ import (
 	"math/rand"
 	"net"
 	"strings"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"time"
 
 	"github.com/dominant-strategies/go-quai/common/mclock"

--- a/p2p/enode/iter.go
+++ b/p2p/enode/iter.go
@@ -17,7 +17,7 @@
 package enode
 
 import (
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"time"
 )
 

--- a/p2p/enode/localnode.go
+++ b/p2p/enode/localnode.go
@@ -22,7 +22,7 @@ import (
 	"net"
 	"reflect"
 	"strconv"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"sync/atomic"
 	"time"
 

--- a/p2p/enode/nodedb.go
+++ b/p2p/enode/nodedb.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"net"
 	"os"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"time"
 
 	"github.com/dominant-strategies/go-quai/rlp"

--- a/p2p/msgrate/msgrate.go
+++ b/p2p/msgrate/msgrate.go
@@ -22,9 +22,8 @@ import (
 	"errors"
 	"math"
 	"sort"
+	"sync"
 	"time"
-
-	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/dominant-strategies/go-quai/log"
 )

--- a/p2p/nat/nat.go
+++ b/p2p/nat/nat.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"time"
 
 	"github.com/dominant-strategies/go-quai/log"

--- a/p2p/nat/natupnp.go
+++ b/p2p/nat/natupnp.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"time"
 
 	"github.com/huin/goupnp"

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -22,9 +22,8 @@ import (
 	"io"
 	"net"
 	"sort"
+	"sync"
 	"time"
-
-	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/dominant-strategies/go-quai/common/mclock"
 	"github.com/dominant-strategies/go-quai/event"

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -25,10 +25,9 @@ import (
 	"fmt"
 	"net"
 	"sort"
+	"sync"
 	"sync/atomic"
 	"time"
-
-	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/dominant-strategies/go-quai/common/mclock"

--- a/p2p/tracker/tracker.go
+++ b/p2p/tracker/tracker.go
@@ -19,7 +19,7 @@ package tracker
 import (
 	"container/list"
 	"fmt"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"time"
 
 	"github.com/dominant-strategies/go-quai/log"

--- a/p2p/transport.go
+++ b/p2p/transport.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"time"
 
 	"github.com/dominant-strategies/go-quai/common"

--- a/quaistats/quaistats.go
+++ b/quaistats/quaistats.go
@@ -27,10 +27,10 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	lru "github.com/hashicorp/golang-lru"
-	sync "github.com/sasha-s/go-deadlock"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/mem"
 

--- a/rlp/encode_test.go
+++ b/rlp/encode_test.go
@@ -24,7 +24,7 @@ import (
 	"io/ioutil"
 	"math/big"
 	"runtime"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"testing"
 
 	"github.com/dominant-strategies/go-quai/common/math"

--- a/rlp/typecache.go
+++ b/rlp/typecache.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"sync/atomic"
 )
 

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -22,7 +22,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"time"
 
 	"github.com/dominant-strategies/go-quai/log"

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -27,7 +27,7 @@ import (
 	"mime"
 	"net/http"
 	"net/url"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"time"
 )
 

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -25,7 +25,7 @@ import (
 	"io"
 	"reflect"
 	"strings"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"time"
 )
 

--- a/rpc/service.go
+++ b/rpc/service.go
@@ -23,7 +23,7 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"unicode"
 
 	"github.com/dominant-strategies/go-quai/log"

--- a/rpc/subscription.go
+++ b/rpc/subscription.go
@@ -27,7 +27,7 @@ import (
 	"math/rand"
 	"reflect"
 	"strings"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"time"
 )
 

--- a/rpc/testservice_test.go
+++ b/rpc/testservice_test.go
@@ -21,7 +21,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"strings"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"time"
 )
 

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -24,7 +24,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"time"
 
 	mapset "github.com/deckarep/golang-set"

--- a/trie/database.go
+++ b/trie/database.go
@@ -22,9 +22,8 @@ import (
 	"io"
 	"reflect"
 	"runtime"
+	"sync"
 	"time"
-
-	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/VictoriaMetrics/fastcache"
 	"github.com/dominant-strategies/go-quai/common"

--- a/trie/secure_trie_test.go
+++ b/trie/secure_trie_test.go
@@ -19,7 +19,7 @@ package trie
 import (
 	"bytes"
 	"runtime"
-	sync "github.com/sasha-s/go-deadlock"
+	"sync"
 	"testing"
 
 	"github.com/dominant-strategies/go-quai/common"

--- a/trie/sync_bloom.go
+++ b/trie/sync_bloom.go
@@ -19,10 +19,9 @@ package trie
 import (
 	"encoding/binary"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"time"
-
-	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/dominant-strategies/go-quai/core/rawdb"

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -21,11 +21,11 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/dominant-strategies/go-quai/crypto"
 	"github.com/dominant-strategies/go-quai/log"
+	"sync"
 )
 
 var (


### PR DESCRIPTION
This reverts commit 9a657c555fdb9b643abbdf8fd0090ff266165bd9.

@dominant-strategies/core-dev
