### PR TITLE
Zero address is now a context-dependent function for external transactions

### DIFF
--- a/common/address.go
+++ b/common/address.go
@@ -149,7 +149,7 @@ func (a Address) Format(s fmt.State, c rune) {
 // MarshalText returns the hex representation of a.
 func (a Address) MarshalText() ([]byte, error) {
 	if a.inner == nil {
-		return hexutil.Bytes(ZeroInternal[:]).MarshalText()
+		return hexutil.Bytes(ZeroExternal[:]).MarshalText()
 	}
 	return a.inner.MarshalText()
 }
@@ -167,7 +167,7 @@ func (a *Address) UnmarshalText(input []byte) error {
 // MarshalJSON marshals a subscription as its ID.
 func (a *Address) MarshalJSON() ([]byte, error) {
 	if a.inner == nil {
-		return json.Marshal(ZeroAddr)
+		return json.Marshal(Zero)
 	}
 	return json.Marshal(a.inner)
 }
@@ -177,7 +177,7 @@ func (a *Address) UnmarshalJSON(input []byte) error {
 	var temp [AddressLength]byte
 	if err := hexutil.UnmarshalFixedJSON(reflect.TypeOf(InternalAddress{}), input, temp[:]); err != nil {
 		if len(input) == 0 {
-			a.inner = Bytes20ToAddress(ZeroInternal).inner
+			a.inner = Bytes20ToAddress(ZeroExternal).inner
 			return nil
 		}
 		return err

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -266,7 +266,7 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 	head.SetTime(g.Timestamp)
 	head.SetExtra(g.ExtraData)
 	head.SetDifficulty(g.Difficulty)
-	head.SetCoinbase(common.ZeroAddr)
+	head.SetCoinbase(common.ZeroAddr())
 	head.SetGasLimit(g.GasLimit)
 	head.SetGasUsed(0)
 	head.SetBaseFee(new(big.Int).SetUint64(params.InitialBaseFee))

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -276,7 +276,7 @@ func (p *StateProcessor) Process(block *types.Block, etxSet types.EtxSet) (types
 			}
 			prevZeroBal := prepareApplyETX(statedb, &etxEntry.ETX)
 			receipt, err = applyTransaction(msg, p.config, p.hc, nil, gp, statedb, blockNumber, blockHash, &etxEntry.ETX, usedGas, vmenv, &etxRLimit, &etxPLimit)
-			statedb.SetBalance(common.ZeroInternal, prevZeroBal) // Reset the balance to what it previously was. Residual balance will be lost
+			statedb.SetBalance(common.ZeroInternal(), prevZeroBal) // Reset the balance to what it previously was. Residual balance will be lost
 
 			if err != nil {
 				return nil, nil, nil, 0, fmt.Errorf("could not apply tx %d [%v]: %w", i, etxEntry.ETX.Hash().Hex(), err)
@@ -454,7 +454,7 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 	if tx.Type() == types.ExternalTxType {
 		prevZeroBal := prepareApplyETX(statedb, tx)
 		receipt, err := applyTransaction(msg, config, bc, author, gp, statedb, header.Number(), header.Hash(), tx, usedGas, vmenv, etxRLimit, etxPLimit)
-		statedb.SetBalance(common.ZeroInternal, prevZeroBal) // Reset the balance to what it previously was (currently a failed external transaction removes all the sent coins from the supply and any residual balance is gone as well)
+		statedb.SetBalance(common.ZeroInternal(), prevZeroBal) // Reset the balance to what it previously was (currently a failed external transaction removes all the sent coins from the supply and any residual balance is gone as well)
 		return receipt, err
 	}
 	return applyTransaction(msg, config, bc, author, gp, statedb, header.Number(), header.Hash(), tx, usedGas, vmenv, etxRLimit, etxPLimit)
@@ -736,10 +736,10 @@ func (p *StateProcessor) Stop() {
 }
 
 func prepareApplyETX(statedb *state.StateDB, tx *types.Transaction) *big.Int {
-	prevZeroBal := statedb.GetBalance(common.ZeroInternal)   // Get current zero address balance
+	prevZeroBal := statedb.GetBalance(common.ZeroInternal()) // Get current zero address balance
 	fee := big.NewInt(0).Add(tx.GasFeeCap(), tx.GasTipCap()) // Add gas price cap to miner tip cap
 	fee.Mul(fee, big.NewInt(int64(tx.Gas())))                // Multiply gas price by gas limit (may need to check for int64 overflow)
 	total := big.NewInt(0).Add(fee, tx.Value())              // Add gas fee to value
-	statedb.SetBalance(common.ZeroInternal, total)           // Use zero address at temp placeholder and set it to gas fee plus value
+	statedb.SetBalance(common.ZeroInternal(), total)         // Use zero address at temp placeholder and set it to gas fee plus value
 	return prevZeroBal
 }

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -192,7 +192,7 @@ func ApplyMessage(evm *vm.EVM, msg Message, gp *GasPool) (*ExecutionResult, erro
 // to returns the recipient of the message.
 func (st *StateTransition) to() common.Address {
 	if st.msg == nil || st.msg.To() == nil /* contract creation */ {
-		return common.ZeroAddr
+		return common.ZeroAddr()
 	}
 	return *st.msg.To()
 }
@@ -299,7 +299,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	}
 	msg := st.msg
 	sender := vm.AccountRef(msg.From())
-	contractCreation := msg.To() == nil
+	contractCreation := msg.To() == nil // for ETX contract creation, perhaps we should compare the "to" to the contextual zero-address
 
 	// Check clauses 4-5, subtract intrinsic gas if everything is correct
 	gas, err := IntrinsicGas(st.data, st.msg.AccessList(), contractCreation)

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -693,7 +693,7 @@ func (tx *Transaction) AsMessage(s Signer, baseFee *big.Int) (Message, error) {
 	}
 	var err error
 	if tx.Type() == ExternalTxType {
-		msg.from = common.ZeroAddr
+		msg.from = common.ZeroAddr()
 		msg.etxsender, err = Sender(s, tx)
 		msg.checkNonce = false
 	} else {
@@ -730,7 +730,7 @@ func (tx *Transaction) AsMessageWithSender(s Signer, baseFee *big.Int, sender *c
 	}
 	var err error
 	if tx.Type() == ExternalTxType {
-		msg.from = common.ZeroAddr
+		msg.from = common.ZeroAddr()
 		msg.etxsender, err = Sender(s, tx)
 		msg.checkNonce = false
 	} else {

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -118,7 +118,7 @@ func Sender(signer Signer, tx *Transaction) (common.Address, error) {
 
 	addr, err := signer.Sender(tx)
 	if err != nil {
-		return common.ZeroAddr, err
+		return common.Zero, err
 	}
 	tx.from.Store(sigCache{signer: signer, from: addr})
 	return addr, nil
@@ -170,7 +170,7 @@ func (s SignerV1) Sender(tx *Transaction) (common.Address, error) {
 	// id, add 27 to become equivalent to unprotected signatures.
 	V = new(big.Int).Add(V, big.NewInt(27))
 	if tx.ChainId().Cmp(s.chainId) != 0 {
-		return common.ZeroAddr, ErrInvalidChainId
+		return common.Zero, ErrInvalidChainId
 	}
 	return recoverPlain(s.Hash(tx), R, S, V)
 }
@@ -257,7 +257,7 @@ func decodeSignature(sig []byte) (r, s, v *big.Int) {
 
 func recoverPlain(sighash common.Hash, R, S, Vb *big.Int) (common.Address, error) {
 	if Vb.BitLen() > 8 {
-		return common.ZeroAddr, ErrInvalidSig
+		return common.Zero, ErrInvalidSig
 	}
 	V := byte(Vb.Uint64() - 27)
 	if !crypto.ValidateSignatureValues(V, R, S) {
@@ -272,10 +272,10 @@ func recoverPlain(sighash common.Hash, R, S, Vb *big.Int) (common.Address, error
 	// recover the public key from the signature
 	pub, err := crypto.Ecrecover(sighash[:], sig)
 	if err != nil {
-		return common.ZeroAddr, err
+		return common.Zero, err
 	}
 	if len(pub) == 0 || pub[0] != 4 {
-		return common.ZeroAddr, errors.New("invalid public key")
+		return common.Zero, errors.New("invalid public key")
 	}
 	addr := common.BytesToAddress(crypto.Keccak256(pub[1:])[12:])
 	return addr, nil

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -407,7 +407,7 @@ func (c *codeAndHash) Hash() common.Hash {
 func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64, value *big.Int, address common.Address) ([]byte, common.Address, uint64, error) {
 	internalCallerAddr, err := caller.Address().InternalAddress()
 	if err != nil {
-		return nil, common.ZeroAddr, 0, err
+		return nil, common.Zero, 0, err
 	}
 	nonce := evm.StateDB.GetNonce(internalCallerAddr)
 	evm.StateDB.SetNonce(internalCallerAddr, nonce+1)
@@ -415,15 +415,15 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 	// Depth check execution. Fail if we're trying to execute above the
 	// limit.
 	if evm.depth > int(params.CallCreateDepth) {
-		return nil, common.ZeroAddr, gas, ErrDepth
+		return nil, common.Zero, gas, ErrDepth
 	}
 	if !evm.Context.CanTransfer(evm.StateDB, caller.Address(), value) {
-		return nil, common.ZeroAddr, gas, ErrInsufficientBalance
+		return nil, common.Zero, gas, ErrInsufficientBalance
 	}
 
 	internalContractAddr, err := address.InternalAddress()
 	if err != nil {
-		return nil, common.ZeroAddr, 0, err
+		return nil, common.Zero, 0, err
 	}
 
 	// We add this to the access list _before_ taking a snapshot. Even if the creation fails,
@@ -433,7 +433,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 	// Ensure there's no existing contract already at the designated address
 	contractHash := evm.StateDB.GetCodeHash(internalContractAddr)
 	if evm.StateDB.GetNonce(internalContractAddr) != 0 || (contractHash != (common.Hash{}) && contractHash != emptyCodeHash) {
-		return nil, common.ZeroAddr, 0, ErrContractAddressCollision
+		return nil, common.Zero, 0, ErrContractAddressCollision
 	}
 	// Create a new account on the state
 	snapshot := evm.StateDB.Snapshot()
@@ -442,7 +442,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 	evm.StateDB.SetNonce(internalContractAddr, 1)
 
 	if err := evm.Context.Transfer(evm.StateDB, caller.Address(), address, value); err != nil {
-		return nil, common.ZeroAddr, 0, err
+		return nil, common.Zero, 0, err
 	}
 
 	// Initialise a new contract and set the code that is to be used by the EVM.
@@ -504,7 +504,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 func (evm *EVM) Create(caller ContractRef, code []byte, gas uint64, value *big.Int) (ret []byte, contractAddr common.Address, leftOverGas uint64, err error) {
 	internalAddr, err := caller.Address().InternalAddress()
 	if err != nil {
-		return nil, common.ZeroAddr, 0, err
+		return nil, common.Zero, 0, err
 	}
 
 	nonce := evm.StateDB.GetNonce(internalAddr)
@@ -519,13 +519,13 @@ func (evm *EVM) Create(caller ContractRef, code []byte, gas uint64, value *big.I
 	// Calculate the gas required for the keccak256 computation of the input data.
 	gasCost, err := calculateKeccakGas(code)
 	if err != nil {
-		return nil, common.ZeroAddr, 0, err
+		return nil, common.Zero, 0, err
 	}
 
 	// attempt to grind the address
 	contractAddr, remainingGas, err := evm.attemptGrindContractCreation(caller, nonce, gas, gasCost, code)
 	if err != nil {
-		return nil, common.ZeroAddr, 0, err
+		return nil, common.Zero, 0, err
 	}
 
 	gas = remainingGas
@@ -557,7 +557,7 @@ func (evm *EVM) attemptGrindContractCreation(caller ContractRef, nonce uint64, g
 
 		// Check if there is enough gas left to continue.
 		if gas < uint64(gasCost) {
-			return common.ZeroAddr, 0, fmt.Errorf("out of gas grinding contract address for %v", caller.Address().Hex())
+			return common.Zero, 0, fmt.Errorf("out of gas grinding contract address for %v", caller.Address().Hex())
 		}
 
 		// Subtract the gas cost for each attempt.
@@ -575,7 +575,7 @@ func (evm *EVM) attemptGrindContractCreation(caller ContractRef, nonce uint64, g
 		}
 	}
 	// Return an error if a valid address could not be found after the maximum number of attempts.
-	return common.ZeroAddr, 0, fmt.Errorf("exceeded number of attempts grinding address %v", caller.Address().Hex())
+	return common.Zero, 0, fmt.Errorf("exceeded number of attempts grinding address %v", caller.Address().Hex())
 }
 
 // Create2 creates a new contract using code as deployment code.

--- a/core/worker.go
+++ b/core/worker.go
@@ -479,7 +479,7 @@ func (w *worker) GeneratePendingHeader(block *types.Block, fill bool) (*types.He
 	start := time.Now()
 	// Set the coinbase if the worker is running or it's required
 	var coinbase common.Address
-	if w.coinbase.Equal(common.ZeroAddr) {
+	if w.coinbase.Equal(common.Zero) {
 		log.Error("Refusing to mine without etherbase")
 		return nil, errors.New("etherbase not found")
 	}
@@ -810,7 +810,7 @@ func (w *worker) prepareWork(genParams *generateParams, block *types.Block) (*en
 		header.SetExtra(w.extra)
 		header.SetBaseFee(misc.CalcBaseFee(w.chainConfig, parent.Header()))
 		if w.isRunning() {
-			if w.coinbase.Equal(common.ZeroAddr) {
+			if w.coinbase.Equal(common.Zero) {
 				log.Error("Refusing to mine without etherbase")
 				return nil, errors.New("refusing to mine without etherbase")
 			}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -317,11 +317,11 @@ func (s *Quai) Etherbase() (eb common.Address, err error) {
 	etherbase := s.etherbase
 	s.lock.RUnlock()
 
-	if !etherbase.Equal(common.ZeroAddr) {
+	if !etherbase.Equal(common.Zero) {
 		return etherbase, nil
 	}
 
-	return common.ZeroAddr, fmt.Errorf("etherbase must be explicitly specified")
+	return common.Zero, fmt.Errorf("etherbase must be explicitly specified")
 }
 
 // isLocalBlock checks whether the specified block is mined

--- a/internal/quaiapi/api.go
+++ b/internal/quaiapi/api.go
@@ -1423,7 +1423,7 @@ func (s *PublicTransactionPoolAPI) GetTransactionReceipt(ctx context.Context, ha
 		fields["logs"] = [][]*types.Log{}
 	}
 	// If the ContractAddress is 20 0x0 bytes, assume it is not a contract creation
-	if !receipt.ContractAddress.Equal(common.ZeroAddr) {
+	if !receipt.ContractAddress.Equal(common.Zero) {
 		fields["contractAddress"] = receipt.ContractAddress
 	}
 	return fields, nil

--- a/internal/quaiapi/transaction_args.go
+++ b/internal/quaiapi/transaction_args.go
@@ -56,7 +56,7 @@ type TransactionArgs struct {
 // from retrieves the transaction sender address.
 func (arg *TransactionArgs) from() common.Address {
 	if arg.From == nil {
-		return common.ZeroAddr
+		return common.ZeroAddr() // I am unsure about this
 	}
 	return *arg.From
 }

--- a/quaiclient/ethclient/ethclient.go
+++ b/quaiclient/ethclient/ethclient.go
@@ -265,10 +265,10 @@ func (ec *Client) TransactionSender(ctx context.Context, tx *types.Transaction, 
 		From common.Address
 	}
 	if err = ec.c.CallContext(ctx, &meta, "eth_getTransactionByBlockHashAndIndex", block, hexutil.Uint64(index)); err != nil {
-		return common.ZeroAddr, err
+		return common.Zero, err
 	}
 	if meta.Hash == (common.Hash{}) || meta.Hash != tx.Hash() {
-		return common.ZeroAddr, errors.New("wrong inclusion block/index")
+		return common.Zero, errors.New("wrong inclusion block/index")
 	}
 	return meta.From, nil
 }

--- a/quaiclient/ethclient/signer.go
+++ b/quaiclient/ethclient/signer.go
@@ -46,7 +46,7 @@ func (s *senderFromServer) Equal(other types.Signer) bool {
 
 func (s *senderFromServer) Sender(tx *types.Transaction) (common.Address, error) {
 	if s.blockhash == (common.Hash{}) {
-		return common.ZeroAddr, errNotCached
+		return common.Zero, errNotCached
 	}
 	return s.addr, nil
 }


### PR DESCRIPTION
This is a first draft of making the "zero" address context dependent for ETXs. ETXs are spent from the "zero" address. The addresses were taken from contracts.go but might not comply with QIP2. Please review and suggest proper zero-addresses if necessary. Also, because it is no longer actually zero, perhaps the word "zero address" is overloaded.

@dominant-strategies/core-dev
