### PR TITLE
Bugfix: Estimate Gas for InternalToExternal Tx

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1040,6 +1040,10 @@ func (pool *TxPool) addTxs(txs []*types.Transaction, local, sync bool) []error {
 				errs[i] = err
 			}
 			continue
+		} else if tx.Type() == types.InternalToExternalTxType && tx.To() == nil {
+			errs[i] = errors.New("to address is nil in InternalToExternalTx") // remove this check when InternalToExternalTx is removed
+			invalidTxMeter.Add(1)
+			continue
 		}
 		if tx.To().IsInQiLedgerScope() {
 			errs[i] = common.MakeErrQiAddress(tx.To().Hex())
@@ -1069,12 +1073,6 @@ func (pool *TxPool) addTxs(txs []*types.Transaction, local, sync bool) []error {
 			_, err = from.InternalAndQuaiAddress()
 			if err != nil {
 				errs[i] = err
-				invalidTxMeter.Add(1)
-				continue
-			}
-			_, err = types.Sender(pool.signer, tx)
-			if err != nil {
-				errs[i] = ErrInvalidSender
 				invalidTxMeter.Add(1)
 				continue
 			}

--- a/internal/quaiapi/quai_api.go
+++ b/internal/quaiapi/quai_api.go
@@ -30,6 +30,7 @@ import (
 	"github.com/dominant-strategies/go-quai/core/types"
 	"github.com/dominant-strategies/go-quai/crypto"
 	"github.com/dominant-strategies/go-quai/log"
+	"github.com/dominant-strategies/go-quai/params"
 	"github.com/dominant-strategies/go-quai/rpc"
 	"github.com/dominant-strategies/go-quai/trie"
 )
@@ -445,7 +446,14 @@ func (s *PublicBlockChainQuaiAPI) EstimateGas(ctx context.Context, args Transact
 	switch args.TxType {
 	case types.QiTxType:
 		return args.CalculateQiTxGas()
-	case types.InternalTxType, types.ExternalTxType, types.InternalToExternalTxType:
+	case types.InternalToExternalTxType:
+		if args.To == nil {
+			return 0, errors.New("to address is required for internal to external transaction")
+		} else if _, err := args.To.InternalAndQuaiAddress(); err != nil {
+			return 0, err
+		}
+		return hexutil.Uint64(params.TxGas + params.ETXGas), nil
+	case types.InternalTxType:
 		return DoEstimateGas(ctx, s.b, args, bNrOrHash, s.b.RPCGasCap())
 	default:
 		return 0, errors.New("unsupported tx type")


### PR DESCRIPTION
And InternalToExternal Tx to must not be nil
Also, estimate gas for ExternalTx will return an error. Instead, the caller should estimate gas as an internal tx on the destination chain.

@dominant-strategies/core-dev
