### PR TITLE
Don't drop the peer if received a stale broadcast

### DIFF
--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -711,9 +711,6 @@ func (f *BlockFetcher) ImportBlocks(peer string, block *types.Block, relay bool)
 		maxStaleBroadcastDist = PrimeMaxStaleBroadcastDist
 	}
 	if relay && currentNum > maxStaleBroadcastDist && currentNum > bcastNum+maxStaleBroadcastDist {
-		// The broadcast blocks is stale. Drop the peer.
-		log.Warn("Peer is mining while not synced, dropping peer", "Id", peer)
-		f.dropPeer(peer)
 		return
 	}
 


### PR DESCRIPTION
This dropping of peer is preventing nodes from syncing. If people are mining stale blocks and nodes are syncing, other nodes will drop the node.

@dominant-strategies/core-dev
