### PR TITLE
Adds nil check after chain.CurrentBlock()

### DIFF
--- a/eth/protocols/eth/handler.go
+++ b/eth/protocols/eth/handler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/dominant-strategies/go-quai/core"
 	"github.com/dominant-strategies/go-quai/core/types"
+	"github.com/dominant-strategies/go-quai/log"
 	"github.com/dominant-strategies/go-quai/metrics"
 	"github.com/dominant-strategies/go-quai/p2p"
 	"github.com/dominant-strategies/go-quai/p2p/enode"
@@ -136,6 +137,10 @@ type NodeInfo struct {
 // nodeInfo retrieves some `quai` protocol metadata about the running host node.
 func nodeInfo(chain *core.Core, network uint64) *NodeInfo {
 	head := chain.CurrentBlock()
+	if head == nil {
+		log.Warn("chain.CurrentBlock() returned nil")
+		return nil
+	}
 	return &NodeInfo{
 		Network: network,
 		Entropy: chain.CurrentLogEntropy(),


### PR DESCRIPTION
@dominant-strategies/core-dev

Tested by running local node and forcing head to be nil. Warning was logged and code continued to execute

```
INFO   [10-24|16:06:56.926] WebSocket enabled                        url=ws://127.0.0.1:8611
INFO   [10-24|16:06:56.926] Stats daemon started
WARNING[10-24|16:06:56.926] chain.CurrentBlock() returned nil
WARNING[10-24|16:06:57.990] Error calculating directory sizes:
INFO   [10-24|16:06:58.711] Allocating genesis accounts              num=8160
INFO   [10-24|16:06:58.786] Commit new sealing work                  number=1 sealhash=0x70571b9875fc42310533c7b3d8e5c30946edc25b5869cfd8cbd31b01ad11beb3 uncles=0 txs=0 etxs=0 gas=0 fees=0 elapsed=89.656ms
INFO   [10-24|16:06:59.044] Port mapping found on                    Interface=UPNP IGDv2-IP2
```