### PR TITLE
Fix SeedHash API

### DIFF
--- a/consensus/progpow/algorithm.go
+++ b/consensus/progpow/algorithm.go
@@ -130,6 +130,12 @@ func seedHash(block uint64) []byte {
 	return seed
 }
 
+// SeedHash is the seed to use for generating a verification cache and the mining
+// dataset.
+func SeedHash(block uint64) []byte {
+	return seedHash(block)
+}
+
 // generateCache creates a verification cache of a given size for an input seed.
 // The cache production process involves first sequentially filling up 32 MB of
 // memory, then performing two passes of Sergio Demian Lerner's RandMemoHash

--- a/core/core.go
+++ b/core/core.go
@@ -567,11 +567,6 @@ func (c *Core) Snapshots() *snapshot.Tree {
 	return nil
 }
 
-// this needs to be implemented, it is being used by a lot of modules
-func (c *Core) SetHead(number uint64) error {
-	return nil
-}
-
 func (c *Core) TxLookupLimit() uint64 {
 	return 0
 }

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -78,11 +78,6 @@ func (b *QuaiAPIBackend) CalcOrder(header *types.Header) (*big.Int, int, error) 
 	return b.eth.core.CalcOrder(header)
 }
 
-func (b *QuaiAPIBackend) SetHead(number uint64) {
-	b.eth.handler.downloader.Cancel()
-	b.eth.core.SetHead(number)
-}
-
 func (b *QuaiAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error) {
 	// Pending block is only known by the miner
 	if number == rpc.PendingBlockNumber {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -114,8 +114,8 @@ func New(stack *node.Node, config *ethconfig.Config) (*Quai, error) {
 	if err != nil {
 		return nil, err
 	}
-	chainConfig, genesisHash, genesisErr := core.SetupGenesisBlockWithOverride(chainDb, config.Genesis)
-	if _, ok := genesisErr.(*params.ConfigCompatError); genesisErr != nil && !ok {
+	chainConfig, _, genesisErr := core.SetupGenesisBlockWithOverride(chainDb, config.Genesis)
+	if genesisErr != nil {
 		return nil, genesisErr
 	}
 
@@ -180,13 +180,6 @@ func New(stack *node.Node, config *ethconfig.Config) (*Quai, error) {
 			Preimages:           config.Preimages,
 		}
 	)
-
-	// Rewind the chain in case of an incompatible config upgrade.
-	if compat, ok := genesisErr.(*params.ConfigCompatError); ok {
-		log.Warn("Rewinding chain to upgrade configuration", "err", compat)
-		eth.core.SetHead(compat.RewindTo)
-		rawdb.WriteChainConfig(chainDb, genesisHash, chainConfig)
-	}
 
 	if config.TxPool.Journal != "" {
 		config.TxPool.Journal = stack.ResolvePath(config.TxPool.Journal)

--- a/internal/quaiapi/api.go
+++ b/internal/quaiapi/api.go
@@ -1518,11 +1518,6 @@ func (api *PrivateDebugAPI) ChaindbCompact() error {
 	return nil
 }
 
-// SetHead rewinds the head of the blockchain to a previous block.
-func (api *PrivateDebugAPI) SetHead(number hexutil.Uint64) {
-	api.b.SetHead(uint64(number))
-}
-
 // PublicNetAPI offers network related RPC methods
 type PublicNetAPI struct {
 	net            *p2p.Server

--- a/internal/quaiapi/api.go
+++ b/internal/quaiapi/api.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dominant-strategies/go-quai/common/hexutil"
 	"github.com/dominant-strategies/go-quai/common/math"
 	"github.com/dominant-strategies/go-quai/consensus/misc"
+	"github.com/dominant-strategies/go-quai/consensus/progpow"
 	"github.com/dominant-strategies/go-quai/core"
 	"github.com/dominant-strategies/go-quai/core/state"
 	"github.com/dominant-strategies/go-quai/core/types"
@@ -1480,7 +1481,7 @@ func (api *PublicDebugAPI) SeedHash(ctx context.Context, number uint64) (string,
 	if block == nil {
 		return "", fmt.Errorf("block #%d not found", number)
 	}
-	return "", fmt.Errorf("progpow does not have seedhash")
+	return fmt.Sprintf("0x%x", progpow.SeedHash(number)), nil
 }
 
 // PrivateDebugAPI is the collection of Quai APIs exposed over the private

--- a/internal/quaiapi/backend.go
+++ b/internal/quaiapi/backend.go
@@ -53,7 +53,6 @@ type Backend interface {
 	RPCTxFeeCap() float64 // global tx fee cap for all transaction related APIs
 
 	// Blockchain API
-	SetHead(number uint64)
 	HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error)
 	HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error)
 	HeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Header, error)


### PR DESCRIPTION
@dominant-strategies/core-dev
This PR fixes the debug_seedHash API to return the progpow seed hash of a block by number.
Referenced in https://github.com/dominant-strategies/go-quai/issues/627