### PR TITLE
Revert "Lock the proc, so that only one proc of append queue happens …

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -7,7 +7,6 @@ import (
 	"math/big"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/dominant-strategies/go-quai/common"
@@ -49,7 +48,6 @@ type Core struct {
 	sl     *Slice
 	engine consensus.Engine
 
-	appendProcMu    sync.RWMutex
 	appendQueue     *lru.Cache
 	processingCache *lru.Cache
 
@@ -278,9 +276,7 @@ func (c *Core) updateAppendQueue() {
 	for {
 		select {
 		case <-futureTimer.C:
-			c.appendProcMu.Lock()
 			c.procAppendQueue()
-			c.appendProcMu.Unlock()
 		case <-c.quit:
 			return
 		}


### PR DESCRIPTION
…at a time"

This reverts commit 7d32a65f19ad6881b473b110fb51259bada66ec1.

@dominant-strategies/core-dev
