### PR TITLE
Workshares are included and being able to mine

### DIFF
--- a/cmd/utils/hierarchical_coordinator.go
+++ b/cmd/utils/hierarchical_coordinator.go
@@ -137,6 +137,7 @@ func (hc *HierarchicalCoordinator) startNode(logPath string, quaiBackend quai.Co
 	hc.p2p.Subscribe(location, &types.WorkObject{})
 	hc.p2p.Subscribe(location, common.Hash{})
 	hc.p2p.Subscribe(location, &types.Transactions{})
+	hc.p2p.Subscribe(location, &types.WorkObjectHeader{})
 
 	StartNode(stack)
 

--- a/consensus/blake3pow/poem.go
+++ b/consensus/blake3pow/poem.go
@@ -77,6 +77,13 @@ func (blake3pow *Blake3pow) TotalLogS(chain consensus.GenesisReader, header *typ
 	if err != nil {
 		return big.NewInt(0)
 	}
+	if blake3pow.NodeLocation().Context() == common.ZONE_CTX {
+		workShareS, err := blake3pow.WorkShareLogS(header)
+		if err != nil {
+			return big.NewInt(0)
+		}
+		intrinsicS = new(big.Int).Add(intrinsicS, workShareS)
+	}
 	switch order {
 	case common.PRIME_CTX:
 		totalS := new(big.Int).Add(header.ParentEntropy(common.PRIME_CTX), header.ParentDeltaS(common.REGION_CTX))
@@ -119,6 +126,13 @@ func (blake3pow *Blake3pow) DeltaLogS(chain consensus.GenesisReader, header *typ
 	if err != nil {
 		return big.NewInt(0)
 	}
+	if blake3pow.NodeLocation().Context() == common.ZONE_CTX {
+		workShareS, err := blake3pow.WorkShareLogS(header)
+		if err != nil {
+			return big.NewInt(0)
+		}
+		intrinsicS = new(big.Int).Add(intrinsicS, workShareS)
+	}
 	switch order {
 	case common.PRIME_CTX:
 		return big.NewInt(0)
@@ -147,6 +161,53 @@ func (blake3pow *Blake3pow) UncledLogS(block *types.WorkObject) *big.Int {
 		totalUncledLogS.Add(totalUncledLogS, intrinsicS)
 	}
 	return totalUncledLogS
+}
+
+func (blake3pow *Blake3pow) WorkShareLogS(wo *types.WorkObject) (*big.Int, error) {
+	workShares := wo.Uncles()
+	totalWsEntropy := big.NewInt(0)
+	for _, ws := range workShares {
+		powHash, err := blake3pow.ComputePowHash(ws)
+		if err != nil {
+			return big.NewInt(0), err
+		}
+		// Two discounts need to be applied to the weight of each work share
+		// 1) Discount based on the amount of number of other possible work
+		// shares for the same entropy value
+		// 2) Discount based on the staleness of inclusion, for every block
+		// delay the weight gets reduced by the factor of 2
+
+		// Discount 1) only applies if the workshare has less weight than the
+		// work object threshold
+		var wsEntropy *big.Int
+		woDiff := new(big.Int).Set(wo.Difficulty())
+		target := new(big.Int).Div(common.Big2e256, woDiff)
+		if new(big.Int).SetBytes(powHash.Bytes()).Cmp(target) > 0 { // powHash > target
+			// The work share that has less than threshold weight needs to add
+			// an extra bit for each level
+			// This is achieved using three steps
+			// 1) Find the difference in entropy between the work share and
+			// threshold in the 2^mantBits bits field because otherwise the precision
+			// is lost due to integer division
+			// 2) Divide this difference with the 2^mantBits to get the number
+			// of bits of difference to discount the workshare entropy
+			// 3) Divide the entropy difference with 2^(extraBits+1) to get the
+			// actual work share weight here +1 is done to the extraBits because
+			// of Quo and if the difference is less than 0, its within the first
+			// level
+			cBigBits := blake3pow.IntrinsicLogS(powHash)
+			thresholdBigBits := blake3pow.IntrinsicLogS(common.BytesToHash(target.Bytes()))
+			wsEntropy = new(big.Int).Sub(thresholdBigBits, cBigBits)
+			extraBits := new(big.Int).Quo(wsEntropy, new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(mantBits)), nil))
+			wsEntropy = new(big.Int).Div(wsEntropy, new(big.Int).Exp(big.NewInt(2), new(big.Int).Add(extraBits, big.NewInt(1)), nil))
+		} else {
+			wsEntropy = new(big.Int).Set(blake3pow.IntrinsicLogS(powHash))
+		}
+
+		// Add the entropy into the total entropy once the discount calculation is done
+		totalWsEntropy.Add(totalWsEntropy, wsEntropy)
+	}
+	return totalWsEntropy, nil
 }
 
 func (blake3pow *Blake3pow) UncledSubDeltaLogS(chain consensus.GenesisReader, header *types.WorkObject) *big.Int {
@@ -202,4 +263,21 @@ func (blake3pow *Blake3pow) CalcRank(chain consensus.GenesisReader, header *type
 	}
 
 	return 0, nil
+}
+
+func (blake3pow *Blake3pow) CheckIfValidWorkShare(workShare *types.WorkObjectHeader) bool {
+	// Extract some data from the header
+	diff := new(big.Int).Set(workShare.Difficulty())
+	c, _ := mathutil.BinaryLog(diff, mantBits)
+	if c <= params.WorkSharesThresholdDiff {
+		return false
+	}
+	workShareThreshold := c - params.WorkSharesThresholdDiff
+	workShareDiff := new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(workShareThreshold)), nil)
+	workShareMintarget := new(big.Int).Div(big2e256, workShareDiff)
+	powHash, err := blake3pow.ComputePowHash(workShare)
+	if err != nil {
+		return false
+	}
+	return new(big.Int).SetBytes(powHash.Bytes()).Cmp(workShareMintarget) <= 0
 }

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -44,6 +44,9 @@ type ChainHeaderReader interface {
 	// GetHeaderByHash retrieves a block header from the database by its hash.
 	GetHeaderByHash(hash common.Hash) *types.WorkObject
 
+	// GetBlockByhash retrieves a block from the database by hash.
+	GetBlockByHash(hash common.Hash) *types.WorkObject
+
 	// GetTerminiByHash retrieves the termini for a given header hash
 	GetTerminiByHash(hash common.Hash) *types.Termini
 
@@ -99,6 +102,13 @@ type Engine interface {
 	// UncledLogS returns the log of the entropy reduction by uncles referenced in the block
 	UncledLogS(block *types.WorkObject) *big.Int
 
+	// WorkShareLogS returns the log of the entropy reduction by the workshare referenced in the block
+	WorkShareLogS(block *types.WorkObject) (*big.Int, error)
+
+	// CheckIfValidWorkShare checks if the workshare meets the work share
+	// requirements defined by the protocol
+	CheckIfValidWorkShare(workShare *types.WorkObjectHeader) bool
+
 	// UncledUncledSubDeltaLogS returns the log of the uncled entropy reduction  since the past coincident
 	UncledSubDeltaLogS(chain GenesisReader, header *types.WorkObject) *big.Int
 
@@ -150,6 +160,9 @@ type Engine interface {
 	// CalcDifficulty is the difficulty adjustment algorithm. It returns the difficulty
 	// that a new block should have.
 	CalcDifficulty(chain ChainHeaderReader, parent *types.WorkObjectHeader) *big.Int
+
+	// ComputePowHash returns the pow hash of the workobject header
+	ComputePowHash(header *types.WorkObjectHeader) (common.Hash, error)
 
 	// IsDomCoincident returns true if this block satisfies the difficulty order
 	// of a dominant chain. If this node does not have a dominant chain (i.e.

--- a/core/core.go
+++ b/core/core.go
@@ -536,6 +536,10 @@ func (c *Core) Engine() consensus.Engine {
 	return c.engine
 }
 
+func (c *Core) CheckIfValidWorkShare(workShare *types.WorkObjectHeader) bool {
+	return c.engine.CheckIfValidWorkShare(workShare)
+}
+
 // Slice retrieves the slice struct.
 func (c *Core) Slice() *Slice {
 	return c.sl
@@ -1075,6 +1079,10 @@ func (c *Core) SubscribePendingHeader(ch chan<- *types.WorkObject) event.Subscri
 }
 
 func (c *Core) IsMining() bool { return c.sl.miner.Mining() }
+
+func (c *Core) SendWorkShare(workShare *types.WorkObjectHeader) error {
+	return c.sl.miner.worker.AddWorkShare(workShare)
+}
 
 //-------------------------//
 // State Processor methods //

--- a/core/events.go
+++ b/core/events.go
@@ -21,8 +21,7 @@ type ChainEvent struct {
 }
 
 type ChainSideEvent struct {
-	Blocks      []*types.WorkObject
-	ResetUncles bool
+	Blocks []*types.WorkObject
 }
 
 type ChainHeadEvent struct {

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -422,7 +422,7 @@ func (hc *HeaderChain) SetCurrentHeader(head *types.WorkObject) error {
 					blocks = append(blocks, block)
 				}
 			}
-			hc.chainSideFeed.Send(ChainSideEvent{Blocks: blocks, ResetUncles: true})
+			hc.chainSideFeed.Send(ChainSideEvent{Blocks: blocks})
 		}()
 	}
 

--- a/core/slice.go
+++ b/core/slice.go
@@ -236,7 +236,6 @@ func (sl *Slice) Append(header *types.WorkObject, domPendingHeader *types.WorkOb
 	if err != nil {
 		return nil, false, false, err
 	}
-
 	time3 := common.PrettyDuration(time.Since(start))
 	// Construct the block locally
 	block, err := sl.ConstructLocalBlock(header)
@@ -404,7 +403,7 @@ func (sl *Slice) Append(header *types.WorkObject, domPendingHeader *types.WorkOb
 			"location":   block.Location(),
 			"parentHash": block.ParentHash(nodeCtx),
 		}).Debug("Found uncle")
-		sl.hc.chainSideFeed.Send(ChainSideEvent{Blocks: []*types.WorkObject{block}, ResetUncles: false})
+		sl.hc.chainSideFeed.Send(ChainSideEvent{Blocks: []*types.WorkObject{block}})
 	}
 
 	// Chain head feed is only used by the Zone chains

--- a/internal/quaiapi/backend.go
+++ b/internal/quaiapi/backend.go
@@ -99,6 +99,8 @@ type Backend interface {
 	AddGenesisPendingEtxs(block *types.WorkObject)
 	SubscribeExpansionEvent(ch chan<- core.ExpansionEvent) event.Subscription
 	WriteGenesisBlock(block *types.WorkObject, location common.Location)
+	SendWorkShare(workShare *types.WorkObjectHeader) error
+	CheckIfValidWorkShare(workShare *types.WorkObjectHeader) bool
 
 	// Transaction pool API
 	SendTx(ctx context.Context, signedTx *types.Transaction) error
@@ -129,6 +131,7 @@ type Backend interface {
 
 	// P2P apis
 	BroadcastBlock(block *types.WorkObject, location common.Location) error
+	BroadcastWorkShare(workShare *types.WorkObjectHeader, location common.Location) error
 }
 
 func GetAPIs(apiBackend Backend) []rpc.API {

--- a/p2p/node/api.go
+++ b/p2p/node/api.go
@@ -298,6 +298,7 @@ func (p *P2PNode) handleBroadcast(sourcePeer peer.ID, data interface{}, nodeLoca
 		p.cacheAdd(v.Hash(), &v, nodeLocation)
 	// TODO: send it to consensus
 	case types.Transactions:
+	case types.WorkObjectHeader:
 	default:
 		log.Global.Debugf("received unsupported block broadcast")
 		// TODO: ban the peer which sent it?

--- a/p2p/node/pubsubManager/utils.go
+++ b/p2p/node/pubsubManager/utils.go
@@ -14,10 +14,11 @@ import (
 
 const (
 	// Data types for gossipsub topics
-	C_workObjectType  = "blocks"
-	C_transactionType = "transactions"
-	C_headerType      = "headers"
-	C_hashType        = "hash"
+	C_workObjectType       = "blocks"
+	C_transactionType      = "transactions"
+	C_headerType           = "headers"
+	C_hashType             = "hash"
+	C_workObjectHeaderType = "woHeaders"
 )
 
 // gets the name of the topic for the given type of data
@@ -28,10 +29,10 @@ func TopicName(genesis common.Hash, location common.Location, data interface{}) 
 		return strings.Join([]string{baseTopic, C_workObjectType}, "/"), nil
 	case common.Hash:
 		return strings.Join([]string{baseTopic, C_hashType}, "/"), nil
-	case *types.Transaction:
-		return strings.Join([]string{baseTopic, C_transactionType}, "/"), nil
 	case *types.Transactions:
 		return strings.Join([]string{baseTopic, C_transactionType}, "/"), nil
+	case *types.WorkObjectHeader:
+		return strings.Join([]string{baseTopic, C_workObjectHeaderType}, "/"), nil
 	default:
 		return "", ErrUnsupportedType
 	}

--- a/p2p/pb/proto_services.go
+++ b/p2p/pb/proto_services.go
@@ -221,6 +221,13 @@ func ConvertAndMarshal(data interface{}) ([]byte, error) {
 			return nil, err
 		}
 		return proto.Marshal(protoTransactions)
+	case *types.WorkObjectHeader:
+		log.Global.Tracef("marshalling block header: %+v", data)
+		protoWoHeader, err := data.ProtoEncode()
+		if err != nil {
+			return nil, err
+		}
+		return proto.Marshal(protoWoHeader)
 	default:
 		return nil, errors.New("unsupported data type")
 	}
@@ -244,6 +251,19 @@ func UnmarshalAndConvert(data []byte, sourceLocation common.Location, dataPtr *i
 			return err
 		}
 		*dataPtr = *workObject
+		return nil
+	case *types.WorkObjectHeader:
+		protoWorkObjectHeader := &types.ProtoWorkObjectHeader{}
+		err := proto.Unmarshal(data, protoWorkObjectHeader)
+		if err != nil {
+			return err
+		}
+		workObjectHeader := &types.WorkObjectHeader{}
+		err = workObjectHeader.ProtoDecode(protoWorkObjectHeader)
+		if err != nil {
+			return err
+		}
+		*dataPtr = *workObjectHeader
 		return nil
 	case *types.Header:
 		protoHeader := &types.ProtoHeader{}

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -201,4 +201,7 @@ var (
 	DifficultyAdjustmentPeriod        = big.NewInt(360)                                             // This is the number of blocks over which the average has to be taken
 	DifficultyAdjustmentFactor int64  = 40                                                          // This is the factor that divides the log of the change in the difficulty
 	MinQuaiConversionAmount           = new(big.Int).Mul(big.NewInt(1), big.NewInt(GWei))           // 0.000000001 Quai
+	MaxWorkShareCount                 = 16
+	WorkSharesThresholdDiff           = 3 // Number of bits lower than the target that the default consensus engine uses
+	WorkSharesInclusionDepth          = 7 // Number of blocks upto which the work shares can be referenced and this is protocol enforced
 )

--- a/quai/api_backend.go
+++ b/quai/api_backend.go
@@ -584,9 +584,21 @@ func (b *QuaiAPIBackend) SubscribeExpansionEvent(ch chan<- core.ExpansionEvent) 
 	return b.quai.core.SubscribeExpansionEvent(ch)
 }
 
+func (b *QuaiAPIBackend) SendWorkShare(workShare *types.WorkObjectHeader) error {
+	return b.quai.core.SendWorkShare(workShare)
+}
+
+func (b *QuaiAPIBackend) CheckIfValidWorkShare(workShare *types.WorkObjectHeader) bool {
+	return b.quai.core.CheckIfValidWorkShare(workShare)
+}
+
 // ///////////////////////////
 // /////// P2P ///////////////
 // ///////////////////////////
 func (b *QuaiAPIBackend) BroadcastBlock(block *types.WorkObject, location common.Location) error {
 	return b.quai.p2p.Broadcast(location, block)
+}
+
+func (b *QuaiAPIBackend) BroadcastWorkShare(workShare *types.WorkObjectHeader, location common.Location) error {
+	return b.quai.p2p.Broadcast(location, workShare)
 }

--- a/quai/p2p_backend.go
+++ b/quai/p2p_backend.go
@@ -101,6 +101,15 @@ func (qbe *QuaiBackend) OnNewBroadcast(sourcePeer p2p.PeerID, data interface{}, 
 		if backend.ProcessingState() {
 			backend.SendRemoteTxs(txs)
 		}
+		// TODO: Handle the error here and mark the peers accordingly
+	case types.WorkObjectHeader:
+		woHeader := data.(types.WorkObjectHeader)
+		backend := *qbe.GetBackend(nodeLocation)
+		if backend == nil {
+			log.Global.Error("no backend found")
+			return false
+		}
+		backend.SendWorkShare(&woHeader)
 	}
 
 	// If it was a good broadcast, mark the peer as lively

--- a/quaiclient/quaiclient.go
+++ b/quaiclient/quaiclient.go
@@ -303,6 +303,11 @@ func (ec *Client) ReceiveMinedHeader(ctx context.Context, header *types.WorkObje
 	return ec.c.CallContext(ctx, nil, "quai_receiveMinedHeader", data)
 }
 
+func (ec *Client) ReceiveWorkShare(ctx context.Context, header *types.WorkObjectHeader) error {
+	data := header.RPCMarshalWorkObjectHeader()
+	return ec.c.CallContext(ctx, nil, "quai_receiveWorkShare", data)
+}
+
 // Filters
 
 // SubscribeFilterLogs subscribes to the results of a streaming filter query.


### PR DESCRIPTION
workshares are sub shares found in the process of producing a block. Including these sub share samples in the block makes the statistical convergence better. So in this PR, workshares have been added into the uncles list. The weight of the workshares is added into the parent entropy and also parent sub delta S. But a discount based on the reference depth and frequency of workshares is applied while adding the entropy of the workshare.