### PR TITLE
Stuck block checker

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -363,6 +363,8 @@ func (c *Core) Stop() {
 
 // WriteBlock write the block to the bodydb database
 func (c *Core) WriteBlock(block *types.Block) {
+	_, order, _ := c.CalcOrder(block.Header())
+	log.Info("Writing block to the database", "Hash", block.Hash(), "Number", block.Number(), "Order", order)
 	c.writeBlockLock.Lock()
 	defer c.writeBlockLock.Unlock()
 
@@ -476,6 +478,10 @@ func (c *Core) IsBlockHashABadHash(hash common.Hash) bool {
 
 func (c *Core) ProcessingState() bool {
 	return c.sl.ProcessingState()
+}
+
+func (c *Core) SendMissingParentFeed(hash common.Hash) {
+	c.sl.missingParentFeed.Send(hash)
 }
 
 //---------------------//

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -468,6 +468,8 @@ func (hc *HeaderChain) loadLastState() error {
 	if head := rawdb.ReadHeadBlockHash(hc.headerDb); head != (common.Hash{}) {
 		if chead := hc.GetHeaderByHash(head); chead != nil {
 			hc.currentHeader.Store(chead)
+		} else {
+			hc.currentHeader.Store(hc.genesisHeader)
 		}
 	}
 

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -694,6 +694,10 @@ func (q *queue) DeliverHeaders(id string, headers []*types.Header, headerProcCh 
 	}
 
 	if len(headers) > 0 {
+		if targetTo < q.headerOffset {
+			// integer underflow (intentional?)
+			logger.Error("Header delivery out of order", "from", targetTo, "offset", q.headerOffset, "targetTo-q.headerOffset", targetTo-q.headerOffset, "len(headers)", len(q.headerResults))
+		}
 		copy(q.headerResults[targetTo-q.headerOffset:], headers)
 	}
 

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -514,12 +514,12 @@ func (h *handler) missingPEtxsRollupLoop() {
 	defer h.wg.Done()
 	for {
 		select {
-		case hash := <-h.missingPEtxsRollupCh:
+		case _ = <-h.missingPEtxsRollupCh:
 			// Check if any of the peers have the body
-			for _, peer := range h.selectSomePeers() {
-				log.Trace("Fetching the missing pending etxs rollup from", "peer", peer.ID(), "hash", hash)
-				peer.RequestOnePendingEtxsRollup(hash)
-			}
+			// for _, peer := range h.selectSomePeers() {
+			// log.Trace("Fetching the missing pending etxs rollup from", "peer", peer.ID(), "hash", hash)
+			// peer.RequestOnePendingEtxsRollup(hash)
+			// }
 
 		case <-h.missingPEtxsRollupSub.Err():
 			return
@@ -541,15 +541,15 @@ func (h *handler) missingPendingEtxsLoop() {
 				log.Warn("Node doesn't have peers for given Location", "location", hashAndLocation.Location)
 			}
 			// Check if any of the peers have the body
-			for _, peer := range peersRunningSlice {
-				log.Trace("Fetching the missing pending etxs from", "peer", peer.ID(), "hash", hashAndLocation.Hash)
-				peer.RequestOnePendingEtxs(hashAndLocation.Hash)
-			}
+			// for _, peer := range peersRunningSlice {
+			// log.Trace("Fetching the missing pending etxs from", "peer", peer.ID(), "hash", hashAndLocation.Hash)
+			// peer.RequestOnePendingEtxs(hashAndLocation.Hash)
+			// }
 			if len(peersRunningSlice) == 0 {
-				for _, peer := range h.selectSomePeers() {
-					log.Trace("Fetching the missing pending etxs from", "peer", peer.ID(), "hash", hashAndLocation.Hash)
-					peer.RequestOnePendingEtxs(hashAndLocation.Hash)
-				}
+				// for _, peer := range h.selectSomePeers() {
+				// log.Trace("Fetching the missing pending etxs from", "peer", peer.ID(), "hash", hashAndLocation.Hash)
+				// peer.RequestOnePendingEtxs(hashAndLocation.Hash)
+				// }
 			}
 		case <-h.missingPendingEtxsSub.Err():
 			return
@@ -615,9 +615,9 @@ func (h *handler) BroadcastPendingEtxs(pEtx types.PendingEtxs) {
 	}
 	transfer := peers[:peerThreshold]
 	// If in region send the pendingEtxs directly, otherwise send the pendingEtxsManifest
-	for _, peer := range transfer {
-		peer.SendPendingEtxs(pEtx)
-	}
+	// for _, peer := range transfer {
+	// 	peer.SendPendingEtxs(pEtx)
+	// }
 	log.Trace("Propagated pending etxs", "hash", hash, "recipients", len(transfer), "len", len(pEtx.Etxs))
 	return
 }
@@ -637,9 +637,9 @@ func (h *handler) BroadcastPendingEtxsRollup(pEtxRollup types.PendingEtxsRollup)
 	}
 	transfer := peers[:peerThreshold]
 	// If in region send the pendingEtxs directly, otherwise send the pendingEtxsManifest
-	for _, peer := range transfer {
-		peer.SendPendingEtxsRollup(pEtxRollup)
-	}
+	// for _, peer := range transfer {
+	// 	peer.SendPendingEtxsRollup(pEtxRollup)
+	// }
 	log.Trace("Propagated pending etxs rollup", "hash", hash, "recipients", len(transfer), "len", len(pEtxRollup.Manifest))
 	return
 }

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -565,7 +565,7 @@ func (h *handler) missingParentLoop() {
 		case hash := <-h.missingParentCh:
 			// Check if any of the peers have the body
 			for _, peer := range h.selectSomePeers() {
-				log.Trace("Fetching the missing parent from", "peer", peer.ID(), "hash", hash)
+				log.Debug("Fetching the missing parent from", "peer", peer.ID(), "hash", hash)
 				peer.RequestBlockByHash(hash)
 			}
 		case <-h.missingParentSub.Err():

--- a/eth/handler_eth.go
+++ b/eth/handler_eth.go
@@ -213,23 +213,24 @@ func (h *ethHandler) handleBlockBroadcast(peer *eth.Peer, block *types.Block) er
 }
 
 func (h *ethHandler) handlePendingEtxs(pendingEtxs types.PendingEtxs) error {
-	err := h.core.AddPendingEtxs(pendingEtxs)
-	if err != nil {
-		log.Error("Error in handling pendingEtxs broadcast", "err", err)
-		return err
-	}
+	// err := h.core.AddPendingEtxs(pendingEtxs)
+	// if err != nil {
+	// 	log.Error("Error in handling pendingEtxs broadcast", "err", err)
+	// 	return err
+	// }
 	return nil
 }
 
 func (h *ethHandler) handlePendingEtxsRollup(peer *eth.Peer, pEtxsRollup types.PendingEtxsRollup) error {
-	err := h.core.AddPendingEtxsRollup(pEtxsRollup)
-	if err != nil {
-		log.Error("Error in handling pendingEtxs rollup broadcast", "err", err)
-		return err
-	}
-	// For each hash in manifest request for the pendingEtxs
-	for _, hash := range pEtxsRollup.Manifest {
-		peer.RequestOnePendingEtxs(hash)
-	}
+	// err := h.core.AddPendingEtxsRollup(pEtxsRollup)
+	// if err != nil {
+	// 	log.Error("Error in handling pendingEtxs rollup broadcast", "err", err)
+	// 	return err
+	// }
+	// // For each hash in manifest request for the pendingEtxs
+	// for _, hash := range pEtxsRollup.Manifest {
+	// 	peer.RequestOnePendingEtxs(hash)
+	// }
+	// return nil
 	return nil
 }

--- a/network.env.dist
+++ b/network.env.dist
@@ -98,7 +98,7 @@ NONCE=5926993 #Change this along with network
 HTTP_ADDR=localhost
 WS_ADDR=localhost
 WS_API=eth,quai
-HTTP_API=quai
+HTTP_API=eth,quai
 
 #Mining Variables
 QUAI_MINING=true


### PR DESCRIPTION
@dominant-strategies/core-dev
The stuck block checker goroutine checks if the peer head is more than 10 blocks ahead of local, and if so, checks if the block has been stuck for more than 20 seconds (head hasn't changed). In this case, we are likely stuck in syncing, and the goroutine sends messages to peers to find the next block.