### PR TITLE
Removed the cache from the GetHeaderOrCandidate call

### DIFF
--- a/core/bodydb.go
+++ b/core/bodydb.go
@@ -152,10 +152,6 @@ func (bc *BodyDb) GetBlock(hash common.Hash, number uint64) *types.Block {
 	if termini == nil {
 		return nil
 	}
-	// Short circuit if the block's already in the cache, retrieve otherwise
-	if block, ok := bc.blockCache.Get(hash); ok {
-		return block.(*types.Block)
-	}
 	block := rawdb.ReadBlock(bc.db, hash, number)
 	if block == nil {
 		return nil

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -625,10 +625,6 @@ func (hc *HeaderChain) GetHeader(hash common.Hash, number uint64) *types.Header 
 	if termini == nil {
 		return nil
 	}
-	// Short circuit if the header's already in the cache, retrieve otherwise
-	if header, ok := hc.headerCache.Get(hash); ok {
-		return header.(*types.Header)
-	}
 	header := rawdb.ReadHeader(hc.headerDb, hash, number)
 	if header == nil {
 		return nil
@@ -656,10 +652,6 @@ func (hc *HeaderChain) GetHeaderByHash(hash common.Hash) *types.Header {
 // GetHeaderOrCandidate retrieves a block header from the database by hash and number,
 // caching it if found.
 func (hc *HeaderChain) GetHeaderOrCandidate(hash common.Hash, number uint64) *types.Header {
-	// Short circuit if the header's already in the cache, retrieve otherwise
-	if header, ok := hc.headerCache.Get(hash); ok {
-		return header.(*types.Header)
-	}
 	header := rawdb.ReadHeader(hc.headerDb, hash, number)
 	if header == nil {
 		return nil
@@ -859,11 +851,6 @@ func (hc *HeaderChain) GetBlockByNumber(number uint64) *types.Block {
 // GetBody retrieves a block body (transactions and uncles) from the database by
 // hash, caching it if found.
 func (hc *HeaderChain) GetBody(hash common.Hash) *types.Body {
-	// Short circuit if the body's already in the cache, retrieve otherwise
-	if cached, ok := hc.bc.bodyCache.Get(hash); ok {
-		body := cached.(*types.Body)
-		return body
-	}
 	number := hc.GetBlockNumber(hash)
 	if number == nil {
 		return nil


### PR DESCRIPTION
There exists race conditions where once a header is read out of the Cache and it gets evicted from the cache, node sees nil pointer dereference. This was observed many times while testing on Garden environment on slices. (slices will experience this more because the cache alloted for slices is smaller in size to save on RAM usage).

@dominant-strategies/core-dev
