### PR TITLE
Revert "Keep cache of recent manifests"

### DIFF
--- a/core/worker.go
+++ b/core/worker.go
@@ -862,10 +862,11 @@ func (w *worker) FinalizeAssemble(chain consensus.ChainHeaderReader, header *typ
 	} else if w.engine.IsDomCoincident(parent.Header()) {
 		manifest = types.BlockManifest{parent.Hash()}
 	} else {
-		manifest, err = w.hc.BuildManifestFromParent(parent.Header())
+		manifest, err = w.hc.CollectBlockManifest(parent.Header())
 		if err != nil {
 			return nil, err
 		}
+		manifest = append(manifest, header.ParentHash())
 	}
 	manifestHash := types.DeriveSha(manifest, trie.NewStackTrie(nil))
 	block.Header().SetManifestHash(manifestHash)


### PR DESCRIPTION
This reverts commit 376d0402962113fbff2a3fa40b5c37e21bf28f8b.

@dominant-strategies/core-dev


Ran this main on garden network with transactions and repeatedly got this error, so reverting it until we fix the issue
```
^[[36mINFO   ^[[0m[06-05|15:32:10.694] filling sub manifest
^[[36mINFO   ^[[0m[06-05|15:32:10.696] Retrieved mined block                    number=14 location=[2 2]
^[[36mINFO   ^[[0m[06-05|15:32:11.097] Starting slice append                    hash=0x00001e9b6dca4a945a28c247d277012de39db4b57f91a49535e7f68a4e0f0744 number=[3 14 61] location=[2 1] parent hash=0x00001bdd9f2c9a771e7db3fbac87
b965f20500841e6fdceecfe68a78547ee3b6
^[[36mINFO   ^[[0m[06-05|15:32:11.100] Append failed.                           hash=0x00001e9b6dca4a945a28c247d277012de39db4b57f91a49535e7f68a4e0f0744 err=manifest does not match hash
^[[36mINFO   ^[[0m[06-05|15:32:11.100] Starting slice append                    hash=0x000005d74e13586b5fbd345767f96e9283b8cac4a4c363a390e7876f776efbbd number=[3 14 39] location=[2 2] parent hash=0x00001bdd9f2c9a771e7db3fbac87
b965f20500841e6fdceecfe68a78547ee3b6
^[[36mINFO   ^[[0m[06-05|15:32:11.105] Append failed.                           hash=0x000005d74e13586b5fbd345767f96e9283b8cac4a4c363a390e7876f776efbbd err=manifest does not match hash
^[[36mINFO   ^[[0m[06-05|15:32:17.157] Looking for peers                        peercount=3 tried=0 static=0
^[[36mINFO   ^[[0m[06-05|15:32:20.096] Starting slice append                    hash=0x000015d6b855264198d9cd396097747779e5bc23216ddeb8181b34be5fd5b2ba number=[3 14 61] location=[2 1] parent hash=0x00001bdd9f2c9a771e7db3fbac87
b965f20500841e6fdceecfe68a78547ee3b6
^[[36mINFO   ^[[0m[06-05|15:32:20.097] Append failed.                           hash=0x000015d6b855264198d9cd396097747779e5bc23216ddeb8181b34be5fd5b2ba err=manifest does not match hash
```
