### PR TITLE
Still keep eth namespace support for filter API

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -281,6 +281,11 @@ func (s *Quai) APIs() []rpc.API {
 			Service:   NewPrivateMinerAPI(s),
 			Public:    false,
 		}, {
+			Namespace: "eth",
+			Version:   "1.0",
+			Service:   filters.NewPublicFilterAPI(s.APIBackend, false, 5*time.Minute),
+			Public:    true,
+		}, {
 			Namespace: "quai",
 			Version:   "1.0",
 			Service:   filters.NewPublicFilterAPI(s.APIBackend, false, 5*time.Minute),

--- a/quaiclient/ethclient/ethclient.go
+++ b/quaiclient/ethclient/ethclient.go
@@ -402,49 +402,6 @@ func (ec *Client) NonceAt(ctx context.Context, account common.Address, blockNumb
 	return uint64(result), err
 }
 
-// Filters
-
-// FilterLogs executes a filter query.
-func (ec *Client) FilterLogs(ctx context.Context, q quai.FilterQuery) ([]types.Log, error) {
-	var result []types.Log
-	arg, err := toFilterArg(q)
-	if err != nil {
-		return nil, err
-	}
-	err = ec.c.CallContext(ctx, &result, "quai_getLogs", arg)
-	return result, err
-}
-
-// SubscribeFilterLogs subscribes to the results of a streaming filter query.
-func (ec *Client) SubscribeFilterLogs(ctx context.Context, q quai.FilterQuery, ch chan<- types.Log) (quai.Subscription, error) {
-	arg, err := toFilterArg(q)
-	if err != nil {
-		return nil, err
-	}
-	return ec.c.EthSubscribe(ctx, ch, "logs", arg)
-}
-
-func toFilterArg(q quai.FilterQuery) (interface{}, error) {
-	arg := map[string]interface{}{
-		"address": q.Addresses,
-		"topics":  q.Topics,
-	}
-	if q.BlockHash != nil {
-		arg["blockHash"] = *q.BlockHash
-		if q.FromBlock != nil || q.ToBlock != nil {
-			return nil, fmt.Errorf("cannot specify both BlockHash and FromBlock/ToBlock")
-		}
-	} else {
-		if q.FromBlock == nil {
-			arg["fromBlock"] = "0x0"
-		} else {
-			arg["fromBlock"] = toBlockNumArg(q.FromBlock)
-		}
-		arg["toBlock"] = toBlockNumArg(q.ToBlock)
-	}
-	return arg, nil
-}
-
 // Pending State
 
 // PendingBalanceAt returns the wei balance of the given account in the pending state.

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -411,6 +411,11 @@ func (c *Client) EthSubscribe(ctx context.Context, channel interface{}, args ...
 	return c.Subscribe(ctx, "eth", channel, args...)
 }
 
+// QuaiSubscribe registers a subscripion under the "eth" namespace.
+func (c *Client) QuaiSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (*ClientSubscription, error) {
+	return c.Subscribe(ctx, "quai", channel, args...)
+}
+
 // ShhSubscribe registers a subscripion under the "shh" namespace.
 // Deprecated: use Subscribe(ctx, "shh", ...).
 func (c *Client) ShhSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (*ClientSubscription, error) {


### PR DESCRIPTION
@dominant-strategies/core-dev
