### PR TITLE
Fixed CreateAccessList

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -21,6 +21,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+
 	"math/big"
 
 	"github.com/dominant-strategies/go-quai/common"
@@ -50,19 +51,26 @@ var (
 )
 
 func InitializePrecompiles(nodeLocation common.Location) {
-	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%x00000000000000000000000000000000000001", nodeLocation.BytePrefix()))] = &ecrecover{}
-	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%x00000000000000000000000000000000000002", nodeLocation.BytePrefix()))] = &sha256hash{}
-	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%x00000000000000000000000000000000000003", nodeLocation.BytePrefix()))] = &ripemd160hash{}
-	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%x00000000000000000000000000000000000004", nodeLocation.BytePrefix()))] = &dataCopy{}
-	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%x00000000000000000000000000000000000005", nodeLocation.BytePrefix()))] = &bigModExp{}
-	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%x00000000000000000000000000000000000006", nodeLocation.BytePrefix()))] = &bn256Add{}
-	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%x00000000000000000000000000000000000007", nodeLocation.BytePrefix()))] = &bn256ScalarMul{}
-	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%x00000000000000000000000000000000000008", nodeLocation.BytePrefix()))] = &bn256Pairing{}
-	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%x00000000000000000000000000000000000009", nodeLocation.BytePrefix()))] = &blake2F{}
-	LockupContractAddresses[[2]byte{nodeLocation[0], nodeLocation[1]}] = common.HexToAddress(fmt.Sprintf("0x%x0000000000000000000000000000000000000A", nodeLocation.BytePrefix()), nodeLocation)
+	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%02x00000000000000000000000000000000000001", nodeLocation.BytePrefix()))] = &ecrecover{}
+	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%02x00000000000000000000000000000000000002", nodeLocation.BytePrefix()))] = &sha256hash{}
+	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%02x00000000000000000000000000000000000003", nodeLocation.BytePrefix()))] = &ripemd160hash{}
+	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%02x00000000000000000000000000000000000004", nodeLocation.BytePrefix()))] = &dataCopy{}
+	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%02x00000000000000000000000000000000000005", nodeLocation.BytePrefix()))] = &bigModExp{}
+	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%02x00000000000000000000000000000000000006", nodeLocation.BytePrefix()))] = &bn256Add{}
+	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%02x00000000000000000000000000000000000007", nodeLocation.BytePrefix()))] = &bn256ScalarMul{}
+	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%02x00000000000000000000000000000000000008", nodeLocation.BytePrefix()))] = &bn256Pairing{}
+	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%02x00000000000000000000000000000000000009", nodeLocation.BytePrefix()))] = &blake2F{}
+	LockupContractAddresses[[2]byte{nodeLocation[0], nodeLocation[1]}] = common.HexToAddress(fmt.Sprintf("0x%02x0000000000000000000000000000000000000A", nodeLocation.BytePrefix()), nodeLocation)
+
+	for address, _ := range PrecompiledContracts {
+		if address.Location().Equal(nodeLocation) {
+			PrecompiledAddresses[nodeLocation.Name()] = append(PrecompiledAddresses[nodeLocation.Name()], common.BytesToAddress(address[:], nodeLocation))
+			PrecompiledAddresses[nodeLocation.Name()] = append(PrecompiledAddresses[nodeLocation.Name()], common.HexToAddress(fmt.Sprintf("0x00000000000000000000000000000000000000%02x", address[19]), nodeLocation))
+		}
+	}
 }
 
-// ActivePrecompiles returns the precompiles enabled with the current configuration.
+// ActivePrecompiles returns the precompiles enabled with the current configuration, except the Lockup Contract.
 func ActivePrecompiles(rules params.Rules, nodeLocation common.Location) []common.Address {
 	return PrecompiledAddresses[nodeLocation.Name()]
 }

--- a/internal/quaiapi/api.go
+++ b/internal/quaiapi/api.go
@@ -1284,6 +1284,12 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 		to = *args.To
 	} else {
 		to = crypto.CreateAddress(args.from(nodeLocation), uint64(*args.Nonce), *args.Data, nodeLocation)
+		if _, err := to.InternalAndQuaiAddress(); err != nil {
+			to, _, err = vm.GrindContract(args.from(nodeLocation), uint64(*args.Nonce), math.MaxUint64, 0, crypto.Keccak256Hash(*args.Data), nodeLocation)
+			if err != nil {
+				return nil, 0, nil, err
+			}
+		}
 	}
 	// Retrieve the precompiles since they don't need to be added to the access list
 	precompiles := vm.ActivePrecompiles(b.ChainConfig().Rules(header.Number(nodeCtx)), nodeLocation)
@@ -1297,7 +1303,8 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 		// Retrieve the current access list to expand
 		accessList := prevTracer.AccessList(nodeLocation)
 		b.Logger().WithField("accessList", accessList).Debug("Creating access list")
-
+		// Set the accesslist to the last al
+		args.AccessList = &accessList
 		// If no gas amount was specified, each unique access list needs it's own
 		// gas calculation. This is quite expensive, but we need to be accurate
 		// and it's convered by the sender only anyway.
@@ -1309,8 +1316,7 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 		}
 		// Copy the original db so we don't modify it
 		statedb := db.Copy()
-		// Set the accesslist to the last al
-		args.AccessList = &accessList
+
 		msg, err := args.ToMessage(b.RPCGasCap(), header.BaseFee(), nodeLocation)
 		if err != nil {
 			return nil, 0, nil, err

--- a/internal/quaiapi/quai_api.go
+++ b/internal/quaiapi/quai_api.go
@@ -696,7 +696,7 @@ func (s *PublicBlockChainQuaiAPI) CreateAccessList(ctx context.Context, args Tra
 	if !s.b.ProcessingState() {
 		return nil, errors.New("createAccessList call can only be made on chain processing the state")
 	}
-	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
+	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 	if blockNrOrHash != nil {
 		bNrOrHash = *blockNrOrHash
 	}

--- a/internal/quaiapi/transaction_args.go
+++ b/internal/quaiapi/transaction_args.go
@@ -158,13 +158,13 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend) error {
 			Data:                 args.Data,
 			AccessList:           args.AccessList,
 		}
-		pendingBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
+		pendingBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 		estimated, err := DoEstimateGas(ctx, b, callArgs, pendingBlockNr, b.RPCGasCap())
 		if err != nil {
 			return err
 		}
 		args.Gas = &estimated
-		log.Global.WithField("gas", args.Gas).Trace("Estimate gas usage automatically")
+		log.Global.WithField("gas", args.Gas).Debug("Estimate gas usage automatically")
 	}
 	if args.ChainID == nil {
 		id := (*hexutil.Big)(b.ChainConfig().ChainID)

--- a/quai/api_backend.go
+++ b/quai/api_backend.go
@@ -268,6 +268,9 @@ func (b *QuaiAPIBackend) GetEVM(ctx context.Context, msg core.Message, state *st
 	if nodeCtx != common.ZONE_CTX {
 		return nil, vmError, errors.New("getEvm can only be called in zone chain")
 	}
+	if parent == nil {
+		return nil, nil, errors.New("parent block not found, parenthash: " + header.ParentHash(b.NodeCtx()).String())
+	}
 	if vmConfig == nil {
 		vmConfig = b.quai.core.GetVMConfig()
 	}

--- a/quai/quaiconfig/config.go
+++ b/quai/quaiconfig/config.go
@@ -84,7 +84,7 @@ var Defaults = Config{
 		Recommit: 3 * time.Second,
 	},
 	TxPool:      core.DefaultTxPoolConfig,
-	RPCGasCap:   50000000,
+	RPCGasCap:   params.GasCeil,
 	GPO:         FullNodeGPO,
 	RPCTxFeeCap: 1, // 1 ether
 }

--- a/quaiclient/ethclient/ethclient.go
+++ b/quaiclient/ethclient/ethclient.go
@@ -520,6 +520,25 @@ func (ec *Client) EstimateFeeForQi(ctx context.Context, tx *types.Transaction) (
 	return (*big.Int)(&result), nil
 }
 
+// AccessListResult returns an optional accesslist
+// Its the result of the `quai_createAccessList` RPC call.
+// It contains an error if the transaction itself failed.
+type AccessListResult struct {
+	Accesslist *types.AccessList `json:"accessList"`
+	Error      string            `json:"error,omitempty"`
+	GasUsed    hexutil.Uint64    `json:"gasUsed"`
+}
+
+// CreateAccessList creates an access list for a transaction.
+func (ec *Client) CreateAccessList(ctx context.Context, msg quai.CallMsg) (AccessListResult, error) {
+	var accessList AccessListResult
+	err := ec.c.CallContext(ctx, &accessList, "quai_createAccessList", toCallArg(msg))
+	if err != nil {
+		return accessList, err
+	}
+	return accessList, nil
+}
+
 // SendTransaction injects a signed transaction into the pending pool for execution.
 //
 // If the transaction was a contract creation use the TransactionReceipt method to get the


### PR DESCRIPTION
quai_createAccessList is a JSON-RPC API method that simulates a transaction in the EVM and returns an Access List of all contracts and storage locations that the transaction accessed. This list does *not* include the **sender** and the **to** because those fields are already in the transaction and are therefore redundant.