### PR TITLE
(feat) modify create opcode to grind address

### DIFF
--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -138,6 +138,8 @@ const (
 
 	// The Refund Quotient is the cap on how much of the used gas can be refunded
 	RefundQuotient uint64 = 5
+
+	MaxAddressGrindAttempts int = 1000 // Maximum number of attempts to grind an address to a valid one
 )
 
 var (


### PR DESCRIPTION
@dominant-strategies/core-dev

napkin math:
my contract to deploy a QRC20 has 4783 bytes and a wordCount of 150.
if we decide to let CREATE grind the address, this QRC20 would take 930 gas per grind. on average with a prefix range for 9 shards this would take 8370 gas. our prefix range will begin with 255 shards so this will on average take 237150 gas come mainnet.