### PR TITLE
Better ETX inclusion

### DIFF
--- a/core/types/etx_set.go
+++ b/core/types/etx_set.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/log"
 	"github.com/dominant-strategies/go-quai/params"
 )
 
@@ -36,6 +37,7 @@ func (set *EtxSet) Update(newInboundEtxs Transactions, currentHeight uint64) {
 		availableAtBlock := entry.Height
 		etxExpirationHeight := availableAtBlock + params.EtxExpirationAge
 		if currentHeight > etxExpirationHeight {
+			log.Warn("ETX expired", "hash", txHash, "availableAtBlock", availableAtBlock, "etxExpirationHeight", etxExpirationHeight, "currentHeight", currentHeight)
 			delete(*set, txHash)
 		}
 	}

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -312,7 +312,10 @@ func (tx *Transaction) GasTipCapIntCmp(other *big.Int) int {
 // EffectiveGasTip returns the effective miner gasTipCap for the given base fee.
 // Note: if the effective gasTipCap is negative, this method returns both error
 // the actual negative value, _and_ ErrGasFeeCapTooLow
-func (tx *Transaction) EffectiveGasTip(baseFee *big.Int) (*big.Int, error) {
+func (tx *Transaction) EffectiveGasTip(baseFee *big.Int, gasTipCap bool) (*big.Int, error) {
+	if gasTipCap {
+		return tx.GasTipCap(), nil
+	}
 	if baseFee == nil {
 		return tx.GasTipCap(), nil
 	}
@@ -327,7 +330,7 @@ func (tx *Transaction) EffectiveGasTip(baseFee *big.Int) (*big.Int, error) {
 // EffectiveGasTipValue is identical to EffectiveGasTip, but does not return an
 // error in case the effective gasTipCap is negative
 func (tx *Transaction) EffectiveGasTipValue(baseFee *big.Int) *big.Int {
-	effectiveTip, _ := tx.EffectiveGasTip(baseFee)
+	effectiveTip, _ := tx.EffectiveGasTip(baseFee, true)
 	return effectiveTip
 }
 
@@ -507,7 +510,7 @@ type TxWithMinerFee struct {
 // miner gasTipCap if a base fee is provided.
 // Returns error in case of a negative effective miner gasTipCap.
 func NewTxWithMinerFee(tx *Transaction, baseFee *big.Int) (*TxWithMinerFee, error) {
-	minerFee, err := tx.EffectiveGasTip(baseFee)
+	minerFee, err := tx.EffectiveGasTip(baseFee, true)
 	if err != nil {
 		return nil, err
 	}

--- a/core/worker.go
+++ b/core/worker.go
@@ -1032,7 +1032,7 @@ func copyReceipts(receipts []*types.Receipt) []*types.Receipt {
 func totalFees(block *types.Block, receipts []*types.Receipt) *big.Float {
 	feesWei := new(big.Int)
 	for i, tx := range block.Transactions() {
-		minerFee, _ := tx.EffectiveGasTip(block.BaseFee())
+		minerFee, _ := tx.EffectiveGasTip(block.BaseFee(), false)
 		feesWei.Add(feesWei, new(big.Int).Mul(new(big.Int).SetUint64(receipts[i].GasUsed), minerFee))
 	}
 	return new(big.Float).Quo(new(big.Float).SetInt(feesWei), new(big.Float).SetInt(big.NewInt(params.Ether)))

--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -109,7 +109,7 @@ func (oracle *Oracle) processBlock(bf *blockFees, percentiles []float64) {
 
 	sorter := make(sortGasAndReward, len(bf.block.Transactions()))
 	for i, tx := range bf.block.Transactions() {
-		reward, _ := tx.EffectiveGasTip(bf.block.BaseFee())
+		reward, _ := tx.EffectiveGasTip(bf.block.BaseFee(), false)
 		sorter[i] = txGasAndReward{gasUsed: bf.receipts[i].GasUsed, reward: reward}
 	}
 	sort.Sort(sorter)

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -228,8 +228,8 @@ func (s *txSorter) Swap(i, j int) {
 func (s *txSorter) Less(i, j int) bool {
 	// It's okay to discard the error because a tx would never be
 	// accepted into a block with an invalid effective tip.
-	tip1, _ := s.txs[i].EffectiveGasTip(s.baseFee)
-	tip2, _ := s.txs[j].EffectiveGasTip(s.baseFee)
+	tip1, _ := s.txs[i].EffectiveGasTip(s.baseFee, true)
+	tip2, _ := s.txs[j].EffectiveGasTip(s.baseFee, true)
 	return tip1.Cmp(tip2) < 0
 }
 
@@ -254,7 +254,7 @@ func (oracle *Oracle) getBlockValues(ctx context.Context, signer types.Signer, b
 
 	var prices []*big.Int
 	for _, tx := range sorter.txs {
-		tip, _ := tx.EffectiveGasTip(block.BaseFee())
+		tip, _ := tx.EffectiveGasTip(block.BaseFee(), true)
 		if ignoreUnder != nil && tip.Cmp(ignoreUnder) == -1 {
 			continue
 		}


### PR DESCRIPTION
@dominant-strategies/core-dev
It's possible that the worker could reject an ETX for too low of an 'effective' gas tip, even if the ETX declares a high miner tip and gas price (max fee per gas). This PR replaces the effective gas tip with the declared gas tip in the tx. Also adds logging whenever an ETX is evicted, as this is dangerous and should not happen.