### PR TITLE
bugfix: Fixed the downloader issue and extra genesis header response

### DIFF
--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -99,10 +99,6 @@ func answerGetBlockHeadersQuery(backend Backend, query *GetBlockHeadersPacket, p
 		// If the to number is reached stop the search
 		// By default the To is 0 and if its value is specified we need to stop
 		if query.To >= query.Origin.Number && query.Reverse {
-			if query.Origin.Number == 0 {
-				genesis := backend.Core().GetHeaderByNumber(0)
-				headers = append(headers, genesis)
-			}
 			break
 		}
 


### PR DESCRIPTION
Removed the unnessesary number checks in the queue, and in the handlers for the get header by number request was sending an extra genesis header which is not required.

Also simplified the logic of accepting the chain of headers in the queue

@dominant-strategies/core-dev
