### PR TITLE
Bugfix: GetTransactionByHash API Encoding

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -182,17 +182,9 @@ func (tx *Transaction) setDecoded(inner TxData, size int) {
 }
 
 func sanityCheckSignature(v *big.Int, r *big.Int, s *big.Int) error {
-	var plainV byte
-	if isProtectedV(v) {
-		chainID := deriveChainId(v).Uint64()
-		plainV = byte(v.Uint64() - 35 - 2*chainID)
-	} else {
-		return ErrExpectedProtection // Unprotected transactions are not supported
-	}
-	if !crypto.ValidateSignatureValues(plainV, r, s) {
+	if !crypto.ValidateSignatureValues(byte(v.Uint64()), r, s) {
 		return ErrInvalidSig
 	}
-
 	return nil
 }
 

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -280,16 +280,3 @@ func recoverPlain(sighash common.Hash, R, S, Vb *big.Int) (common.Address, error
 	addr := common.BytesToAddress(crypto.Keccak256(pub[1:])[12:])
 	return addr, nil
 }
-
-// deriveChainId derives the chain id from the given v parameter
-func deriveChainId(v *big.Int) *big.Int {
-	if v.BitLen() <= 64 {
-		v := v.Uint64()
-		if v == 27 || v == 28 {
-			return new(big.Int)
-		}
-		return new(big.Int).SetUint64((v - 35) / 2)
-	}
-	v = new(big.Int).Sub(v, big.NewInt(35))
-	return v.Div(v, big.NewInt(2))
-}


### PR DESCRIPTION
@dominant-strategies/core-dev
We no longer encode the chain ID into the v-value of the transaction signature (neither does Ethereum) and therefore checking if the transaction is replay-protected via the v-value is unnecessary. Instead, we have the chain ID in the transaction struct and it is signed along with the rest of the transaction data.