### PR TITLE
Docs improvements

### DIFF
--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -150,7 +150,7 @@ func RegisterQuaiStatsService(stack *node.Node, backend quaiapi.Backend, url str
 }
 
 // Fatalf formats a message to standard error and exits the program.
-// The message is also printed to standard output if standard error
+// The message is also printed to standard output if the standard error
 // is redirected to a different file.
 func Fatalf(format string, args ...interface{}) {
 	w := io.MultiWriter(os.Stdout, os.Stderr)

--- a/cmd/utils/hierarchical_coordinator.go
+++ b/cmd/utils/hierarchical_coordinator.go
@@ -251,7 +251,7 @@ func (hc *HierarchicalCoordinator) TriggerTreeExpansion(block *types.WorkObject)
 		return err
 	}
 
-	// If only new zones to be added, go through all the regions and add a new zone
+	// If only new zones are to be added, go through all the regions and add a new zone
 	if !newRegionShouldBeAdded && newZoneShouldBeAdded {
 		// add a new zone to all the current active regions
 		for i := 0; i < int(currentRegions); i++ {

--- a/common/bitutil/bitutil_test.go
+++ b/common/bitutil/bitutil_test.go
@@ -190,7 +190,7 @@ func benchmarkBaseOR(b *testing.B, size int) {
 	}
 }
 
-var GloBool bool // Exported global will not be dead-code eliminated, at least not yet.
+var GloBool bool // Exported globally will not be dead-code eliminated, at least not yet.
 
 // Benchmarks the potentially optimized bit testing performance.
 func BenchmarkFastTest1KB(b *testing.B) { benchmarkFastTest(b, 1024) }

--- a/common/bitutil/compress.go
+++ b/common/bitutil/compress.go
@@ -97,7 +97,7 @@ func bitsetEncodeBytes(data []byte) []byte {
 }
 
 // DecompressBytes decompresses data with a known target size. If the input data
-// matches the size of the target, it means no compression was done in the first
+// matches the size of the target, which means no compression was done in the first
 // place.
 func DecompressBytes(data []byte, target int) ([]byte, error) {
 	if len(data) > target {

--- a/common/mclock/simclock.go
+++ b/common/mclock/simclock.go
@@ -26,7 +26,7 @@ import (
 // simulates a scheduler on a virtual timescale where actual processing takes zero time.
 //
 // The virtual clock doesn't advance on its own, call Run to advance it and execute timers.
-// Since there is no way to influence the Go scheduler, testing timeout behaviour involving
+// Since there is no way to influence the Go scheduler, testing timeout behavior involving
 // goroutines needs special care. A good way to test such timeouts is as follows: First
 // perform the action that is supposed to time out. Ensure that the timer you want to test
 // is created. Then run the clock until after the timeout. Finally observe the effect of

--- a/quai/abi/event.go
+++ b/quai/abi/event.go
@@ -29,7 +29,7 @@ import (
 // don't get the signature canonical representation as the first LOG topic.
 type Event struct {
 	// Name is the event name used for internal representation. It's derived from
-	// the raw name and a suffix will be added in the case of a event overload.
+	// the raw name and a suffix will be added in the case of an event overload.
 	//
 	// e.g.
 	// These are two events that have the same name:

--- a/quai/abi/method.go
+++ b/quai/abi/method.go
@@ -48,7 +48,7 @@ const (
 // from the storage and therefore requires no Tx to be sent to the
 // network. A method such as `Transact` does require a Tx and thus will
 // be flagged `false`.
-// Input specifies the required input parameters for this gives method.
+// Input specifies the required input parameters for this given method.
 type Method struct {
 	// Name is the method name used for internal representation. It's derived from
 	// the raw name and a suffix will be added in the case of a function overload.


### PR DESCRIPTION
Rectify typographical inaccuracies

This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.

Hope it helps.