### PR TITLE
Bugfixes: No errors on precompile, proper translation, proper initialization

### DIFF
--- a/cmd/go-quai/config.go
+++ b/cmd/go-quai/config.go
@@ -27,8 +27,6 @@ import (
 	"gopkg.in/urfave/cli.v1"
 
 	"github.com/dominant-strategies/go-quai/cmd/utils"
-	"github.com/dominant-strategies/go-quai/common"
-	"github.com/dominant-strategies/go-quai/core/vm"
 	"github.com/dominant-strategies/go-quai/eth/ethconfig"
 	"github.com/dominant-strategies/go-quai/internal/quaiapi"
 	"github.com/dominant-strategies/go-quai/log"
@@ -118,7 +116,6 @@ func defaultNodeConfig(ctx *cli.Context) node.Config {
 
 // makeConfigNode loads quai configuration and creates a blank node instance.
 func makeConfigNode(ctx *cli.Context) (*node.Node, quaiConfig) {
-	nodeCtx := common.NodeLocation.Context()
 	// Load defaults.
 	cfg := quaiConfig{
 		Eth:     ethconfig.Defaults,
@@ -145,10 +142,6 @@ func makeConfigNode(ctx *cli.Context) (*node.Node, quaiConfig) {
 		cfg.Ethstats.URL = ctx.GlobalString(utils.QuaiStatsURLFlag.Name)
 	}
 	applyMetricConfig(ctx, &cfg)
-	// Onlt initialize the precompile for the zone chain
-	if nodeCtx == common.ZONE_CTX {
-		vm.InitializePrecompiles()
-	}
 	return stack, cfg
 }
 

--- a/core/bodydb.go
+++ b/core/bodydb.go
@@ -76,6 +76,7 @@ func NewBodyDb(db ethdb.Database, engine consensus.Engine, hc *HeaderChain, chai
 	// only start the state processor in zone
 	if nodeCtx == common.ZONE_CTX && bc.ProcessingState() {
 		bc.processor = NewStateProcessor(chainConfig, hc, engine, vmConfig, cacheConfig, txLookupLimit)
+		vm.InitializePrecompiles()
 	}
 
 	return bc, nil

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -42,15 +42,15 @@ type PrecompiledContract interface {
 }
 
 var TranslatedAddresses = map[common.AddressBytes]int{
-	common.AddressBytes([20]byte{1}): 0,
-	common.AddressBytes([20]byte{2}): 1,
-	common.AddressBytes([20]byte{3}): 2,
-	common.AddressBytes([20]byte{4}): 3,
-	common.AddressBytes([20]byte{5}): 4,
-	common.AddressBytes([20]byte{6}): 5,
-	common.AddressBytes([20]byte{7}): 6,
-	common.AddressBytes([20]byte{8}): 7,
-	common.AddressBytes([20]byte{9}): 8,
+	common.AddressBytes(intToByteArray20(1)): 0,
+	common.AddressBytes(intToByteArray20(2)): 1,
+	common.AddressBytes(intToByteArray20(3)): 2,
+	common.AddressBytes(intToByteArray20(4)): 3,
+	common.AddressBytes(intToByteArray20(5)): 4,
+	common.AddressBytes(intToByteArray20(6)): 5,
+	common.AddressBytes(intToByteArray20(7)): 6,
+	common.AddressBytes(intToByteArray20(8)): 7,
+	common.AddressBytes(intToByteArray20(9)): 8,
 }
 
 var (
@@ -593,4 +593,10 @@ func (c *blake2F) Run(input []byte) ([]byte, error) {
 		binary.LittleEndian.PutUint64(output[offset:offset+8], h[i])
 	}
 	return output, nil
+}
+
+func intToByteArray20(n uint8) [20]byte {
+	var byteArray [20]byte
+	byteArray[19] = byte(n) // Use the last byte for the integer
+	return byteArray
 }

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -45,6 +45,9 @@ type (
 )
 
 func (evm *EVM) precompile(addr common.Address) (PrecompiledContract, bool, common.Address) {
+	if evm.Context.BlockNumber.Uint64() <= params.CarbonForkBlockNumber { // no precompiles before the fork
+		return nil, false, addr
+	}
 	if index, ok := TranslatedAddresses[addr.Bytes20()]; ok {
 		addr = PrecompiledAddresses[common.NodeLocation.Name()][index]
 	}

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -694,6 +694,8 @@ func opCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 	if err == nil || err == ErrExecutionReverted {
 		ret = common.CopyBytes(ret)
 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
+	} else if err == common.ErrInvalidScope && interpreter.evm.Context.BlockNumber.Uint64() > params.CarbonForkBlockNumber {
+		return nil, err
 	}
 	scope.Contract.Gas += returnGas
 
@@ -710,7 +712,7 @@ func opCallCode(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 	addr, value, inOffset, inSize, retOffset, retSize := stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop()
 	toAddr := common.Bytes20ToAddress(addr.Bytes20())
 	// Check if address is in proper context
-	if !common.IsInChainScope(toAddr.Bytes()) { // checked here because the error returned from CallCode is not returned from this function
+	if !common.IsInChainScope(toAddr.Bytes()) && interpreter.evm.Context.BlockNumber.Uint64() <= params.CarbonForkBlockNumber {
 		return nil, common.ErrInvalidScope
 	}
 	// Get arguments from the memory.
@@ -733,6 +735,8 @@ func opCallCode(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 	if err == nil || err == ErrExecutionReverted {
 		ret = common.CopyBytes(ret)
 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
+	} else if err == common.ErrInvalidScope && interpreter.evm.Context.BlockNumber.Uint64() > params.CarbonForkBlockNumber {
+		return nil, err
 	}
 	scope.Contract.Gas += returnGas
 
@@ -749,7 +753,7 @@ func opDelegateCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 	addr, inOffset, inSize, retOffset, retSize := stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop()
 	toAddr := common.Bytes20ToAddress(addr.Bytes20())
 	// Check if address is in proper context
-	if !common.IsInChainScope(toAddr.Bytes()) {
+	if !common.IsInChainScope(toAddr.Bytes()) && interpreter.evm.Context.BlockNumber.Uint64() <= params.CarbonForkBlockNumber {
 		return nil, common.ErrInvalidScope
 	}
 	// Get arguments from the memory.
@@ -765,6 +769,8 @@ func opDelegateCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 	if err == nil || err == ErrExecutionReverted {
 		ret = common.CopyBytes(ret)
 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
+	} else if err == common.ErrInvalidScope && interpreter.evm.Context.BlockNumber.Uint64() > params.CarbonForkBlockNumber {
+		return nil, err
 	}
 	scope.Contract.Gas += returnGas
 
@@ -781,7 +787,7 @@ func opStaticCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) 
 	addr, inOffset, inSize, retOffset, retSize := stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop()
 	toAddr := common.Bytes20ToAddress(addr.Bytes20())
 	// Check if address is in proper context
-	if !common.IsInChainScope(toAddr.Bytes()) {
+	if !common.IsInChainScope(toAddr.Bytes()) && interpreter.evm.Context.BlockNumber.Uint64() <= params.CarbonForkBlockNumber {
 		return nil, common.ErrInvalidScope
 	}
 	// Get arguments from the memory.
@@ -797,6 +803,8 @@ func opStaticCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) 
 	if err == nil || err == ErrExecutionReverted {
 		ret = common.CopyBytes(ret)
 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
+	} else if err == common.ErrInvalidScope && interpreter.evm.Context.BlockNumber.Uint64() > params.CarbonForkBlockNumber {
+		return nil, err
 	}
 	scope.Contract.Gas += returnGas
 


### PR DESCRIPTION
There are several issues with precompiles that are fixed in this PR.

1. StaticCall and DelegateCall returned out of scope errors on precompile addresses that are called before they are translated to in-scope addresses.
2. Precompile addresses generated by Solidity were not properly translated to in-scope precompiles
3. The precompiles were not properly initialized when the node starts up because the NodeLocation was empty.

@dominant-strategies/core-dev
