### PR TITLE
Only Read the workobject with workshares during the verify uncles

### DIFF
--- a/consensus/blake3pow/consensus.go
+++ b/consensus/blake3pow/consensus.go
@@ -212,7 +212,7 @@ func (blake3pow *Blake3pow) VerifyUncles(chain consensus.ChainReader, block *typ
 		// If the ancestor doesn't have any uncles, we don't have to iterate them
 		if ancestorHeader.UncleHash() != types.EmptyUncleHash {
 			// Need to add those uncles to the banned list too
-			ancestor := chain.GetWorkObject(parent)
+			ancestor := chain.GetWorkObjectWithWorkShares(parent)
 			if ancestor == nil {
 				break
 			}

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -70,6 +70,10 @@ type ChainReader interface {
 
 	// GetBlock retrieves a block from the database by hash and number.
 	GetWorkObject(hash common.Hash) *types.WorkObject
+
+	// GetWorkObjectWithWorkShares retrieves a block from the database by hash
+	// but only has header and workshares populated in the body
+	GetWorkObjectWithWorkShares(hash common.Hash) *types.WorkObject
 }
 
 type GenesisReader interface {

--- a/consensus/progpow/consensus.go
+++ b/consensus/progpow/consensus.go
@@ -215,7 +215,7 @@ func (progpow *Progpow) VerifyUncles(chain consensus.ChainReader, block *types.W
 		// If the ancestor doesn't have any uncles, we don't have to iterate them
 		if ancestorHeader.UncleHash() != types.EmptyUncleHash {
 			// Need to add those uncles to the banned list too
-			ancestor := chain.GetWorkObject(parent)
+			ancestor := chain.GetWorkObjectWithWorkShares(parent)
 			if ancestor == nil {
 				break
 			}

--- a/core/bodydb.go
+++ b/core/bodydb.go
@@ -195,6 +195,20 @@ func (bc *BodyDb) GetWorkObject(hash common.Hash) *types.WorkObject {
 	return wo
 }
 
+// GetWorkObjectWithWorkShares retrieves a workObject with workshares from the database by hash,
+// caching it if found.
+func (bc *BodyDb) GetWorkObjectWithWorkShares(hash common.Hash) *types.WorkObject {
+	termini := rawdb.ReadTermini(bc.db, hash)
+	if termini == nil {
+		return nil
+	}
+	wo := rawdb.ReadWorkObjectWithWorkShares(bc.db, hash)
+	if wo == nil {
+		return nil
+	}
+	return wo
+}
+
 // GetBlockOrCandidate retrieves any known block from the database by hash and number,
 // caching it if found.
 func (bc *BodyDb) GetBlockOrCandidate(hash common.Hash, number uint64) *types.WorkObject {

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -816,6 +816,10 @@ func (hc *HeaderChain) GetWorkObject(hash common.Hash) *types.WorkObject {
 	return hc.bc.GetWorkObject(hash)
 }
 
+func (hc *HeaderChain) GetWorkObjectWithWorkShares(hash common.Hash) *types.WorkObject {
+	return hc.bc.GetWorkObjectWithWorkShares(hash)
+}
+
 // CheckContext checks to make sure the range of a context or order is valid
 func (hc *HeaderChain) CheckContext(context int) error {
 	if context < 0 || context > common.HierarchyDepth {


### PR DESCRIPTION
During the workshare/uncle verification we read the workobject with the transactions from the database but we only need to get the workshare information, and this was causing significant RAM usage at high TPS testing. This optimization completely removes that RAM usage by just reading the WorkShares along with the Header information