### PR TITLE
Supress noisy prints from the Logs

### DIFF
--- a/core/worker.go
+++ b/core/worker.go
@@ -1035,10 +1035,10 @@ func totalFees(block *types.Block, receipts []*types.Receipt) *big.Float {
 }
 
 func (w *worker) CurrentInfo(header *types.Header) bool {
-	if w.headerPrints.Contains(header) {
+	if w.headerPrints.Contains(header.Hash()) {
 		return false
 	}
 
-	w.headerPrints.Add(header, nil)
+	w.headerPrints.Add(header.Hash(), nil)
 	return header.NumberU64()+c_startingPrintLimit > w.hc.CurrentHeader().NumberU64()
 }

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -467,7 +467,7 @@ func (q *queue) reserveHeaders(p *peerConnection, count int, taskPool map[common
 			progress = true
 			delete(taskPool, header.Hash())
 			proc = proc - 1
-			log.Error("Fetch reservation already delivered", "number", header.Number().Uint64())
+			log.Trace("Fetch reservation already delivered", "number", header.Number().Uint64())
 			continue
 		}
 		if throttle {


### PR DESCRIPTION
@dominant-strategies/core-dev

Also this fixes the bug with the CurrentInfo print check, previously we were checking if the header exists, but it should be header hash, because header is a pointer and is different everytime
