### PR TITLE
Increase coinbase reward for local network

### DIFF
--- a/consensus/blake3pow/consensus.go
+++ b/consensus/blake3pow/consensus.go
@@ -467,6 +467,9 @@ func (blake3pow *Blake3pow) ComputePowLight(header *types.Header) (common.Hash, 
 func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header *types.Header, uncles []*types.Header) {
 	// Select the correct block reward based on chain progression
 	blockReward := misc.CalculateReward(header)
+	if config.ChainID == params.Blake3PowLocalChainConfig.ChainID {
+		blockReward = big.NewInt(1e18)
+	}
 
 	coinbase, err := header.Coinbase().InternalAddress()
 	if err != nil {

--- a/consensus/progpow/consensus.go
+++ b/consensus/progpow/consensus.go
@@ -499,6 +499,9 @@ func (progpow *Progpow) FinalizeAndAssemble(chain consensus.ChainHeaderReader, h
 func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header *types.Header, uncles []*types.Header) {
 	// Select the correct block reward based on chain progression
 	blockReward := misc.CalculateReward(header)
+	if config.ChainID == params.ProgpowLocalChainConfig.ChainID {
+		blockReward = big.NewInt(1e18) // 1 Quai per block in local
+	}
 
 	coinbase, err := header.Coinbase().InternalAddress()
 	if err != nil {


### PR DESCRIPTION
@dominant-strategies/core-dev
This allows developers to run their own local networks and receive Quai quickly (for testing transactions).