### PR TITLE
bugfix: only stop the state processor in zones

### DIFF
--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -492,7 +492,9 @@ func (hc *HeaderChain) Stop() {
 	hc.scope.Close()
 	hc.bc.scope.Close()
 	hc.wg.Wait()
-	hc.bc.processor.Stop()
+	if common.NodeLocation.Context() == common.ZONE_CTX {
+		hc.bc.processor.Stop()
+	}
 	log.Info("headerchain stopped")
 }
 


### PR DESCRIPTION
@dominant-strategies/core-dev
