### PR TITLE
stats for chi and external transactions

### DIFF
--- a/quaistats/quaistats.go
+++ b/quaistats/quaistats.go
@@ -842,12 +842,12 @@ func (s *Service) report(url string, dataType string, stats interface{}, authJwt
 type cachedBlock struct {
 	number        uint64
 	parentHash    common.Hash
-	txCount       uint64
-	quaiTxCount   uint64
-	qiTxCount     uint64
-	extTxCount    uint64
-	extTxInCount  uint64
-	extTxOutCount uint64
+	txCount       float64
+	quaiTxCount   float64
+	qiTxCount     float64
+	extTxCount    float64
+	extTxInCount  float64
+	extTxOutCount float64
 	time          uint64
 }
 
@@ -1020,9 +1020,9 @@ type nodeStats struct {
 }
 
 type subTps struct {
-	TotalNoTransactions1h uint64 `json:"totalNoTransactions1h"`
-	TPS1m                 uint64 `json:"tps1m"`
-	TPS1hr                uint64 `json:"tps1hr"`
+	TotalNoTransactions1h float64 `json:"totalNoTransactions1h"`
+	TPS1m                 float64 `json:"tps1m"`
+	TPS1hr                float64 `json:"tps1hr"`
 }
 
 type tps struct {
@@ -1039,9 +1039,9 @@ type BatchObject struct {
 }
 
 func (s *Service) cacheBlock(block *types.WorkObject) cachedBlock {
-	txCount := uint64(len(block.Transactions()))
-	quaiTxCount := uint64(len(block.QuaiTransactions()))
-	qiTxCount := uint64(len(block.QiTransactions()))
+	txCount := float64(len(block.Transactions()))
+	quaiTxCount := float64(len(block.QuaiTransactions()))
+	qiTxCount := float64(len(block.QiTransactions()))
 	extTxInCount := txCount - quaiTxCount - qiTxCount
 
 	currentBlock := cachedBlock{
@@ -1051,7 +1051,7 @@ func (s *Service) cacheBlock(block *types.WorkObject) cachedBlock {
 		quaiTxCount:   quaiTxCount,
 		qiTxCount:     qiTxCount,
 		extTxInCount:  extTxInCount,
-		extTxOutCount: uint64(len(block.ExtTransactions())),
+		extTxOutCount: float64(len(block.ExtTransactions())),
 		time:          block.Time(),
 	}
 	s.blockLookupCache.Add(block.Hash(), currentBlock)
@@ -1059,16 +1059,16 @@ func (s *Service) cacheBlock(block *types.WorkObject) cachedBlock {
 }
 
 func (s *Service) calculateTPS(block *types.WorkObject) *tps {
-	var totalTransactions1h uint64
-	var totalTransactions1m uint64
-	var quaiTotalTransactions1h uint64
-	var quaiTotalTransactions1m uint64
-	var qiTotalTransactions1h uint64
-	var qiTotalTransactions1m uint64
-	var extInTotalTransactions1h uint64
-	var extInTotalTransactions1m uint64
-	var extOutTotalTransactions1h uint64
-	var extOutTotalTransactions1m uint64
+	var totalTransactions1h float64
+	var totalTransactions1m float64
+	var quaiTotalTransactions1h float64
+	var quaiTotalTransactions1m float64
+	var qiTotalTransactions1h float64
+	var qiTotalTransactions1m float64
+	var extInTotalTransactions1h float64
+	var extInTotalTransactions1m float64
+	var extOutTotalTransactions1h float64
+	var extOutTotalTransactions1m float64
 	var currentBlock interface{}
 	var ok bool
 
@@ -1124,7 +1124,7 @@ func (s *Service) calculateTPS(block *types.WorkObject) *tps {
 
 	// Catches if we get to genesis block and are still within the window
 	if currentBlock.(cachedBlock).number == 1 && withinMinute {
-		delta := block.Time() - currentBlock.(cachedBlock).time
+		delta := float64(block.Time() - currentBlock.(cachedBlock).time)
 		return &tps{
 			Tx: subTps{
 				TPS1m:                 totalTransactions1m / delta,
@@ -1153,7 +1153,7 @@ func (s *Service) calculateTPS(block *types.WorkObject) *tps {
 			},
 		}
 	} else if currentBlock.(cachedBlock).number == 1 {
-		delta := block.Time() - currentBlock.(cachedBlock).time
+		delta := float64(block.Time() - currentBlock.(cachedBlock).time)
 		return &tps{
 			Tx: subTps{
 				TPS1m:                 totalTransactions1m / 60,
@@ -1182,31 +1182,33 @@ func (s *Service) calculateTPS(block *types.WorkObject) *tps {
 			},
 		}
 	}
+	// make window size float
+	cWindowSizeFloat := float64(c_windowSize)
 
 	return &tps{
 		Tx: subTps{
 			TPS1m:                 totalTransactions1m / 60,
-			TPS1hr:                totalTransactions1h / c_windowSize,
+			TPS1hr:                totalTransactions1h / cWindowSizeFloat,
 			TotalNoTransactions1h: totalTransactions1h,
 		},
 		QuaiTx: subTps{
 			TPS1m:                 quaiTotalTransactions1m / 60,
-			TPS1hr:                quaiTotalTransactions1h / c_windowSize,
+			TPS1hr:                quaiTotalTransactions1h / cWindowSizeFloat,
 			TotalNoTransactions1h: quaiTotalTransactions1h,
 		},
 		QiTx: subTps{
 			TPS1m:                 qiTotalTransactions1m / 60,
-			TPS1hr:                qiTotalTransactions1h / c_windowSize,
+			TPS1hr:                qiTotalTransactions1h / cWindowSizeFloat,
 			TotalNoTransactions1h: qiTotalTransactions1h,
 		},
 		ExtTxIn: subTps{
 			TPS1m:                 extInTotalTransactions1m / 60,
-			TPS1hr:                extInTotalTransactions1h / c_windowSize,
+			TPS1hr:                extInTotalTransactions1h / cWindowSizeFloat,
 			TotalNoTransactions1h: extInTotalTransactions1h,
 		},
 		ExtTxOut: subTps{
 			TPS1m:                 extOutTotalTransactions1m / 60,
-			TPS1hr:                extOutTotalTransactions1h / c_windowSize,
+			TPS1hr:                extOutTotalTransactions1h / cWindowSizeFloat,
 			TotalNoTransactions1h: extOutTotalTransactions1h,
 		},
 	}

--- a/quaistats/quaistats.go
+++ b/quaistats/quaistats.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/dgrijalva/jwt-go"
 	"io/ioutil"
 	"math/big"
 	"net"
@@ -34,8 +35,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/dgrijalva/jwt-go"
 
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/shirou/gopsutil/cpu"
@@ -841,10 +840,15 @@ func (s *Service) report(url string, dataType string, stats interface{}, authJwt
 }
 
 type cachedBlock struct {
-	number     uint64
-	parentHash common.Hash
-	txCount    uint64
-	time       uint64
+	number        uint64
+	parentHash    common.Hash
+	txCount       uint64
+	quaiTxCount   uint64
+	qiTxCount     uint64
+	extTxCount    uint64
+	extTxInCount  uint64
+	extTxOutCount uint64
+	time          uint64
 }
 
 // nodeInfo is the collection of meta information about a node that is displayed
@@ -970,11 +974,13 @@ func (s *Service) isJwtExpired(authJwt string) (bool, error) {
 
 // Trusted Only
 type blockTransactionStats struct {
-	Timestamp             *big.Int `json:"timestamp"`
-	TotalNoTransactions1h uint64   `json:"totalNoTransactions1h"`
-	TPS1m                 uint64   `json:"tps1m"`
-	TPS1hr                uint64   `json:"tps1hr"`
-	Chain                 string   `json:"chain"`
+	Timestamp *big.Int `json:"timestamp"`
+	Tx        subTps   `json:"tx"`
+	QuaiTx    subTps   `json:"quaiTx"`
+	QiTx      subTps   `json:"qiTx"`
+	ExtTxIn   subTps   `json:"extTxIn"`
+	ExtTxOut  subTps   `json:"extTxOut"`
+	Chain     string   `json:"chain"`
 }
 
 // Trusted Only
@@ -1013,10 +1019,18 @@ type nodeStats struct {
 	HashedMAC           string     `json:"hashedMAC"`
 }
 
+type subTps struct {
+	TotalNoTransactions1h uint64 `json:"totalNoTransactions1h"`
+	TPS1m                 uint64 `json:"tps1m"`
+	TPS1hr                uint64 `json:"tps1hr"`
+}
+
 type tps struct {
-	TPS1m                     uint64
-	TPS1hr                    uint64
-	TotalNumberTransactions1h uint64
+	Tx       subTps
+	QuaiTx   subTps
+	QiTx     subTps
+	ExtTxIn  subTps
+	ExtTxOut subTps
 }
 
 type BatchObject struct {
@@ -1025,11 +1039,20 @@ type BatchObject struct {
 }
 
 func (s *Service) cacheBlock(block *types.WorkObject) cachedBlock {
+	txCount := uint64(len(block.Transactions()))
+	quaiTxCount := uint64(len(block.QuaiTransactions()))
+	qiTxCount := uint64(len(block.QiTransactions()))
+	extTxInCount := txCount - quaiTxCount - qiTxCount
+
 	currentBlock := cachedBlock{
-		number:     block.NumberU64(s.backend.NodeCtx()),
-		parentHash: block.ParentHash(s.backend.NodeCtx()),
-		txCount:    uint64(len(block.Transactions())),
-		time:       block.Time(),
+		number:        block.NumberU64(s.backend.NodeCtx()),
+		parentHash:    block.ParentHash(s.backend.NodeCtx()),
+		txCount:       txCount,
+		quaiTxCount:   quaiTxCount,
+		qiTxCount:     qiTxCount,
+		extTxInCount:  extTxInCount,
+		extTxOutCount: uint64(len(block.ExtTransactions())),
+		time:          block.Time(),
 	}
 	s.blockLookupCache.Add(block.Hash(), currentBlock)
 	return currentBlock
@@ -1038,6 +1061,14 @@ func (s *Service) cacheBlock(block *types.WorkObject) cachedBlock {
 func (s *Service) calculateTPS(block *types.WorkObject) *tps {
 	var totalTransactions1h uint64
 	var totalTransactions1m uint64
+	var quaiTotalTransactions1h uint64
+	var quaiTotalTransactions1m uint64
+	var qiTotalTransactions1h uint64
+	var qiTotalTransactions1m uint64
+	var extInTotalTransactions1h uint64
+	var extInTotalTransactions1m uint64
+	var extOutTotalTransactions1h uint64
+	var extOutTotalTransactions1m uint64
 	var currentBlock interface{}
 	var ok bool
 
@@ -1057,8 +1088,16 @@ func (s *Service) calculateTPS(block *types.WorkObject) *tps {
 
 		// Add the number of transactions in the block to the total
 		totalTransactions1h += currentBlock.(cachedBlock).txCount
+		quaiTotalTransactions1h += currentBlock.(cachedBlock).quaiTxCount
+		qiTotalTransactions1h += currentBlock.(cachedBlock).qiTxCount
+		extInTotalTransactions1h += currentBlock.(cachedBlock).extTxInCount
+		extOutTotalTransactions1h += currentBlock.(cachedBlock).extTxOutCount
 		if withinMinute && currentBlock.(cachedBlock).time+60 > block.Time() {
 			totalTransactions1m += currentBlock.(cachedBlock).txCount
+			quaiTotalTransactions1m += currentBlock.(cachedBlock).quaiTxCount
+			qiTotalTransactions1m += currentBlock.(cachedBlock).qiTxCount
+			extInTotalTransactions1m += currentBlock.(cachedBlock).extTxInCount
+			extOutTotalTransactions1m += currentBlock.(cachedBlock).extTxOutCount
 		} else {
 			withinMinute = false
 		}
@@ -1087,23 +1126,89 @@ func (s *Service) calculateTPS(block *types.WorkObject) *tps {
 	if currentBlock.(cachedBlock).number == 1 && withinMinute {
 		delta := block.Time() - currentBlock.(cachedBlock).time
 		return &tps{
-			TPS1m:                     totalTransactions1m / delta,
-			TPS1hr:                    totalTransactions1h / delta,
-			TotalNumberTransactions1h: totalTransactions1h,
+			Tx: subTps{
+				TPS1m:                 totalTransactions1m / delta,
+				TPS1hr:                totalTransactions1h / delta,
+				TotalNoTransactions1h: totalTransactions1h,
+			},
+			QuaiTx: subTps{
+				TPS1m:                 quaiTotalTransactions1m / delta,
+				TPS1hr:                quaiTotalTransactions1h / delta,
+				TotalNoTransactions1h: quaiTotalTransactions1h,
+			},
+			QiTx: subTps{
+				TPS1m:                 qiTotalTransactions1m / delta,
+				TPS1hr:                qiTotalTransactions1h / delta,
+				TotalNoTransactions1h: qiTotalTransactions1h,
+			},
+			ExtTxIn: subTps{
+				TPS1m:                 extInTotalTransactions1m / delta,
+				TPS1hr:                extInTotalTransactions1h / delta,
+				TotalNoTransactions1h: extInTotalTransactions1h,
+			},
+			ExtTxOut: subTps{
+				TPS1m:                 extOutTotalTransactions1m / delta,
+				TPS1hr:                extOutTotalTransactions1h / delta,
+				TotalNoTransactions1h: extOutTotalTransactions1h,
+			},
 		}
 	} else if currentBlock.(cachedBlock).number == 1 {
 		delta := block.Time() - currentBlock.(cachedBlock).time
 		return &tps{
-			TPS1m:                     totalTransactions1m / 60,
-			TPS1hr:                    totalTransactions1h / delta,
-			TotalNumberTransactions1h: totalTransactions1h,
+			Tx: subTps{
+				TPS1m:                 totalTransactions1m / 60,
+				TPS1hr:                totalTransactions1h / delta,
+				TotalNoTransactions1h: totalTransactions1h,
+			},
+			QuaiTx: subTps{
+				TPS1m:                 quaiTotalTransactions1m / 60,
+				TPS1hr:                quaiTotalTransactions1h / delta,
+				TotalNoTransactions1h: quaiTotalTransactions1h,
+			},
+			QiTx: subTps{
+				TPS1m:                 qiTotalTransactions1m / 60,
+				TPS1hr:                qiTotalTransactions1h / delta,
+				TotalNoTransactions1h: qiTotalTransactions1h,
+			},
+			ExtTxIn: subTps{
+				TPS1m:                 extInTotalTransactions1m / 60,
+				TPS1hr:                extInTotalTransactions1h / delta,
+				TotalNoTransactions1h: extInTotalTransactions1h,
+			},
+			ExtTxOut: subTps{
+				TPS1m:                 extOutTotalTransactions1m / 60,
+				TPS1hr:                extOutTotalTransactions1h / delta,
+				TotalNoTransactions1h: extOutTotalTransactions1h,
+			},
 		}
 	}
 
 	return &tps{
-		TPS1m:                     totalTransactions1m / 60,
-		TPS1hr:                    totalTransactions1h / c_windowSize,
-		TotalNumberTransactions1h: totalTransactions1h,
+		Tx: subTps{
+			TPS1m:                 totalTransactions1m / 60,
+			TPS1hr:                totalTransactions1h / c_windowSize,
+			TotalNoTransactions1h: totalTransactions1h,
+		},
+		QuaiTx: subTps{
+			TPS1m:                 quaiTotalTransactions1m / 60,
+			TPS1hr:                quaiTotalTransactions1h / c_windowSize,
+			TotalNoTransactions1h: quaiTotalTransactions1h,
+		},
+		QiTx: subTps{
+			TPS1m:                 qiTotalTransactions1m / 60,
+			TPS1hr:                qiTotalTransactions1h / c_windowSize,
+			TotalNoTransactions1h: qiTotalTransactions1h,
+		},
+		ExtTxIn: subTps{
+			TPS1m:                 extInTotalTransactions1m / 60,
+			TPS1hr:                extInTotalTransactions1h / c_windowSize,
+			TotalNoTransactions1h: extInTotalTransactions1h,
+		},
+		ExtTxOut: subTps{
+			TPS1m:                 extOutTotalTransactions1m / 60,
+			TPS1hr:                extOutTotalTransactions1h / c_windowSize,
+			TotalNoTransactions1h: extOutTotalTransactions1h,
+		},
 	}
 }
 
@@ -1152,11 +1257,13 @@ func (s *Service) assembleBlockTransactionStats(block *types.WorkObject) *blockT
 
 	// Assemble and return the block stats
 	return &blockTransactionStats{
-		Timestamp:             new(big.Int).SetUint64(block.Time()),
-		TotalNoTransactions1h: tps.TotalNumberTransactions1h,
-		TPS1m:                 tps.TPS1m,
-		TPS1hr:                tps.TPS1hr,
-		Chain:                 s.backend.NodeLocation().Name(),
+		Timestamp: new(big.Int).SetUint64(block.Time()),
+		Tx:        tps.Tx,
+		QuaiTx:    tps.QuaiTx,
+		QiTx:      tps.QiTx,
+		ExtTxIn:   tps.ExtTxIn,
+		ExtTxOut:  tps.ExtTxOut,
+		Chain:     s.backend.NodeLocation().Name(),
 	}
 }
 


### PR DESCRIPTION
Now sends transaction stats for multiple transaction types. Please coordinate with me when merging or redeploying with this commit because I will need to update the rest of the stats stack at the same type. Otherwise, no transaction stats until it is updated.