### PR TITLE
Qi Address Scope Check

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -533,6 +533,8 @@ func AddGenesisUtxos(state *state.StateDB, nodeLocation common.Location, logger 
 			Denomination: uint8(utxo.Denomination),
 		}
 
-		state.CreateUTXO(hash, uint16(utxo.Index), newUtxo)
+		if err := state.CreateUTXO(hash, uint16(utxo.Index), newUtxo); err != nil {
+			panic(fmt.Sprintf("Failed to create genesis UTXO: %v", err))
+		}
 	}
 }


### PR DESCRIPTION
@dominant-strategies/core-dev
I am quite sure the check is redundant, but check if an address is in Qi ledger scope and internal shard scope before adding new utxo to set.
https://github.com/dominant-strategies/go-quai/issues/1400