### PR TITLE
improve network.env comment verbosity

### DIFF
--- a/network.env.dist
+++ b/network.env.dist
@@ -1,4 +1,6 @@
-#Unique Coinbase addresses
+# Coinbase Addresses
+# If this node is being used to mine, block rewards (coinbase rewards) will be paid out to the following addresses.
+# Each of these addresses must be unique and map to the correct shard it has been inputted for. 
 
 ZONE_0_0_COINBASE=0x04a3e45aa16163F2663015b6695894D918866d19
 ZONE_0_1_COINBASE=0x21c7650E65b164B2ab645eAF1141b569B2c82Bd7
@@ -53,7 +55,9 @@ ZONE_2_2_PORT_TCP=30315
 ZONE_2_2_PORT_HTTP=8678
 ZONE_2_2_PORT_WS=8679
 
-# Dom websocket urls
+
+# Dominant websocket urls
+
 REGION_0_DOM_URL=ws://127.0.0.1
 REGION_1_DOM_URL=ws://127.0.0.1
 REGION_2_DOM_URL=ws://127.0.0.1
@@ -67,65 +71,79 @@ ZONE_2_0_DOM_URL=ws://127.0.0.1
 ZONE_2_1_DOM_URL=ws://127.0.0.1
 ZONE_2_2_DOM_URL=ws://127.0.0.1
 
-# Sub websocket urls
+
+# Subordinate websocket urls
+
 PRIME_SUB_URLS=ws://127.0.0.1:8579,ws://127.0.0.1:8581,ws://127.0.0.1:8583
 REGION_0_SUB_URLS=ws://127.0.0.1:8611,ws://127.0.0.1:8643,ws://127.0.0.1:8675
 REGION_1_SUB_URLS=ws://127.0.0.1:8613,ws://127.0.0.1:8645,ws://127.0.0.1:8677
 REGION_2_SUB_URLS=ws://127.0.0.1:8615,ws://127.0.0.1:8647,ws://127.0.0.1:8679
 
-# Slices that are running
+
+# The SLICES variable determines which slices of the network the node will run.
+# The default configuration of 9 slices will run a "global node."
+# Selecting any subset of slices will run either a "multi-slice node" or a "slice node."
+
 SLICES="[0 0],[0 1],[0 2],[1 0],[1 1],[1 2],[2 0],[2 1],[2 2]"
 
-#Boolean Variable Definition
-#Enables or disables http porting
-#Enables or disables websocket porting
-ENABLE_HTTP=true
-ENABLE_WS=true
-ENABLE_UNLOCK=false
-ENABLE_ARCHIVE=false
 
-#Input Variable Definition
-#Network Options include colosseum and garden 
-#http.addr options include 0.0.0.0 and 127.0.0.1 (local host)
-#ws.addr options include 0.0.0.0 and 127.0.0.1 (local host)
-#ws.api options include any blockchain compatible api
+# Boolean Variables
+
+ENABLE_HTTP=true # ENABLE_HTTP enables or disables http API.
+ENABLE_WS=true # ENABLE_WS enables or disables websocket API.
+ENABLE_ARCHIVE=false # ENABLE_ARCHIVE enables or disables running an archive node.
+
+
+# Input Variables
 
 # WARNING: Only allow websocket connections (i.e. WS_ADDR) from a trusted
 # network. At time of writing, no transport security is implemented, but this is
-# a trusted communication channel.
-NETWORK=colosseum
-NONCE=5926993 #Change this along with network
-HTTP_ADDR=localhost
-WS_ADDR=localhost
-WS_API=eth,quai
-HTTP_API=quai
+# a trusted communication channel. 
 
-#Mining Variables
-QUAI_MINING=true
+NETWORK=colosseum # NETWORK options include colosseum (mainnet), garden (testnet), and local.
+NONCE=5926993 # Change this along with network. You will need to input the correct NONCE to join the P2P network.
+HTTP_ADDR=localhost # HTTP_ADDR options include 0.0.0.0 and 127.0.0.1 (local host)
+WS_ADDR=localhost # WS_ADDR options include 0.0.0.0 and 127.0.0.1 (local host)
+WS_API=eth,quai # WS_API and HTTPS_API options include any blockchain compatible API
+HTTP_API=quai 
+ENABLE_NAT=false # ENABLE_NAT should be turned to true if port forwarding is being used.
+# EXT_IP=Optional # EXT_IP should be set to the node's external IP if port forwarding is being used.
+RUN_BLAKE3=false # Turning RUN_BLAKE3 to true allows for BLAKE3 mining to be performed when running a local node.
 
-#Bootnode Specific Variables
-#Should only be used by bootnode operators, i.e. team developers
+
+# Bootnode-Specific Variables
+# Should only be used by bootnode operators, i.e. team developers
+
 HTTP_CORSDOMAIN="*"
 WS_ORIG="*"
 BOOTNODE=false
 CORS=false
 
-# Verbosity variable
-VERBOSITY=4
 
-# Syncmode variable
-SYNCMODE=full
+# Verbosity Variable 
+
+VERBOSITY=4 # Lowers or raises the debug level to print more or less information about the node.
+
+
+# Syncmode Variables
+
+SYNCMODE=full # SYNCMODE specifies what type of syncing the node will perform. Currently, only full syncing is supported.
 NO_DISCOVER=false
 
-# Stats information
-QUAI_STATS=false
-STATS_NAME=
+
+# Stats Information
+
+QUAI_STATS=false # QUAI_STATS determines whether or not the node should be displayed on the node stats page (https://stats.quai.network/).
+STATS_NAME= # If invited, a node can specify the provided STATS_NAME, STATS_PASS, and STATS_HOST to share information to the stats page.
 STATS_PASS=
 STATS_HOST=
 
-# Output format variables
-SHOW_COLORS=true
-RUN_BLAKE3=false
+
+# Database Variable
+
 DB_ENGINE=leveldb
-ENABLE_NAT=false
-# EXT_IP=Optional, enable if you have port forwarding
+
+
+# Output Format Variable
+
+SHOW_COLORS=true


### PR DESCRIPTION
Hello,

Back again with a PR to make things more understandable for users. In this PR I added comments and descriptors for many of the variables, reorganized some of the variables to fit into the correct categories, and removed stale variables (QUAI_MINING and ENABLE_UNLOCK).

If I was mistaken in removing either of the stale variables and they are still in use, please let me know!
