### PR TITLE
Worker needs to prune expired ETXs before building blocks

### DIFF
--- a/core/types/etx_set.go
+++ b/core/types/etx_set.go
@@ -2,10 +2,7 @@ package types
 
 import (
 	"github.com/dominant-strategies/go-quai/common"
-)
-
-const (
-	EtxExpirationAge = 100 // With 10s blocks, ETX expire after ~24hrs
+	"github.com/dominant-strategies/go-quai/params"
 )
 
 // The EtxSet maps an ETX hash to the ETX and block number in which it became available.
@@ -37,7 +34,7 @@ func (set *EtxSet) Update(newInboundEtxs Transactions, currentHeight uint64) {
 	// Remove expired ETXs
 	for txHash, entry := range *set {
 		availableAtBlock := entry.Height
-		etxExpirationHeight := availableAtBlock + EtxExpirationAge
+		etxExpirationHeight := availableAtBlock + params.EtxExpirationAge
 		if currentHeight > etxExpirationHeight {
 			delete(*set, txHash)
 		}

--- a/core/worker.go
+++ b/core/worker.go
@@ -827,6 +827,7 @@ func (w *worker) fillTransactions(interrupt *int32, env *environment, block *typ
 	if etxSet == nil {
 		return
 	}
+	etxSet.Update(types.Transactions{}, block.NumberU64()) // Prune any expired ETXs
 	pending, err := w.txPool.TxPoolPending(true, etxSet)
 	if err != nil {
 		return

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -43,6 +43,7 @@ const (
 	ETXPrimeMaxFraction   int    = common.NumRegionsInPrime * common.NumZonesInRegion       // The maximum fraction of transactions for cross-prime ETXs
 	ETXRLimitMin          int    = 10                                                       // Minimum possible cross-region ETX limit
 	ETXPLimitMin          int    = 10                                                       // Minimum possible cross-prime ETX limit
+	EtxExpirationAge      uint64 = 100                                                      // Number of blocks an ETX may wait for inclusion at the destination
 
 	Sha3Gas     uint64 = 30 // Once per SHA3 operation.
 	Sha3WordGas uint64 = 6  // Once per word of the SHA3 operation's data.


### PR DESCRIPTION
This fixes a bug, where the worker might build blocks which include inbound ETXs which _should_ have expired _on this block_. A lot of factors have to converge for this bug to trigger, but once it does, the worker (all workers) becomes unable to build on the latest block.