### PR TITLE
bugfix: fix err return and do not set sync target in Prime

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -353,6 +353,7 @@ func (c *Core) SetSyncTarget(header *types.Header) {
 				}
 			}
 		}
+		return
 	}
 	c.syncTarget = header
 }

--- a/internal/quaiapi/quai_api.go
+++ b/internal/quaiapi/quai_api.go
@@ -831,10 +831,11 @@ func (s *PublicBlockChainQuaiAPI) GetPendingEtxsFromSub(ctx context.Context, raw
 	return fields, nil
 }
 
-func (s *PublicBlockChainQuaiAPI) SetSyncTarget(ctx context.Context, raw json.RawMessage) {
+func (s *PublicBlockChainQuaiAPI) SetSyncTarget(ctx context.Context, raw json.RawMessage) error {
 	var header *types.Header
 	if err := json.Unmarshal(raw, &header); err != nil {
-		return
+		return err
 	}
 	s.b.SetSyncTarget(header)
+	return nil
 }


### PR DESCRIPTION
@dominant-strategies/core-dev
```
[33mWARNING[0m[10-20|19:27:22.351] rpc/handler.go:306                       Served quai_setSyncTarget                reqid=2 t=122.353µs err=missing required field 'parentHash' for Header  
```
