### PR TITLE
Enforce Access Lists

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -139,8 +139,8 @@ type StateDB struct {
 	preimages map[common.Hash][]byte
 
 	// Per-transaction access list
-	accessList *accessList
-
+	accessList      *accessList
+	accessListDebug bool // used for simulating the EVM to create an access list
 	// Journal of state modifications. This is the backbone of
 	// Snapshot and RevertToSnapshot.
 	journal        *journal
@@ -936,7 +936,7 @@ func (s *StateDB) Copy() *StateDB {
 	// However, it doesn't cost us much to copy an empty list, so we do it anyway
 	// to not blow up if we ever decide copy it in the middle of a transaction
 	state.accessList = s.accessList.Copy()
-
+	state.accessListDebug = s.accessListDebug
 	// If there's a prefetcher running, make an inactive copy of it that can
 	// only access data but does not actively preload (since the user will not
 	// know that they need to explicitly terminate an active copy).
@@ -1233,58 +1233,63 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 // - Add destination to access list
 // - Add precompiles to access list
 // - Add the contents of the optional tx access list
-func (s *StateDB) PrepareAccessList(sender common.Address, dst *common.Address, precompiles []common.Address, list types.AccessList) {
-	s.AddAddressToAccessList(sender)
+func (s *StateDB) PrepareAccessList(sender common.Address, dst *common.Address, precompiles []common.Address, list types.AccessList, debug bool) {
+	s.accessListDebug = debug
+	s.AddAddressToAccessList(sender.Bytes20())
 	if dst != nil {
-		s.AddAddressToAccessList(*dst)
+		s.AddAddressToAccessList(dst.Bytes20())
 		// If it's a create-tx, the destination will be added inside evm.create
 	}
 	for _, addr := range precompiles {
-		s.AddAddressToAccessList(addr)
+		s.AddAddressToAccessList(addr.Bytes20())
 	}
 	for _, el := range list {
-		s.AddAddressToAccessList(el.Address)
+		s.AddAddressToAccessList(el.Address.Bytes20())
 		for _, key := range el.StorageKeys {
-			s.AddSlotToAccessList(el.Address, key)
+			s.AddSlotToAccessList(el.Address.Bytes20(), key)
 		}
 	}
 }
 
 // AddAddressToAccessList adds the given address to the access list
-func (s *StateDB) AddAddressToAccessList(addr common.Address) {
-	addrBytes := addr.Bytes20()
-	if s.accessList.AddAddress(addrBytes) {
-		s.journal.append(accessListAddAccountChange{&addrBytes})
+func (s *StateDB) AddAddressToAccessList(addr common.AddressBytes) {
+	if s.accessList.AddAddress(addr) {
+		s.journal.append(accessListAddAccountChange{&addr})
 	}
 }
 
 // AddSlotToAccessList adds the given (address, slot)-tuple to the access list
-func (s *StateDB) AddSlotToAccessList(addr common.Address, slot common.Hash) {
-	addrBytes := addr.Bytes20()
-	addrMod, slotMod := s.accessList.AddSlot(addrBytes, slot)
+func (s *StateDB) AddSlotToAccessList(addr common.AddressBytes, slot common.Hash) {
+	addrMod, slotMod := s.accessList.AddSlot(addr, slot)
 	if addrMod {
 		// In practice, this should not happen, since there is no way to enter the
 		// scope of 'address' without having the 'address' become already added
 		// to the access list (via call-variant, create, etc).
 		// Better safe than sorry, though
-		s.journal.append(accessListAddAccountChange{&addrBytes})
+		s.journal.append(accessListAddAccountChange{&addr})
 	}
 	if slotMod {
 		s.journal.append(accessListAddSlotChange{
-			address: &addrBytes,
+			address: &addr,
 			slot:    &slot,
 		})
 	}
 }
 
 // AddressInAccessList returns true if the given address is in the access list.
-func (s *StateDB) AddressInAccessList(addr common.Address) bool {
-	return s.accessList.ContainsAddress(addr.Bytes20())
+func (s *StateDB) AddressInAccessList(addr common.AddressBytes) bool {
+	if s.accessListDebug {
+		return true
+	}
+	return s.accessList.ContainsAddress(addr)
 }
 
 // SlotInAccessList returns true if the given (address, slot)-tuple is in the access list.
-func (s *StateDB) SlotInAccessList(addr common.Address, slot common.Hash) (addressPresent bool, slotPresent bool) {
-	return s.accessList.Contains(addr.Bytes20(), slot)
+func (s *StateDB) SlotInAccessList(addr common.AddressBytes, slot common.Hash) (addressPresent bool, slotPresent bool) {
+	if s.accessListDebug {
+		return true, true
+	}
+	return s.accessList.Contains(addr, slot)
 }
 
 // This can be optimized via VLQ encoding as btcd has done

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -356,7 +356,8 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 
 	// Set up the initial access list.
 	rules := st.evm.ChainConfig().Rules(st.evm.Context.BlockNumber)
-	st.state.PrepareAccessList(msg.From(), msg.To(), vm.ActivePrecompiles(rules, st.evm.ChainConfig().Location), msg.AccessList())
+	activePrecompiles := vm.ActivePrecompiles(rules, st.evm.ChainConfig().Location)
+	st.state.PrepareAccessList(msg.From(), msg.To(), activePrecompiles, msg.AccessList(), st.evm.Config.Debug)
 
 	if !st.msg.IsETX() && !contractCreation && len(st.data) == 27 && bytes.Equal(st.data[:7], suicide) && st.to().Equal(st.msg.From()) {
 		// Caller requests self-destruct

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -21,6 +21,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+
 	"math/big"
 
 	"github.com/dominant-strategies/go-quai/common"
@@ -50,19 +51,26 @@ var (
 )
 
 func InitializePrecompiles(nodeLocation common.Location) {
-	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%x00000000000000000000000000000000000001", nodeLocation.BytePrefix()))] = &ecrecover{}
-	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%x00000000000000000000000000000000000002", nodeLocation.BytePrefix()))] = &sha256hash{}
-	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%x00000000000000000000000000000000000003", nodeLocation.BytePrefix()))] = &ripemd160hash{}
-	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%x00000000000000000000000000000000000004", nodeLocation.BytePrefix()))] = &dataCopy{}
-	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%x00000000000000000000000000000000000005", nodeLocation.BytePrefix()))] = &bigModExp{}
-	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%x00000000000000000000000000000000000006", nodeLocation.BytePrefix()))] = &bn256Add{}
-	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%x00000000000000000000000000000000000007", nodeLocation.BytePrefix()))] = &bn256ScalarMul{}
-	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%x00000000000000000000000000000000000008", nodeLocation.BytePrefix()))] = &bn256Pairing{}
-	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%x00000000000000000000000000000000000009", nodeLocation.BytePrefix()))] = &blake2F{}
-	LockupContractAddresses[[2]byte{nodeLocation[0], nodeLocation[1]}] = common.HexToAddress(fmt.Sprintf("0x%x0000000000000000000000000000000000000A", nodeLocation.BytePrefix()), nodeLocation)
+	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%02x00000000000000000000000000000000000001", nodeLocation.BytePrefix()))] = &ecrecover{}
+	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%02x00000000000000000000000000000000000002", nodeLocation.BytePrefix()))] = &sha256hash{}
+	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%02x00000000000000000000000000000000000003", nodeLocation.BytePrefix()))] = &ripemd160hash{}
+	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%02x00000000000000000000000000000000000004", nodeLocation.BytePrefix()))] = &dataCopy{}
+	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%02x00000000000000000000000000000000000005", nodeLocation.BytePrefix()))] = &bigModExp{}
+	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%02x00000000000000000000000000000000000006", nodeLocation.BytePrefix()))] = &bn256Add{}
+	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%02x00000000000000000000000000000000000007", nodeLocation.BytePrefix()))] = &bn256ScalarMul{}
+	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%02x00000000000000000000000000000000000008", nodeLocation.BytePrefix()))] = &bn256Pairing{}
+	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%02x00000000000000000000000000000000000009", nodeLocation.BytePrefix()))] = &blake2F{}
+	LockupContractAddresses[[2]byte{nodeLocation[0], nodeLocation[1]}] = common.HexToAddress(fmt.Sprintf("0x%02x0000000000000000000000000000000000000A", nodeLocation.BytePrefix()), nodeLocation)
+
+	for address, _ := range PrecompiledContracts {
+		if address.Location().Equal(nodeLocation) {
+			PrecompiledAddresses[nodeLocation.Name()] = append(PrecompiledAddresses[nodeLocation.Name()], common.BytesToAddress(address[:], nodeLocation))
+			PrecompiledAddresses[nodeLocation.Name()] = append(PrecompiledAddresses[nodeLocation.Name()], common.HexToAddress(fmt.Sprintf("0x00000000000000000000000000000000000000%02x", address[19]), nodeLocation))
+		}
+	}
 }
 
-// ActivePrecompiles returns the precompiles enabled with the current configuration.
+// ActivePrecompiles returns the precompiles enabled with the current configuration, except the Lockup Contract.
 func ActivePrecompiles(rules params.Rules, nodeLocation common.Location) []common.Address {
 	return PrecompiledAddresses[nodeLocation.Name()]
 }

--- a/core/vm/errors.go
+++ b/core/vm/errors.go
@@ -35,6 +35,7 @@ var (
 	ErrReturnDataOutOfBounds    = errors.New("return data out of bounds")
 	ErrGasUintOverflow          = errors.New("gas uint64 overflow")
 	ErrInvalidCode              = errors.New("invalid code: must not begin with 0xef")
+	ErrInvalidAccessList        = errors.New("invalid access list")
 )
 
 // ErrStackUnderflow wraps an evm error when the items on the stack less

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -477,10 +477,9 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 	if err != nil {
 		return nil, common.Zero, 0, 0, err
 	}
-
-	// We add this to the access list _before_ taking a snapshot. Even if the creation fails,
-	// the access-list change should not be rolled back
-	evm.StateDB.AddAddressToAccessList(address)
+	if addressOk := evm.StateDB.AddressInAccessList(internalContractAddr.Bytes20()); !addressOk {
+		return nil, common.Zero, 0, 0, ErrInvalidAccessList
+	}
 
 	// Ensure there's no existing contract already at the designated address
 	contractHash := evm.StateDB.GetCodeHash(internalContractAddr)
@@ -508,6 +507,11 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 
 	if evm.Config.Debug && evm.depth == 0 {
 		evm.Config.Tracer.CaptureStart(evm, caller.Address(), address, true, codeAndHash.code, gas, value)
+	}
+	if evm.Config.Debug {
+		if tracer, ok := evm.Config.Tracer.(*AccessListTracer); ok {
+			tracer.list.addAddress(address)
+		}
 	}
 	start := time.Now()
 

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -267,6 +267,9 @@ func opBalance(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]
 	if err != nil { // if an ErrInvalidScope error is returned, the caller (usually interpreter.go/Run) will return the error to Call which will eventually set ReceiptStatusFailed in the tx receipt (state_processor.go/applyTransaction)
 		return nil, err
 	}
+	if addressOk := interpreter.evm.StateDB.AddressInAccessList(address.Bytes20()); !addressOk {
+		return nil, ErrInvalidAccessList
+	}
 	slot.SetFromBig(interpreter.evm.StateDB.GetBalance(address))
 	return nil, nil
 }
@@ -354,6 +357,9 @@ func opReturnDataCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeConte
 
 func opExtCodeSize(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	slot := scope.Stack.peek()
+	if addressOk := interpreter.evm.StateDB.AddressInAccessList(slot.Bytes20()); !addressOk {
+		return nil, ErrInvalidAccessList
+	}
 	slot.SetUint64(uint64(interpreter.evm.StateDB.GetCodeSize(slot.Bytes20())))
 	return nil, nil
 }
@@ -396,6 +402,9 @@ func opExtCodeCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext)
 	addr, err := common.Bytes20ToAddress(a.Bytes20(), interpreter.evm.chainConfig.Location).InternalAndQuaiAddress()
 	if err != nil {
 		return nil, err
+	}
+	if addressOk := interpreter.evm.StateDB.AddressInAccessList(addr.Bytes20()); !addressOk {
+		return nil, ErrInvalidAccessList
 	}
 	codeCopy := getData(interpreter.evm.StateDB.GetCode(addr), uint64CodeOffset, length.Uint64())
 	scope.Memory.Set(memOffset.Uint64(), length.Uint64(), codeCopy)
@@ -441,6 +450,9 @@ func opExtCodeHash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext)
 	address, err := common.Bytes20ToAddress(slot.Bytes20(), interpreter.evm.chainConfig.Location).InternalAndQuaiAddress()
 	if err != nil {
 		return nil, err
+	}
+	if addressOk := interpreter.evm.StateDB.AddressInAccessList(address.Bytes20()); !addressOk {
+		return nil, ErrInvalidAccessList
 	}
 	if interpreter.evm.StateDB.Empty(address) {
 		slot.Clear()
@@ -538,6 +550,9 @@ func opSload(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 	if err != nil {
 		return nil, err
 	}
+	if addressOk, slotOk := interpreter.evm.StateDB.SlotInAccessList(addr.Bytes20(), hash); !addressOk || !slotOk {
+		return nil, ErrInvalidAccessList
+	}
 	val := interpreter.evm.StateDB.GetState(addr, hash)
 	loc.SetBytes(val.Bytes())
 	return nil, nil
@@ -549,6 +564,9 @@ func opSstore(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 	addr, err := scope.Contract.Address().InternalAndQuaiAddress()
 	if err != nil {
 		return nil, err
+	}
+	if addressOk, slotOk := interpreter.evm.StateDB.SlotInAccessList(addr.Bytes20(), common.Hash(loc.Bytes32())); !addressOk || !slotOk {
+		return nil, ErrInvalidAccessList
 	}
 	interpreter.evm.StateDB.SetState(addr,
 		loc.Bytes32(), val.Bytes32())
@@ -686,6 +704,9 @@ func opCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 		gas += params.CallStipend
 		bigVal = value.ToBig()
 	}
+	if addressOk := interpreter.evm.StateDB.AddressInAccessList(toAddr.Bytes20()); !addressOk {
+		return nil, ErrInvalidAccessList
+	}
 
 	ret, returnGas, stateGas, err := interpreter.evm.Call(scope.Contract, toAddr, args, gas, bigVal, nil)
 
@@ -725,7 +746,9 @@ func opCallCode(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 		gas += params.CallStipend
 		bigVal = value.ToBig()
 	}
-
+	if addressOk := interpreter.evm.StateDB.AddressInAccessList(addr.Bytes20()); !addressOk {
+		return nil, ErrInvalidAccessList
+	}
 	ret, returnGas, err := interpreter.evm.CallCode(scope.Contract, toAddr, args, gas, bigVal)
 	if err != nil {
 		temp.Clear()
@@ -755,7 +778,9 @@ func opDelegateCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 	toAddr := common.Bytes20ToAddress(addr.Bytes20(), interpreter.evm.chainConfig.Location)
 	// Get arguments from the memory.
 	args := scope.Memory.GetPtr(int64(inOffset.Uint64()), int64(inSize.Uint64()))
-
+	if addressOk := interpreter.evm.StateDB.AddressInAccessList(toAddr.Bytes20()); !addressOk {
+		return nil, ErrInvalidAccessList
+	}
 	ret, returnGas, err := interpreter.evm.DelegateCall(scope.Contract, toAddr, args, gas)
 	if err != nil {
 		temp.Clear()
@@ -785,7 +810,9 @@ func opStaticCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) 
 	toAddr := common.Bytes20ToAddress(addr.Bytes20(), interpreter.evm.chainConfig.Location)
 	// Get arguments from the memory.
 	args := scope.Memory.GetPtr(int64(inOffset.Uint64()), int64(inSize.Uint64()))
-
+	if addressOk := interpreter.evm.StateDB.AddressInAccessList(toAddr.Bytes20()); !addressOk {
+		return nil, ErrInvalidAccessList
+	}
 	ret, returnGas, err := interpreter.evm.StaticCall(scope.Contract, toAddr, args, gas)
 	if err != nil {
 		temp.Clear()
@@ -831,6 +858,12 @@ func opSuicide(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]
 	beneficiaryAddr, err := common.Bytes20ToAddress(beneficiary.Bytes20(), interpreter.evm.chainConfig.Location).InternalAndQuaiAddress()
 	if err != nil {
 		return nil, err
+	}
+	if addressOk := interpreter.evm.StateDB.AddressInAccessList(addr.Bytes20()); !addressOk { // this may be unnecessary since the contract address ('to') is always in the access list implicitly
+		return nil, ErrInvalidAccessList
+	}
+	if addressOk := interpreter.evm.StateDB.AddressInAccessList(beneficiaryAddr.Bytes20()); !addressOk {
+		return nil, ErrInvalidAccessList
 	}
 	balance := interpreter.evm.StateDB.GetBalance(addr)
 	interpreter.evm.StateDB.AddBalance(beneficiaryAddr, balance)

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -58,15 +58,15 @@ type StateDB interface {
 	// is defined according to (balance = nonce = code = 0).
 	Empty(common.InternalAddress) bool
 
-	PrepareAccessList(sender common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList)
-	AddressInAccessList(addr common.Address) bool
-	SlotInAccessList(addr common.Address, slot common.Hash) (addressOk bool, slotOk bool)
+	PrepareAccessList(sender common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList, debug bool)
+	AddressInAccessList(addr common.AddressBytes) bool
+	SlotInAccessList(addr common.AddressBytes, slot common.Hash) (addressOk bool, slotOk bool)
 	// AddAddressToAccessList adds the given address to the access list. This operation is safe to perform
 	// even if the feature/fork is not active yet
-	AddAddressToAccessList(addr common.Address)
+	AddAddressToAccessList(addr common.AddressBytes)
 	// AddSlotToAccessList adds the given (address,slot) to the access list. This operation is safe to perform
 	// even if the feature/fork is not active yet
-	AddSlotToAccessList(addr common.Address, slot common.Hash)
+	AddSlotToAccessList(addr common.AddressBytes, slot common.Hash)
 
 	RevertToSnapshot(int)
 	Snapshot() int

--- a/internal/quaiapi/api.go
+++ b/internal/quaiapi/api.go
@@ -1284,6 +1284,12 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 		to = *args.To
 	} else {
 		to = crypto.CreateAddress(args.from(nodeLocation), uint64(*args.Nonce), *args.Data, nodeLocation)
+		if _, err := to.InternalAndQuaiAddress(); err != nil {
+			to, _, err = vm.GrindContract(args.from(nodeLocation), uint64(*args.Nonce), math.MaxUint64, 0, crypto.Keccak256Hash(*args.Data), nodeLocation)
+			if err != nil {
+				return nil, 0, nil, err
+			}
+		}
 	}
 	// Retrieve the precompiles since they don't need to be added to the access list
 	precompiles := vm.ActivePrecompiles(b.ChainConfig().Rules(header.Number(nodeCtx)), nodeLocation)
@@ -1297,7 +1303,8 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 		// Retrieve the current access list to expand
 		accessList := prevTracer.AccessList(nodeLocation)
 		b.Logger().WithField("accessList", accessList).Debug("Creating access list")
-
+		// Set the accesslist to the last al
+		args.AccessList = &accessList
 		// If no gas amount was specified, each unique access list needs it's own
 		// gas calculation. This is quite expensive, but we need to be accurate
 		// and it's convered by the sender only anyway.
@@ -1309,8 +1316,7 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 		}
 		// Copy the original db so we don't modify it
 		statedb := db.Copy()
-		// Set the accesslist to the last al
-		args.AccessList = &accessList
+
 		msg, err := args.ToMessage(b.RPCGasCap(), header.BaseFee(), nodeLocation)
 		if err != nil {
 			return nil, 0, nil, err

--- a/internal/quaiapi/api.go
+++ b/internal/quaiapi/api.go
@@ -646,7 +646,8 @@ func DoCall(ctx context.Context, b Backend, args TransactionArgs, blockNrOrHash 
 	if err != nil {
 		return nil, err
 	}
-	evm, vmError, err := b.GetEVM(ctx, msg, state, header, parent, &vm.Config{NoBaseFee: true})
+	tracer := vm.NewAccessListTracer(types.AccessList{}, common.ZeroAddress(b.NodeLocation()), common.ZeroAddress(b.NodeLocation()), vm.ActivePrecompiles(b.ChainConfig().Rules(header.Number(nodeCtx)), b.NodeLocation()))
+	evm, vmError, err := b.GetEVM(ctx, msg, state, header, parent, &vm.Config{Tracer: tracer, NoBaseFee: true, Debug: true})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/quaiapi/quai_api.go
+++ b/internal/quaiapi/quai_api.go
@@ -696,7 +696,7 @@ func (s *PublicBlockChainQuaiAPI) CreateAccessList(ctx context.Context, args Tra
 	if !s.b.ProcessingState() {
 		return nil, errors.New("createAccessList call can only be made on chain processing the state")
 	}
-	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
+	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 	if blockNrOrHash != nil {
 		bNrOrHash = *blockNrOrHash
 	}

--- a/internal/quaiapi/transaction_args.go
+++ b/internal/quaiapi/transaction_args.go
@@ -158,13 +158,13 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend) error {
 			Data:                 args.Data,
 			AccessList:           args.AccessList,
 		}
-		pendingBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
+		pendingBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 		estimated, err := DoEstimateGas(ctx, b, callArgs, pendingBlockNr, b.RPCGasCap())
 		if err != nil {
 			return err
 		}
 		args.Gas = &estimated
-		log.Global.WithField("gas", args.Gas).Trace("Estimate gas usage automatically")
+		log.Global.WithField("gas", args.Gas).Debug("Estimate gas usage automatically")
 	}
 	if args.ChainID == nil {
 		id := (*hexutil.Big)(b.ChainConfig().ChainID)

--- a/quai/api_backend.go
+++ b/quai/api_backend.go
@@ -268,6 +268,9 @@ func (b *QuaiAPIBackend) GetEVM(ctx context.Context, msg core.Message, state *st
 	if nodeCtx != common.ZONE_CTX {
 		return nil, vmError, errors.New("getEvm can only be called in zone chain")
 	}
+	if parent == nil {
+		return nil, nil, errors.New("parent block not found, parenthash: " + header.ParentHash(b.NodeCtx()).String())
+	}
 	if vmConfig == nil {
 		vmConfig = b.quai.core.GetVMConfig()
 	}

--- a/quai/quaiconfig/config.go
+++ b/quai/quaiconfig/config.go
@@ -84,7 +84,7 @@ var Defaults = Config{
 		Recommit: 3 * time.Second,
 	},
 	TxPool:      core.DefaultTxPoolConfig,
-	RPCGasCap:   50000000,
+	RPCGasCap:   params.GasCeil,
 	GPO:         FullNodeGPO,
 	RPCTxFeeCap: 1, // 1 ether
 }

--- a/quaiclient/ethclient/ethclient.go
+++ b/quaiclient/ethclient/ethclient.go
@@ -520,6 +520,25 @@ func (ec *Client) EstimateFeeForQi(ctx context.Context, tx *types.Transaction) (
 	return (*big.Int)(&result), nil
 }
 
+// AccessListResult returns an optional accesslist
+// Its the result of the `quai_createAccessList` RPC call.
+// It contains an error if the transaction itself failed.
+type AccessListResult struct {
+	Accesslist *types.AccessList `json:"accessList"`
+	Error      string            `json:"error,omitempty"`
+	GasUsed    hexutil.Uint64    `json:"gasUsed"`
+}
+
+// CreateAccessList creates an access list for a transaction.
+func (ec *Client) CreateAccessList(ctx context.Context, msg quai.CallMsg) (AccessListResult, error) {
+	var accessList AccessListResult
+	err := ec.c.CallContext(ctx, &accessList, "quai_createAccessList", toCallArg(msg))
+	if err != nil {
+		return accessList, err
+	}
+	return accessList, nil
+}
+
 // SendTransaction injects a signed transaction into the pending pool for execution.
 //
 // If the transaction was a contract creation use the TransactionReceipt method to get the


### PR DESCRIPTION
An Access List is a set of addresses and storage keys that a transaction accesses in the EVM. The list must be provided with the transaction, and if the list is incomplete, the transaction will fail. Therefore a user who wants to send a transaction that uses the EVM must call quai_createAccessList and attach the returned access list to the transaction before signing and submitting. A transaction that does not use the EVM, such as a simple balance transfer, does **not** need to supply an Access List because the sender and receiver are already part of the transaction.

**This PR makes many changes to the EVM and requires a robust review and audit.**