### PR TITLE
fix: estimate gas pendingBlock to latestBlock

### DIFF
--- a/internal/quaiapi/quai_api.go
+++ b/internal/quaiapi/quai_api.go
@@ -409,7 +409,7 @@ func (s *PublicBlockChainQuaiAPI) EstimateGas(ctx context.Context, args Transact
 	if nodeCtx != common.ZONE_CTX {
 		return 0, errors.New("estimateGas can only called in a zone chain")
 	}
-	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
+	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 	if blockNrOrHash != nil {
 		bNrOrHash = *blockNrOrHash
 	}


### PR DESCRIPTION
@dominant-strategies/core-dev

Fixes `block not found` error while doing `quai_estimateGas`

Example API call:

```
{
     "id": 1,
     "jsonrpc": "2.0",
     "method": "quai_estimateGas",
     "params": [{"from": "0x04a3e45aa16163F2663015b6695894D918866d19","to": "0x1930e0b28d3766e895df661de871a9b8ab70a4da","gas": "0x76c0","gasPrice": "0x9184e72a000","value": "0x9184e72a","data": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"}]
}
```