### PR TITLE
ETX limit error message should dereference pointer

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -333,10 +333,10 @@ func applyTransaction(msg types.Message, config *params.ChainConfig, bc ChainCon
 		}
 	}
 	if ETXRCount > *etxRLimit {
-		return nil, fmt.Errorf("tx %032x emits too many cross-region ETXs for block. emitted: %d, limit: %d", tx.Hash(), ETXRCount, etxRLimit)
+		return nil, fmt.Errorf("tx %032x emits too many cross-region ETXs for block. emitted: %d, limit: %d", tx.Hash(), ETXRCount, *etxRLimit)
 	}
 	if ETXPCount > *etxPLimit {
-		return nil, fmt.Errorf("tx %032x emits too many cross-prime ETXs for block. emitted: %d, limit: %d", tx.Hash(), ETXPCount, etxPLimit)
+		return nil, fmt.Errorf("tx %032x emits too many cross-prime ETXs for block. emitted: %d, limit: %d", tx.Hash(), ETXPCount, *etxPLimit)
 	}
 	*etxRLimit -= ETXRCount
 	*etxPLimit -= ETXPCount


### PR DESCRIPTION
@dominant-strategies/core-dev
The returned error message includes the wrong etxlimit because the integer pointer isn't dereferenced.