### PR TITLE
Propagation hooks

### DIFF
--- a/p2p/node/api.go
+++ b/p2p/node/api.go
@@ -65,6 +65,7 @@ func (p *P2PNode) Broadcast(location common.Location, data interface{}) error {
 
 func (p *P2PNode) SetConsensusBackend(be quai.ConsensusAPI) {
 	p.consensus = be
+	p.pubsub.SetQuaiBackend(be)
 }
 
 type stopFunc func() error

--- a/p2p/protocol/interface.go
+++ b/p2p/protocol/interface.go
@@ -4,8 +4,8 @@ import (
 	"math/big"
 
 	"github.com/libp2p/go-libp2p/core/host"
-	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/dominant-strategies/go-quai/core/types"

--- a/quai/interface.go
+++ b/quai/interface.go
@@ -1,13 +1,16 @@
 package quai
 
 import (
+	"context"
 	"math/big"
 
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/dominant-strategies/go-quai/core/types"
 
 	"github.com/dominant-strategies/go-quai/trie"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core"
+	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 // The consensus backend will implement the following interface to provide information to the networking backend.
@@ -19,6 +22,9 @@ type ConsensusAPI interface {
 	// Specify the peer which propagated the data to us, as well as the data itself.
 	// Return true if this data should be relayed to peers. False if it should be ignored.
 	OnNewBroadcast(core.PeerID, interface{}, common.Location) bool
+
+	// Creates the function that will be used to determine if a message should be propagated.
+	ValidatorFunc() func(ctx context.Context, id peer.ID, msg *pubsub.Message) pubsub.ValidationResult
 
 	// Asks the consensus backend to lookup a block by hash and location.
 	// If the block is found, it should be returned. Otherwise, nil should be returned.

--- a/quai/p2p_backend.go
+++ b/quai/p2p_backend.go
@@ -11,6 +11,8 @@ import (
 	"github.com/dominant-strategies/go-quai/p2p"
 	"github.com/dominant-strategies/go-quai/rpc"
 	"github.com/dominant-strategies/go-quai/trie"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 // QuaiBackend implements the quai consensus protocol
@@ -112,6 +114,29 @@ func (qbe *QuaiBackend) GetTrieNode(hash common.Hash, location common.Location) 
 func (qbe *QuaiBackend) GetHeight(location common.Location) uint64 {
 	// Example/mock implementation
 	panic("todo")
+}
+
+func (qbe *QuaiBackend) ValidatorFunc() func(ctx context.Context, id p2p.PeerID, msg *pubsub.Message) pubsub.ValidationResult {
+	return func(ctx context.Context, id peer.ID, msg *pubsub.Message) pubsub.ValidationResult {
+		var data interface{}
+		data = msg.Message.GetData()
+		switch data.(type) {
+		case types.Block:
+			block := data.(types.Block)
+			backend := *qbe.GetBackend(block.Location())
+			if backend == nil {
+				log.Global.WithFields(log.Fields{
+					"peer":     id,
+					"hash":     block.Hash(),
+					"location": block.Location(),
+				}).Error("no backend found for this location")
+				return pubsub.ValidationReject
+			}
+		case types.Transaction:
+			return pubsub.ValidationAccept
+		}
+		return pubsub.ValidationAccept
+	}
 }
 
 func (qbe *QuaiBackend) LookupBlock(hash common.Hash, location common.Location) *types.Block {


### PR DESCRIPTION
@dominant-strategies/core-dev
These are stubs for validation of:

blocks
transactions
Anything that gets ValidationReject will not only not re-propagate to peers, but will also not be sent to consensus. Suggest quick validation of things without excessive processing.