### PR TITLE
Bugfixes: EVM timestamp should use parent timestamp, remove unused emittedEtxs, fixed receipt ETX collection

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -126,9 +126,7 @@ func (v *BlockValidator) ValidateState(block *types.Block, statedb *state.StateD
 	var emittedEtxs types.Transactions
 	for _, receipt := range receipts {
 		if receipt.Status == types.ReceiptStatusSuccessful {
-			for _, etx := range receipt.Etxs {
-				emittedEtxs = append(emittedEtxs, etx)
-			}
+			emittedEtxs = append(emittedEtxs, receipt.Etxs...)
 		}
 	}
 	time6 := common.PrettyDuration(time.Since(start))

--- a/core/evm.go
+++ b/core/evm.go
@@ -23,6 +23,8 @@ import (
 	"github.com/dominant-strategies/go-quai/consensus"
 	"github.com/dominant-strategies/go-quai/core/types"
 	"github.com/dominant-strategies/go-quai/core/vm"
+	"github.com/dominant-strategies/go-quai/log"
+	"github.com/dominant-strategies/go-quai/params"
 )
 
 // ChainContext supports retrieving headers and consensus parameters from the
@@ -51,13 +53,24 @@ func NewEVMBlockContext(header *types.Header, chain ChainContext, author *common
 	if header.BaseFee() != nil {
 		baseFee = new(big.Int).Set(header.BaseFee())
 	}
+
+	timestamp := header.Time() // base case, should only be the case in genesis block or before forkBlock (in testnet)
+	if header.Number().Uint64() != 0 && header.Number().Uint64() > params.CarbonForkBlockNumber {
+		parent := chain.GetHeader(header.ParentHash(), header.Number().Uint64()-1)
+		if parent != nil {
+			timestamp = parent.Time()
+		} else {
+			log.Fatal("Parent is nil, panic", "headerHash", header.Hash(), "parentHash", header.ParentHash(), "number", header.Number().Uint64())
+		}
+	}
+
 	return vm.BlockContext{
 		CanTransfer: CanTransfer,
 		Transfer:    Transfer,
 		GetHash:     GetHashFn(header, chain),
 		Coinbase:    beneficiary,
 		BlockNumber: new(big.Int).Set(header.Number()),
-		Time:        new(big.Int).SetUint64(header.Time()),
+		Time:        new(big.Int).SetUint64(timestamp),
 		Difficulty:  new(big.Int).Set(header.Difficulty()),
 		BaseFee:     baseFee,
 		GasLimit:    header.GasLimit(),

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -253,7 +253,6 @@ func (p *StateProcessor) Process(block *types.Block, etxSet types.EtxSet) (types
 		etxPLimit = params.ETXPLimitMin
 	}
 
-	var emittedEtxs types.Transactions
 	for i, tx := range block.Transactions() {
 		startProcess := time.Now()
 		msg, err := tx.AsMessageWithSender(types.MakeSigner(p.config, header.Number()), header.BaseFee(), senders[tx.Hash()])
@@ -294,7 +293,6 @@ func (p *StateProcessor) Process(block *types.Block, etxSet types.EtxSet) (types
 			if err != nil {
 				return nil, nil, nil, 0, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
 			}
-			emittedEtxs = append(emittedEtxs, receipt.Etxs...)
 			timeTxDelta := time.Since(startTimeTx)
 			timeTx += timeTxDelta
 		} else {


### PR DESCRIPTION
@dominant-strategies/core-dev
Block to change timestamp in EVM is block 690000 across all zones.