### PR TITLE
View stream cache status

### DIFF
--- a/p2p/node/streamManager/streamManager.go
+++ b/p2p/node/streamManager/streamManager.go
@@ -128,12 +128,12 @@ func (sm *basicStreamManager) GetStream(peerID p2p.PeerID) (network.Stream, erro
 			return existingStream.stream, nil
 		}
 		go quaiprotocol.QuaiProtocolHandler(stream, sm.p2pBackend)
-		log.Global.Debug("Had to create new stream")
+		log.Global.WithField("PeerID", peerID).Info("Had to create new stream")
 		if streamMetrics != nil {
 			streamMetrics.WithLabelValues("NumStreams").Inc()
 		}
 	} else {
-		log.Global.Trace("Requested stream was found in cache")
+		log.Global.WithField("PeerID", peerID).Info("Requested stream was found in cache")
 	}
 
 	return wrappedStream.stream, err


### PR DESCRIPTION
This was requested to go in main to keep track of streamCache accesses. Tests are run at info level so that's where the print was set.