### PR TITLE
Accessor methods tests 2

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -26,7 +26,6 @@ import (
 	"github.com/dominant-strategies/go-quai/event"
 	"github.com/dominant-strategies/go-quai/log"
 	"github.com/dominant-strategies/go-quai/params"
-	"github.com/dominant-strategies/go-quai/rlp"
 	"github.com/dominant-strategies/go-quai/trie"
 )
 
@@ -911,12 +910,6 @@ func (c *Core) SubscribeChainHeadEvent(ch chan<- ChainHeadEvent) event.Subscript
 // hash, caching it if found.
 func (c *Core) GetBody(hash common.Hash) *types.WorkObject {
 	return c.sl.hc.GetBody(hash)
-}
-
-// GetBodyRLP retrieves a block body in RLP encoding from the database by hash,
-// caching it if found.
-func (c *Core) GetBodyRLP(hash common.Hash) rlp.RawValue {
-	return c.sl.hc.GetBodyRLP(hash)
 }
 
 // GetTerminiByHash retrieves the termini stored for a given header hash

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -23,7 +23,6 @@ import (
 	"github.com/dominant-strategies/go-quai/event"
 	"github.com/dominant-strategies/go-quai/log"
 	"github.com/dominant-strategies/go-quai/params"
-	"github.com/dominant-strategies/go-quai/rlp"
 	"github.com/dominant-strategies/go-quai/trie"
 	lru "github.com/hashicorp/golang-lru/v2"
 )
@@ -914,26 +913,6 @@ func (hc *HeaderChain) GetBody(hash common.Hash) *types.WorkObject {
 	}
 	// Cache the found body for next time and return
 	hc.bc.bodyCache.Add(hash, *body)
-	return body
-}
-
-// GetBodyRLP retrieves a block body in RLP encoding from the database by hash,
-// caching it if found.
-func (hc *HeaderChain) GetBodyRLP(hash common.Hash) rlp.RawValue {
-	// Short circuit if the body's already in the cache, retrieve otherwise
-	if cached, ok := hc.bc.bodyProtoCache.Get(hash); ok {
-		return cached
-	}
-	number := hc.GetBlockNumber(hash)
-	if number == nil {
-		return nil
-	}
-	body := rawdb.ReadBodyProto(hc.headerDb, hash, *number)
-	if len(body) == 0 {
-		return nil
-	}
-	// Cache the found body for next time and return
-	hc.bc.bodyProtoCache.Add(hash, body)
 	return body
 }
 

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -266,7 +266,7 @@ func ReadPbCacheBody(db ethdb.Reader, hash common.Hash) *types.WorkObject {
 		db.Logger().WithField("err", err).Fatal("Failed to proto Unmarshal body")
 	}
 	body := new(types.WorkObject)
-	body.ProtoDecode(protoWorkObject, db.Location(), types.PhObject)
+	err = body.ProtoDecode(protoWorkObject, db.Location(), types.PhObject)
 	if err != nil {
 		db.Logger().WithFields(log.Fields{
 			"hash": hash,

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -72,39 +72,6 @@ func ReadAllHashes(db ethdb.Iteratee, number uint64) []common.Hash {
 	return hashes
 }
 
-// ReadAllCanonicalHashes retrieves all canonical number and hash mappings at the
-// certain chain range. If the accumulated entries reaches the given threshold,
-// abort the iteration and return the semi-finish result.
-func ReadAllCanonicalHashes(db ethdb.Iteratee, from uint64, to uint64, limit int) ([]uint64, []common.Hash) {
-	// Short circuit if the limit is 0.
-	if limit == 0 {
-		return nil, nil
-	}
-	var (
-		numbers []uint64
-		hashes  []common.Hash
-	)
-	// Construct the key prefix of start point.
-	start, end := headerHashKey(from), headerHashKey(to)
-	it := db.NewIterator(nil, start)
-	defer it.Release()
-
-	for it.Next() {
-		if bytes.Compare(it.Key(), end) >= 0 {
-			break
-		}
-		if key := it.Key(); len(key) == len(headerPrefix)+8+1 && bytes.Equal(key[len(key)-1:], headerHashSuffix) {
-			numbers = append(numbers, binary.BigEndian.Uint64(key[len(headerPrefix):len(headerPrefix)+8]))
-			hashes = append(hashes, common.BytesToHash(it.Value()))
-			// If the accumulated entries reaches the limit threshold, return.
-			if len(numbers) >= limit {
-				break
-			}
-		}
-	}
-	return numbers, hashes
-}
-
 // ReadHeaderNumber returns the header number assigned to a hash.
 func ReadHeaderNumber(db ethdb.KeyValueReader, hash common.Hash) *uint64 {
 	data, _ := db.Get(headerNumberKey(hash))
@@ -174,89 +141,6 @@ func ReadHeadBlockHash(db ethdb.KeyValueReader) common.Hash {
 func WriteHeadBlockHash(db ethdb.KeyValueWriter, hash common.Hash) {
 	if err := db.Put(headWorkObjectKey, hash.Bytes()); err != nil {
 		db.Logger().WithField("err", err).Fatal("Failed to store last block's hash")
-	}
-}
-
-// ReadLastPivotNumber retrieves the number of the last pivot block. If the node
-// full synced, the last pivot will always be nil.
-func ReadLastPivotNumber(db ethdb.KeyValueReader) *uint64 {
-	data, _ := db.Get(lastPivotKey)
-	if len(data) == 0 {
-		return nil
-	}
-	protoPivot := new(ProtoNumber)
-	err := proto.Unmarshal(data, protoPivot)
-	if err != nil {
-		db.Logger().WithField("err", err).Fatal("Failed to proto Unmarshal pivot block number")
-	}
-	return &protoPivot.Number
-}
-
-// WriteLastPivotNumber stores the number of the last pivot block.
-func WriteLastPivotNumber(db ethdb.KeyValueWriter, pivot uint64) {
-	protoPivot := new(ProtoNumber)
-	protoPivot.Number = pivot
-	enc, err := proto.Marshal(protoPivot)
-	if err != nil {
-		db.Logger().WithField("err", err).Fatal("Failed to encode pivot block number")
-	}
-	if err := db.Put(lastPivotKey, enc); err != nil {
-		db.Logger().WithField("err", err).Fatal("Failed to store pivot block number")
-	}
-}
-
-// ReadFastTrieProgress retrieves the number of tries nodes fast synced to allow
-// reporting correct numbers across restarts.
-func ReadFastTrieProgress(db ethdb.KeyValueReader) uint64 {
-	data, _ := db.Get(fastTrieProgressKey)
-	if len(data) == 0 {
-		return 0
-	}
-	return new(big.Int).SetBytes(data).Uint64()
-}
-
-// WriteFastTrieProgress stores the fast sync trie process counter to support
-// retrieving it across restarts.
-func WriteFastTrieProgress(db ethdb.KeyValueWriter, count uint64) {
-	if err := db.Put(fastTrieProgressKey, new(big.Int).SetUint64(count).Bytes()); err != nil {
-		db.Logger().WithField("err", err).Fatal("Failed to store fast sync trie progress")
-	}
-}
-
-// ReadTxIndexTail retrieves the number of oldest indexed block
-// whose transaction indices has been indexed. If the corresponding entry
-// is non-existent in database it means the indexing has been finished.
-func ReadTxIndexTail(db ethdb.KeyValueReader) *uint64 {
-	data, _ := db.Get(txIndexTailKey)
-	if len(data) != 8 {
-		return nil
-	}
-	number := binary.BigEndian.Uint64(data)
-	return &number
-}
-
-// WriteTxIndexTail stores the number of oldest indexed block
-// into database.
-func WriteTxIndexTail(db ethdb.KeyValueWriter, number uint64) {
-	if err := db.Put(txIndexTailKey, encodeBlockNumber(number)); err != nil {
-		db.Logger().WithField("err", err).Fatal("Failed to store the transaction index tail")
-	}
-}
-
-// ReadFastTxLookupLimit retrieves the tx lookup limit used in fast sync.
-func ReadFastTxLookupLimit(db ethdb.KeyValueReader) *uint64 {
-	data, _ := db.Get(fastTxLookupLimitKey)
-	if len(data) != 8 {
-		return nil
-	}
-	number := binary.BigEndian.Uint64(data)
-	return &number
-}
-
-// WriteFastTxLookupLimit stores the txlookup limit used in fast sync into database.
-func WriteFastTxLookupLimit(db ethdb.KeyValueWriter, number uint64) {
-	if err := db.Put(fastTxLookupLimitKey, encodeBlockNumber(number)); err != nil {
-		db.Logger().WithField("err", err).Fatal("Failed to store transaction lookup limit for fast sync")
 	}
 }
 
@@ -351,32 +235,6 @@ func ReadBodyProto(db ethdb.Reader, hash common.Hash, number uint64) []byte {
 		}
 	}
 	return nil // Can't find the data anywhere.
-}
-
-// ReadCanonicalBodyProto retrieves the block body (transactions and uncles) for the canonical
-// block at number, in Proto encoding.
-func ReadCanonicalBodyProto(db ethdb.Reader, number uint64) []byte {
-	// If it's an ancient one, we don't need the canonical hash
-	data, _ := db.Ancient(freezerBodiesTable, number)
-	if len(data) == 0 {
-		// Need to get the hash
-		data, _ = db.Get(blockBodyKey(number, ReadCanonicalHash(db, number)))
-		// In the background freezer is moving data from leveldb to flatten files.
-		// So during the first check for ancient db, the data is not yet in there,
-		// but when we reach into leveldb, the data was already moved. That would
-		// result in a not found error.
-		if len(data) == 0 {
-			data, _ = db.Ancient(freezerBodiesTable, number)
-		}
-	}
-	return data
-}
-
-// WriteBodyProto stores an Proto encoded block body into the database.
-func WriteBodyProto(db ethdb.KeyValueWriter, hash common.Hash, number uint64, data []byte) {
-	if err := db.Put(blockBodyKey(number, hash), data); err != nil {
-		db.Logger().WithField("err", err).Fatal("Failed to store block body")
-	}
 }
 
 // HasBody verifies the existence of a block body corresponding to the hash.
@@ -869,18 +727,6 @@ func DeleteAllHeadsHashes(db ethdb.KeyValueWriter) {
 	}
 }
 
-// HasReceipts verifies the existence of all the transaction receipts belonging
-// to a block.
-func HasReceipts(db ethdb.Reader, hash common.Hash, number uint64) bool {
-	if has, err := db.Ancient(freezerHashTable, number); err == nil && common.BytesToHash(has) == hash {
-		return true
-	}
-	if has, err := db.Has(blockReceiptsKey(number, hash)); !has || err != nil {
-		return false
-	}
-	return true
-}
-
 // ReadReceiptsProto retrieves all the transaction receipts belonging to a block in Proto encoding.
 func ReadReceiptsProto(db ethdb.Reader, hash common.Hash, number uint64) []byte {
 	// First try to look up the data in ancient database. Extra hash
@@ -1125,19 +971,6 @@ func FindCommonAncestor(db ethdb.Reader, a, b *types.WorkObject, nodeCtx int) *t
 		}
 	}
 	return a
-}
-
-// ReadHeadHeader returns the current canonical head header.
-func ReadHeadHeader(db ethdb.Reader) *types.WorkObject {
-	headHeaderHash := ReadHeadHeaderHash(db)
-	if headHeaderHash == (common.Hash{}) {
-		return nil
-	}
-	headHeaderNumber := ReadHeaderNumber(db, headHeaderHash)
-	if headHeaderNumber == nil {
-		return nil
-	}
-	return ReadHeader(db, headHeaderHash)
 }
 
 // ReadHeadBlock returns the current canonical head block.

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -764,22 +764,8 @@ func ReadReceipts(db ethdb.Reader, hash common.Hash, number uint64, config *para
 
 // WriteReceipts stores all the transaction receipts belonging to a block.
 func WriteReceipts(db ethdb.KeyValueWriter, hash common.Hash, number uint64, receipts types.Receipts) {
-	// Convert the receipts into their storage form and serialize them
-	storageReceipts := make(types.ReceiptsForStorage, len(receipts))
-	for i, receipt := range receipts {
-		storageReceipts[i] = (*types.ReceiptForStorage)(receipt)
-	}
-
-	protoReceipts, err := storageReceipts.ProtoEncode()
-	if err != nil {
-		db.Logger().WithField("err", err).Fatal("Failed to proto encode receipt")
-	}
-	bytes, err := proto.Marshal(protoReceipts)
-	if err != nil {
-		db.Logger().WithField("err", err).Fatal("Failed to proto Marshal receipt")
-	}
 	// Store the flattened receipt slice
-	if err := db.Put(blockReceiptsKey(number, hash), bytes); err != nil {
+	if err := db.Put(blockReceiptsKey(number, hash), receipts.Bytes(db.Logger())); err != nil {
 		db.Logger().WithField("err", err).Fatal("Failed to store block receipts")
 	}
 }

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -145,7 +145,7 @@ func HasHeader(db ethdb.Reader, hash common.Hash, number uint64) bool {
 	if has, err := db.Ancient(freezerHashTable, number); err == nil && common.BytesToHash(has) == hash {
 		return true
 	}
-	if has, err := db.Has(headerKey(number, hash)); !has || err != nil {
+	if has, err := db.Has(blockWorkObjectHeaderKey(hash)); !has || err != nil {
 		return false
 	}
 	return true
@@ -163,18 +163,8 @@ func ReadHeader(db ethdb.Reader, hash common.Hash) *types.WorkObject {
 
 // DeleteHeader removes all block header data associated with a hash.
 func DeleteHeader(db ethdb.KeyValueWriter, hash common.Hash, number uint64) {
-	deleteHeaderWithoutNumber(db, hash, number)
-	if err := db.Delete(headerNumberKey(hash)); err != nil {
-		db.Logger().WithField("err", err).Fatal("Failed to delete hash to number mapping")
-	}
-}
-
-// deleteHeaderWithoutNumber removes only the block header but does not remove
-// the hash to number mapping.
-func deleteHeaderWithoutNumber(db ethdb.KeyValueWriter, hash common.Hash, number uint64) {
-	if err := db.Delete(headerKey(number, hash)); err != nil {
-		db.Logger().WithField("err", err).Fatal("Failed to delete header")
-	}
+	DeleteWorkObjectHeader(db, hash, types.BlockObject)
+	DeleteHeaderNumber(db, hash)
 }
 
 // HasBody verifies the existence of a block body corresponding to the hash.
@@ -465,7 +455,6 @@ func DeleteBlockWithoutNumber(db ethdb.KeyValueWriter, hash common.Hash, number 
 	DeleteWorkObjectBody(db, hash)
 	DeleteWorkObjectHeader(db, hash, woType) //TODO: mmtx transaction
 	DeleteReceipts(db, hash, number)
-	deleteHeaderWithoutNumber(db, hash, number)
 }
 
 // ReadWorkObjectBody retreive's the work object body stored in hash.

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -182,7 +182,7 @@ func HasBody(db ethdb.Reader, hash common.Hash, number uint64) bool {
 	if has, err := db.Ancient(freezerHashTable, number); err == nil && common.BytesToHash(has) == hash {
 		return true
 	}
-	if has, err := db.Has(blockBodyKey(number, hash)); !has || err != nil {
+	if has, err := db.Has(workObjectBodyKey(hash)); !has || err != nil {
 		return false
 	}
 	return true

--- a/core/rawdb/accessors_chain_indexes_test.go
+++ b/core/rawdb/accessors_chain_indexes_test.go
@@ -1,0 +1,85 @@
+package rawdb
+
+import (
+	"testing"
+
+	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/core/types"
+	"github.com/dominant-strategies/go-quai/log"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestTxLookupStorage(t *testing.T) {
+	db := NewMemoryDatabase(log.Global)
+
+	if entry := ReadTxLookupEntry(db, common.Hash{1}); entry != nil {
+		t.Fatalf("Non existent tx lookup returned: %v", entry)
+	}
+
+	if entry := ReadTxLookupEntry(db, common.Hash{2}); entry != nil {
+		t.Fatalf("Non existent tx lookup returned: %v", entry)
+	}
+
+	hashes := []common.Hash{{1}, {2}}
+
+	WriteTxLookupEntries(db, 1, hashes)
+
+	tx1 := createTransaction(1)
+	tx2 := createTransaction(2)
+	block := createBlockWithTransactions(types.Transactions{tx1, tx2})
+
+	WriteTxLookupEntriesByBlock(db, block, common.ZONE_CTX)
+
+	if entry := ReadTxLookupEntry(db, common.Hash{1}); *entry != 1 {
+		t.Fatal("Wrong tx lookup returned for hash 1")
+	}
+
+	if entry := ReadTxLookupEntry(db, common.Hash{2}); *entry != 1 {
+		t.Fatal("Wrong tx lookup returned for hash 2")
+	}
+
+	DeleteTxLookupEntries(db, hashes)
+
+	// check deleted tx lookups
+	if entry := ReadTxLookupEntry(db, common.Hash{1}); entry != nil {
+		t.Fatal("Deleted lookup returned for hash 1")
+	}
+
+	if entry := ReadTxLookupEntry(db, common.Hash{2}); entry != nil {
+		t.Fatal("Deleted lookup returned for hash 2")
+	}
+
+	// txs writen by block
+	if entry := ReadTxLookupEntry(db, tx1.Hash()); *entry != block.NumberU64(common.ZONE_CTX) {
+		t.Fatal("Wrong tx lookup returned for tx1 hash")
+	}
+
+	if entry := ReadTxLookupEntry(db, tx2.Hash()); *entry != block.NumberU64(common.ZONE_CTX) {
+		t.Fatal("Wrong tx lookup returned for tx2 hash")
+	}
+
+	//v4-v5 tx lookup
+	v4Hash := common.Hash{4}
+	v4Number := uint64(3)
+	WriteHeaderNumber(db, v4Hash, v4Number)
+	writeTxLookupEntry(db, v4Hash, v4Hash.Bytes())
+
+	if entry := ReadTxLookupEntry(db, v4Hash); *entry != v4Number {
+		t.Fatal("Wrong tx lookup returned for v4 hash")
+	}
+
+	//v3 tx lookup
+	v3Hash := common.Hash{5}
+	v3ProtoHash := &common.ProtoHash{Value: v3Hash.Bytes()}
+	v3Number := uint64(4)
+	v3entry, err := proto.Marshal(&ProtoLegacyTxLookupEntry{BlockIndex: v3Number, Hash: v3ProtoHash})
+	if err != nil {
+		t.Fatal("Failed to marshal ProtoLegacyTxLookupEntry")
+	}
+	writeTxLookupEntry(db, v3Hash, v3entry)
+
+	if entry := ReadTxLookupEntry(db, v3Hash); *entry != v3Number {
+		t.Fatal("Wrong tx lookup returned for v4 hash")
+	}
+
+}

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -561,15 +561,25 @@ func TestWorkObjectStorage(t *testing.T) {
 	if entry := ReadWorkObject(db, header.Hash(), types.BlockObject); entry != nil {
 		t.Fatalf("Non existent header returned: %v", entry)
 	}
-	t.Log("Header Hash stored", header.Hash())
+
+	if HasBody(db, header.Hash(), number.Uint64()) {
+		t.Fatalf("HasBody returned true on unexistent block")
+	}
+
 	// Write and verify the header in the database
 	WriteWorkObject(db, header.Hash(), header, types.BlockObject, common.ZONE_CTX)
+	t.Log("Header Hash stored", header.Hash())
 	entry := ReadWorkObject(db, header.Hash(), types.BlockObject)
 	if entry == nil {
 		t.Fatalf("Stored header not found with hash %s", entry.Hash())
 	} else if entry.Hash() != header.Hash() {
 		t.Fatalf("Retrieved header mismatch: have %v, want %v", entry, header)
 	}
+
+	if !HasBody(db, header.Hash(), number.Uint64()) {
+		t.Fatalf("HasBody returned false after writing block")
+	}
+
 	// Delete the header and verify the execution
 	DeleteWorkObject(db, header.Hash(), header.Number(common.ZONE_CTX).Uint64(), types.BlockObject)
 	if entry := ReadWorkObject(db, header.Hash(), types.BlockObject); entry != nil {

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -32,25 +32,6 @@ func TestCanonicalHashStorage(t *testing.T) {
 		t.Fatalf("Retrieved canonical hash mismatch: have %v, want %v", entry, hash)
 	}
 
-	var cases = []struct {
-		from, to uint64
-		limit    int
-		expect   []uint64
-	}{
-		{1, 2, 0, nil},
-		{1, 3, 2, []uint64{1, 2}},
-		{2, 6, 6, []uint64{2, 3, 4, 5}},
-		{1, 6, 6, []uint64{1, 2, 3, 4, 5}},
-		{6, 7, 6, nil},
-	}
-
-	for i, c := range cases {
-		numbers, _ := ReadAllCanonicalHashes(db, c.from, c.to, c.limit)
-		if !reflect.DeepEqual(numbers, c.expect) {
-			t.Fatalf("Case %d failed, want %v, got %v", i, c.expect, numbers)
-		}
-	}
-
 	// Delete all data from database.
 	for i := uint64(1); i <= 5; i++ {
 		DeleteCanonicalHash(db, uint64(i))
@@ -147,62 +128,6 @@ func TestHeadBlockStorage(t *testing.T) {
 
 	if entry := ReadHeadBlockHash(db); entry != hash {
 		t.Fatalf("Stored head block hash not found: %v", entry)
-	}
-}
-
-func TestLastPivotStorage(t *testing.T) {
-	db := NewMemoryDatabase(log.Global)
-
-	if entry := ReadLastPivotNumber(db); entry != nil {
-		t.Fatalf("Non existent last pivot number returned: %v", entry)
-	}
-
-	WriteLastPivotNumber(db, uint64(1))
-
-	if entry := ReadLastPivotNumber(db); *entry != uint64(1) {
-		t.Fatalf("Stored last pivot not found: %v", entry)
-	}
-}
-
-func TestFastTrieStorage(t *testing.T) {
-	db := NewMemoryDatabase(log.Global)
-
-	if entry := ReadFastTrieProgress(db); entry != 0 {
-		t.Fatalf("Non existent fast trie returned: %v", entry)
-	}
-
-	WriteFastTrieProgress(db, uint64(1))
-
-	if entry := ReadFastTrieProgress(db); entry != uint64(1) {
-		t.Fatalf("Stored fast trie not found: %v", entry)
-	}
-}
-
-func TestTxIndexTailStorage(t *testing.T) {
-	db := NewMemoryDatabase(log.Global)
-
-	if entry := ReadTxIndexTail(db); entry != nil {
-		t.Fatalf("Non existent tx index returned: %v", entry)
-	}
-
-	WriteTxIndexTail(db, uint64(1))
-
-	if entry := ReadTxIndexTail(db); *entry != uint64(1) {
-		t.Fatalf("Stored tx index not found: %v", entry)
-	}
-}
-
-func TestFastTxLookupStorage(t *testing.T) {
-	db := NewMemoryDatabase(log.Global)
-
-	if entry := ReadFastTxLookupLimit(db); entry != nil {
-		t.Fatalf("Non existent fast tx lookup returned: %v", entry)
-	}
-
-	WriteFastTxLookupLimit(db, uint64(1))
-
-	if entry := ReadFastTxLookupLimit(db); *entry != uint64(1) {
-		t.Fatalf("Stored fast tx lookup not found: %v", entry)
 	}
 }
 
@@ -325,29 +250,6 @@ func TestBestPhKeyStorage(t *testing.T) {
 
 	if entry := ReadBestPhKey(db); entry != emptyHash {
 		t.Fatalf("Failed to delete key: %v", entry)
-	}
-}
-
-func TestEtxSetStorage(t *testing.T) {
-	db := NewMemoryDatabase(log.Global)
-
-	// Create a test etxSet to move around the database and make sure it's really new
-	etxSet := types.NewEtxSet()
-	hash := common.Hash{1}
-	var number uint64 = 0
-	if entry := ReadEtxSet(db, hash, number); entry != nil {
-		t.Fatalf("Non existent etxSet returned: %v", entry)
-	}
-	t.Log("EtxSet Hash stored", hash)
-	// Write and verify the etxSet in the database
-	WriteEtxSet(db, hash, 0, etxSet)
-	if entry := ReadEtxSet(db, hash, number); entry == nil {
-		t.Fatalf("Stored etxSet not found with hash %s", hash)
-	}
-	// Delete the etxSet and verify the execution
-	DeleteEtxSet(db, hash, number)
-	if entry := ReadEtxSet(db, hash, number); entry != nil {
-		t.Fatalf("Deleted etxSet returned: %v", entry)
 	}
 }
 

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -760,3 +760,23 @@ func TestAddressOutpointsStorage(t *testing.T) {
 	}
 }
 
+func TestGenesisHashesStorage(t *testing.T) {
+	db := NewMemoryDatabase(log.Global)
+
+	if entry := ReadGenesisHashes(db); len(entry) != 0 {
+		t.Fatalf("Non existent genesis hashes returned: %v", entry)
+	}
+
+	hashes := common.Hashes{{1}, {2}}
+	WriteGenesisHashes(db, hashes)
+
+	if entry := ReadGenesisHashes(db); entry[0] != hashes[0] || entry[1] != hashes[1] {
+		t.Fatalf("Stored genesis hashes not found: %v", entry)
+	}
+
+	DeleteGenesisHashes(db)
+
+	if entry := ReadGenesisHashes(db); len(entry) != 0 {
+		t.Fatalf("Deleted genesis hashes returned: %v", entry)
+	}
+}

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -770,12 +770,16 @@ func TestAncientReceiptsStorage(t *testing.T) {
 
 }
 
-func writeBlockForReceipts(db ethdb.Database, hash common.Hash, txs types.Transactions) {
+func createBlockWithTransactions(txs types.Transactions) *types.WorkObject {
 	woBody := types.EmptyWorkObjectBody()
 	woBody.SetHeader(types.EmptyHeader())
 	woBody.SetTransactions(txs)
-	header := types.NewWorkObject(types.NewWorkObjectHeader(types.EmptyRootHash, types.EmptyRootHash, big.NewInt(11), big.NewInt(30000), big.NewInt(42), types.EmptyRootHash, types.BlockNonce{23}, 1, common.LocationFromAddressBytes([]byte{0x01, 0x01}), common.BytesToAddress([]byte{0}, common.Location{0, 0})), woBody, nil)
-	WriteWorkObject(db, hash, header, types.BlockObject, common.ZONE_CTX)
+	return types.NewWorkObject(types.NewWorkObjectHeader(types.EmptyRootHash, types.EmptyRootHash, big.NewInt(11), big.NewInt(30000), big.NewInt(42), types.EmptyRootHash, types.BlockNonce{23}, 1, common.LocationFromAddressBytes([]byte{0x01, 0x01}), common.BytesToAddress([]byte{0}, common.Location{0, 0})), woBody, nil)
+}
+
+func writeBlockForReceipts(db ethdb.Database, hash common.Hash, txs types.Transactions) {
+	wo := createBlockWithTransactions(txs)
+	WriteWorkObject(db, hash, wo, types.BlockObject, common.ZONE_CTX)
 }
 
 func TestInterlinkHashesStorage(t *testing.T) {

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -184,9 +184,7 @@ func TestPbCacheStorage(t *testing.T) {
 	}
 
 	// Create a test header to move around the database and make sure it's really new
-	woBody := &types.WorkObjectBody{}
-	woBody.SetTransactions([]*types.Transaction{})
-	woBody.SetExtTransactions([]*types.Transaction{})
+	woBody := types.EmptyWorkObjectBody()
 	woBody.SetHeader(types.EmptyHeader())
 
 	woHeader := types.NewWorkObjectHeader(types.EmptyRootHash, types.EmptyRootHash, big.NewInt(11), big.NewInt(30000), big.NewInt(42), types.EmptyRootHash, types.BlockNonce{23}, 1, common.LocationFromAddressBytes([]byte{0x01, 0x01}), common.BytesToAddress([]byte{1}, common.Location{0, 0}))
@@ -341,7 +339,6 @@ func TestBlockHashesIterator(t *testing.T) {
 	for i, tc := range testCases {
 		hashes[i] = make(map[common.Hash]bool)
 		for j := int64(1); j <= tc.blockAmount; j++ {
-			//TODO: FILL UP DATABASE
 			blockHeader := types.EmptyHeader()
 			blockBody := types.EmptyWorkObjectBody()
 			blockBody.SetHeader(blockHeader)
@@ -582,13 +579,13 @@ func TestWorkObjectStorage(t *testing.T) {
 	db := NewMemoryDatabase(log.Global)
 
 	// Create a test header to move around the database and make sure it's really new
-	woBody := &types.WorkObjectBody{}
-	woBody.SetTransactions([]*types.Transaction{})
-	woBody.SetExtTransactions([]*types.Transaction{})
+	woBody := types.EmptyWorkObjectBody()
 	woBody.SetHeader(types.EmptyHeader())
 
 	number := big.NewInt(11)
-	header := types.NewWorkObject(types.NewWorkObjectHeader(types.EmptyRootHash, types.EmptyRootHash, big.NewInt(11), big.NewInt(30000), big.NewInt(42), types.EmptyRootHash, types.BlockNonce{23}, 1, common.LocationFromAddressBytes([]byte{0x01, 0x01}), common.BytesToAddress([]byte{0}, common.Location{0, 0})), woBody, nil)
+
+	woHeader := types.NewWorkObjectHeader(types.EmptyRootHash, types.EmptyRootHash, big.NewInt(11), big.NewInt(30000), big.NewInt(42), types.EmptyRootHash, types.BlockNonce{23}, 1, common.LocationFromAddressBytes([]byte{0x01, 0x01}), common.BytesToAddress([]byte{0}, common.Location{0, 0}))
+	header := types.NewWorkObject(woHeader, woBody, nil)
 	if entry := ReadWorkObject(db, header.Hash(), types.BlockObject); entry != nil {
 		t.Fatalf("Non existent header returned: %v", entry)
 	}

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -684,3 +684,26 @@ func TestReceiptsStorage(t *testing.T) {
 		t.Fatalf("Deleted receipts returned: %v", entry)
 	}
 }
+
+func TestInterlinkHashesStorage(t *testing.T) {
+	db := NewMemoryDatabase(log.Global)
+
+	hash := common.Hash{1}
+	if entry := ReadInterlinkHashes(db, hash); entry != nil {
+		t.Fatalf("Non existent interlink hashes returned: %v", entry)
+	}
+
+	interlinkHashes := common.Hashes{{2}, {3}}
+
+	WriteInterlinkHashes(db, hash, interlinkHashes)
+
+	if entry := ReadInterlinkHashes(db, common.Hash{1}); entry[0] != interlinkHashes[0] || entry[1] != interlinkHashes[1] {
+		t.Fatalf("Stored interlink hashes not found: %v", entry)
+	}
+
+	DeleteInterlinkHashes(db, common.Hash{1})
+
+	if entry := ReadInterlinkHashes(db, common.Hash{1}); entry != nil {
+		t.Fatalf("Deleted interlink hashes returned: %v", entry)
+	}
+}

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -132,7 +132,7 @@ func TestHeadHeaderStorage(t *testing.T) {
 	}
 }
 
-func TestHeadBlockStorage(t *testing.T) {
+func TestHeadBlockHashStorage(t *testing.T) {
 	db := NewMemoryDatabase(log.Global)
 
 	emptyHash := common.Hash{}
@@ -146,6 +146,34 @@ func TestHeadBlockStorage(t *testing.T) {
 	if entry := ReadHeadBlockHash(db); entry != hash {
 		t.Fatalf("Stored head block hash not found: %v", entry)
 	}
+}
+
+func TestHeadBlockStorage(t *testing.T) {
+	db := NewMemoryDatabase(log.Global)
+
+	if entry := ReadHeadBlock(db); entry != nil {
+		t.Fatalf("Non existent head block returned: %v", entry)
+	}
+
+	hash := common.Hash{1}
+	WriteHeadBlockHash(db, hash)
+
+	if entry := ReadHeadBlock(db); entry != nil {
+		t.Fatalf("Non existent head block returned: %v", entry)
+	}
+
+	blockNumber := uint64(1)
+	WriteHeaderNumber(db, hash, blockNumber)
+
+	wo := types.EmptyWorkObject(common.ZONE_CTX)
+	wo.WorkObjectHeader().SetCoinbase(common.BytesToAddress([]byte{1}, common.Location{0, 0}))
+
+	WriteWorkObject(db, hash, wo, types.BlockObject, common.ZONE_CTX)
+
+	if entry := ReadHeadBlock(db); entry == nil || entry.Hash() != wo.Hash() {
+		t.Fatalf("Failed to read head block: expeted: %v \n found: %v", wo, entry)
+	}
+
 }
 
 func TestPbCacheStorage(t *testing.T) {

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -63,7 +63,7 @@ func TestHeaderStorage(t *testing.T) {
 
 	wo := types.NewWorkObject(woHeader, woBody, nil)
 
-	if HasHeader(db, header.Hash(), common.REGION_CTX) {
+	if HasHeader(db, wo.Hash(), common.REGION_CTX) {
 		t.Fatal("Non existent header returned")
 	}
 	if entry := ReadHeader(db, wo.Hash()); entry != nil {
@@ -73,7 +73,7 @@ func TestHeaderStorage(t *testing.T) {
 	WriteWorkObject(db, wo.Hash(), wo, types.BlockObject, common.REGION_CTX)
 	t.Log("Header Hash stored", header.Hash())
 
-	if HasHeader(db, header.Hash(), header.NumberU64(common.REGION_CTX)) {
+	if !HasHeader(db, wo.Hash(), header.NumberU64(common.REGION_CTX)) {
 		t.Fatal("HasHeader returned false")
 	}
 

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -707,3 +707,56 @@ func TestInterlinkHashesStorage(t *testing.T) {
 		t.Fatalf("Deleted interlink hashes returned: %v", entry)
 	}
 }
+
+func TestAddressOutpointsStorage(t *testing.T) {
+	db := NewMemoryDatabase(log.Global)
+
+	address := "0x008aeeda4d805471df9b2a5b0f38a0c3bcba786b"
+	address2 := "0x008b2a5b0f38a0c3bcba786ba3df9b2a5b0f38a0"
+
+	if entry := ReadOutpointsForAddress(db, address); len(entry) != 0 {
+		t.Fatalf("Non existent address outpoints returned: %v", entry)
+	}
+
+	outpoint := types.OutpointAndDenomination{
+		TxHash:       common.Hash{1},
+		Index:        uint16(1),
+		Denomination: uint8(1),
+	}
+
+	outpoint2 := types.OutpointAndDenomination{
+		TxHash:       common.Hash{2},
+		Index:        uint16(1),
+		Denomination: uint8(1),
+	}
+
+	outpointMap := map[string]*types.OutpointAndDenomination{
+		outpoint.Key(): &outpoint,
+	}
+
+	outpointMap2 := map[string]*types.OutpointAndDenomination{
+		outpoint2.Key(): &outpoint2,
+	}
+
+	addressOutpointMap := map[string]map[string]*types.OutpointAndDenomination{
+		address:  outpointMap,
+		address2: outpointMap2,
+	}
+
+	WriteAddressOutpoints(db, addressOutpointMap)
+
+	if entry := ReadOutpointsForAddress(db, address); len(entry) == 0 || *entry[outpoint.Key()] != outpoint {
+		if len(entry) > 0 {
+			t.Fatalf("expected: %v \n found: %v", entry[outpoint.Key()], outpoint)
+		}
+		t.Fatal("Stored outpoint not found")
+	}
+
+	if entry := ReadOutpointsForAddress(db, address2); len(entry) == 0 || *entry[outpoint2.Key()] != outpoint2 {
+		if len(entry) > 0 {
+			t.Fatalf("expected: %v \n found: %v", entry[outpoint2.Key()], outpoint2)
+		}
+		t.Fatal("Stored outpoint not found")
+	}
+}
+

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -101,7 +101,7 @@ func (db *nofreezedb) AncientSize(kind string) (uint64, error) {
 }
 
 // AppendAncient returns an error as we don't have a backing chain freezer.
-func (db *nofreezedb) AppendAncient(number uint64, hash, header, body, receipts []byte) error {
+func (db *nofreezedb) AppendAncient(number uint64, hash, receipts []byte) error {
 	return errNotSupported
 }
 
@@ -456,7 +456,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte, logger *log.
 	}
 	// Inspect append-only file store then.
 	ancientSizes := []*common.StorageSize{&ancientHeadersSize, &ancientBodiesSize, &ancientReceiptsSize, &ancientHashesSize, &ancientTdsSize}
-	for i, category := range []string{freezerHeaderTable, freezerBodiesTable, freezerReceiptTable, freezerHashTable, freezerDifficultyTable} {
+	for i, category := range []string{freezerReceiptTable, freezerHashTable, freezerDifficultyTable} {
 		if size, err := db.AncientSize(category); err == nil {
 			*ancientSizes[i] += common.StorageSize(size)
 			total += common.StorageSize(size)

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -391,7 +391,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte, logger *log.
 		switch {
 		case bytes.HasPrefix(key, headerPrefix) && len(key) == (len(headerPrefix)+8+common.HashLength):
 			headers.Add(size)
-		case bytes.HasPrefix(key, blockBodyPrefix) && len(key) == (len(blockBodyPrefix)+8+common.HashLength):
+		case bytes.HasPrefix(key, workObjectBodyPrefix) && len(key) == (len(workObjectBodyPrefix)+8+common.HashLength):
 			bodies.Add(size)
 		case bytes.HasPrefix(key, blockReceiptsPrefix) && len(key) == (len(blockReceiptsPrefix)+8+common.HashLength):
 			receipts.Add(size)

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -389,7 +389,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte, logger *log.
 		)
 		total += size
 		switch {
-		case bytes.HasPrefix(key, headerPrefix) && len(key) == (len(headerPrefix)+8+common.HashLength):
+		case bytes.HasPrefix(key, blockWorkObjectHeaderPrefix) && len(key) == (len(blockWorkObjectHeaderPrefix)+8+common.HashLength):
 			headers.Add(size)
 		case bytes.HasPrefix(key, workObjectBodyPrefix) && len(key) == (len(workObjectBodyPrefix)+8+common.HashLength):
 			bodies.Add(size)

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -101,7 +101,7 @@ func (db *nofreezedb) AncientSize(kind string) (uint64, error) {
 }
 
 // AppendAncient returns an error as we don't have a backing chain freezer.
-func (db *nofreezedb) AppendAncient(number uint64, hash, header, body, receipts, etxSet []byte) error {
+func (db *nofreezedb) AppendAncient(number uint64, hash, header, body, receipts []byte) error {
 	return errNotSupported
 }
 
@@ -456,7 +456,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte, logger *log.
 	}
 	// Inspect append-only file store then.
 	ancientSizes := []*common.StorageSize{&ancientHeadersSize, &ancientBodiesSize, &ancientReceiptsSize, &ancientHashesSize, &ancientTdsSize}
-	for i, category := range []string{freezerHeaderTable, freezerBodiesTable, freezerReceiptTable, freezerHashTable, freezerDifficultyTable, freezerEtxSetsTable} {
+	for i, category := range []string{freezerHeaderTable, freezerBodiesTable, freezerReceiptTable, freezerHashTable, freezerDifficultyTable} {
 		if size, err := db.AncientSize(category); err == nil {
 			*ancientSizes[i] += common.StorageSize(size)
 			total += common.StorageSize(size)

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -430,9 +430,9 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte, logger *log.
 		default:
 			var accounted bool
 			for _, meta := range [][]byte{
-				databaseVersionKey, headHeaderKey, headWorkObjectKey, lastPivotKey,
-				fastTrieProgressKey, snapshotDisabledKey, snapshotRootKey, snapshotJournalKey,
-				snapshotGeneratorKey, snapshotRecoveryKey, txIndexTailKey, fastTxLookupLimitKey,
+				databaseVersionKey, headHeaderKey, headWorkObjectKey,
+				snapshotDisabledKey, snapshotRootKey, snapshotJournalKey,
+				snapshotGeneratorKey, snapshotRecoveryKey,
 				uncleanShutdownKey, badWorkObjectKey,
 			} {
 				if bytes.Equal(key, meta) {

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -229,11 +229,6 @@ func processedStateKey(hash common.Hash) []byte {
 	return append(processedStatePrefix, hash.Bytes()...)
 }
 
-// blockBodyKey = blockBodyPrefix + num (uint64 big endian) + hash
-func blockBodyKey(number uint64, hash common.Hash) []byte {
-	return append(append(blockBodyPrefix, encodeBlockNumber(number)...), hash.Bytes()...)
-}
-
 // blockReceiptsKey = blockReceiptsPrefix + num (uint64 big endian) + hash
 func blockReceiptsKey(number uint64, hash common.Hash) []byte {
 	return append(append(blockReceiptsPrefix, encodeBlockNumber(number)...), hash.Bytes()...)

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -111,9 +111,6 @@ var (
 )
 
 const (
-	// freezerHeaderTable indicates the name of the freezer header table.
-	freezerHeaderTable = "headers"
-
 	// freezerHashTable indicates the name of the freezer canonical hash table.
 	freezerHashTable = "hashes"
 
@@ -130,7 +127,6 @@ const (
 // FreezerNoSnappy configures whether compression is disabled for the ancient-tables.
 // Hashes and difficulties don't compress well.
 var FreezerNoSnappy = map[string]bool{
-	freezerHeaderTable:     false,
 	freezerHashTable:       true,
 	freezerBodiesTable:     false,
 	freezerReceiptTable:    false,

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -38,17 +38,8 @@ var (
 	// headersHashKey tracks the latest known headers hash in Blockchain.
 	headsHashesKey = []byte("HeadersHash")
 
-	// phCacheKey tracks the latest known pending headers in Blockchain.
-	phCacheKey = []byte("PhCache")
-
 	// phHead tracks the latest known pending headers hash in Blockchain.
 	phHeadKey = []byte("PhHead")
-
-	// lastPivotKey tracks the last pivot block used by fast sync (to reenable on sethead).
-	lastPivotKey = []byte("LastPivot")
-
-	// fastTrieProgressKey tracks the number of trie entries imported during fast sync.
-	fastTrieProgressKey = []byte("TrieSync")
 
 	// snapshotDisabledKey flags that the snapshot should not be maintained due to initial sync.
 	snapshotDisabledKey = []byte("SnapshotDisabled")
@@ -68,12 +59,6 @@ var (
 	// snapshotSyncStatusKey tracks the snapshot sync status across restarts.
 	snapshotSyncStatusKey = []byte("SnapshotSyncStatus")
 
-	// txIndexTailKey tracks the oldest block whose transactions have been indexed.
-	txIndexTailKey = []byte("TransactionIndexTail")
-
-	// fastTxLookupLimitKey tracks the transaction lookup limit during fast sync.
-	fastTxLookupLimitKey = []byte("FastTransactionLookupLimit")
-
 	// badWorkObjectKey tracks the list of bad blocks seen by local
 	badWorkObjectKey = []byte("InvalidWorkObject")
 
@@ -90,19 +75,13 @@ var (
 	headerNumberPrefix = []byte("H") // headerNumberPrefix + hash -> num (uint64 big endian)
 
 	pendingHeaderPrefix         = []byte("ph")    // pendingHeaderPrefix + hash -> header
-	candidateBodyPrefix         = []byte("cb")    // candidateBodyPrefix + hash -> Body
 	pbBodyPrefix                = []byte("pb")    // pbBodyPrefix + hash -> *types.Body
 	pbBodyHashPrefix            = []byte("pbKey") // pbBodyPrefix -> []common.Hash
-	phTerminiPrefix             = []byte("pht")   // phTerminiPrefix + hash -> []common.Hash
-	phBodyPrefix                = []byte("pc")    // phBodyPrefix + hash -> []common.Hash + Td
 	terminiPrefix               = []byte("tk")    //terminiPrefix + hash -> []common.Hash
 	blockWorkObjectHeaderPrefix = []byte("bw")    //blockWObjectHeaderPrefix + hash -> []common.Hash
 	txWorkObjectHeaderPrefix    = []byte("tw")    //txWorkObjectHeaderPrefix + hash -> []common.Hash
 	phWorkObjectHeaderPrefix    = []byte("pw")    //phWorkObjectHeaderPrefix + hash -> []common.Hash
 	workObjectBodyPrefix        = []byte("wb")    //workObjectBodyPrefix + hash -> []common.Hash
-	blockWorkObjectPrefix       = []byte("bo")    //blockWorkObjectPrefix + hash -> []common.Hash
-	txWorkObjectPrefix          = []byte("to")    //txWorkObjectPrefix + hash -> []common.Hash
-	phWorkObjectPrefix          = []byte("po")    //phWorkObjectPrefix + hash -> []common.Hash
 	badHashesListPrefix         = []byte("bh")
 	inboundEtxsPrefix           = []byte("ie")    // inboundEtxsPrefix + hash -> types.Transactions
 	UtxoPrefix                  = []byte("ut")    // outpointPrefix + hash -> types.Outpoint
@@ -125,9 +104,6 @@ var (
 	SnapshotAccountPrefix = []byte("a") // SnapshotAccountPrefix + account hash -> account trie value
 	SnapshotStoragePrefix = []byte("o") // SnapshotStoragePrefix + account hash + storage hash -> storage trie value
 	CodePrefix            = []byte("c") // CodePrefix + code hash -> account code
-
-	expansionStatusPrefix = []byte("exp") // ExpansionStatusPrefix + block hash -> ExpansionStatus
-	efficiencyScorePrefix = []byte("es")  // EfficiencyScorePrefix + block hash -> EfficiencyScore
 
 	preimagePrefix = []byte("secure-key-")  // preimagePrefix + hash -> preimage
 	configPrefix   = []byte("quai-config-") // config prefix for the db
@@ -249,16 +225,6 @@ func pbBodyHashKey() []byte {
 	return pbBodyHashPrefix
 }
 
-// phBodyTerminiKey = phTerminiPrefix + hash
-func phBodyTerminiKey(hash common.Hash) []byte {
-	return append(phTerminiPrefix, hash.Bytes()...)
-}
-
-// headerTDKey = headerPrefix + num (uint64 big endian) + hash + headerTDSuffix
-func headerTDKey(number uint64, hash common.Hash) []byte {
-	return append(headerKey(number, hash), headerTDSuffix...)
-}
-
 // headerHashKey = headerPrefix + num (uint64 big endian) + headerHashSuffix
 func headerHashKey(number uint64) []byte {
 	return append(append(headerPrefix, encodeBlockNumber(number)...), headerHashSuffix...)
@@ -321,16 +287,6 @@ func preimageKey(hash common.Hash) []byte {
 // codeKey = CodePrefix + hash
 func codeKey(hash common.Hash) []byte {
 	return append(CodePrefix, hash.Bytes()...)
-}
-
-// expansionStatusKey = expansionStatusPrefix + hash
-func expansionStatusKey(hash common.Hash) []byte {
-	return append(expansionStatusPrefix, hash.Bytes()...)
-}
-
-// efficiencyScoreKey = efficiencyScorePrefix + hash
-func efficiencyScoreKey(hash common.Hash) []byte {
-	return append(efficiencyScorePrefix, hash.Bytes()...)
 }
 
 // IsCodeKey reports whether the given byte slice is the key of contract code,

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -308,10 +308,6 @@ func etxSetKey(number uint64, hash common.Hash) []byte {
 	return append(append(etxSetHashesPrefix, encodeBlockNumber(number)...), hash.Bytes()...)
 }
 
-func etxKey(hash common.Hash) []byte {
-	return append(etxPrefix, hash.Bytes()...)
-}
-
 // pendingEtxsKey = pendingEtxsPrefix + hash
 func pendingEtxsKey(hash common.Hash) []byte {
 	return append(pendingEtxsPrefix, hash.Bytes()...)

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -89,15 +89,13 @@ var (
 	AddressUtxosPrefix          = []byte("au")    // addressUtxosPrefix + hash -> []types.UtxoEntry
 	processedStatePrefix        = []byte("ps")    // processedStatePrefix + hash -> boolean
 
-	blockBodyPrefix         = []byte("b")   // blockBodyPrefix + num (uint64 big endian) + hash -> block body
-	blockReceiptsPrefix     = []byte("r")   // blockReceiptsPrefix + num (uint64 big endian) + hash -> block receipts
-	etxSetHashesPrefix      = []byte("e")   // etxSetPrefix + num (uint64 big endian) + hash -> EtxSetHashes at block
-	etxPrefix               = []byte("etx") // etxKey + hash -> Etx
-	pendingEtxsPrefix       = []byte("pe")  // pendingEtxsPrefix + hash -> PendingEtxs at block
-	pendingEtxsRollupPrefix = []byte("pr")  // pendingEtxsRollupPrefix + hash -> PendingEtxsRollup at block
-	manifestPrefix          = []byte("ma")  // manifestPrefix + hash -> Manifest at block
-	interlinkPrefix         = []byte("il")  // interlinkPrefix + hash -> Interlink at block
-	bloomPrefix             = []byte("bl")  // bloomPrefix + hash -> bloom at block
+	blockBodyPrefix         = []byte("b")  // blockBodyPrefix + num (uint64 big endian) + hash -> block body
+	blockReceiptsPrefix     = []byte("r")  // blockReceiptsPrefix + num (uint64 big endian) + hash -> block receipts
+	pendingEtxsPrefix       = []byte("pe") // pendingEtxsPrefix + hash -> PendingEtxs at block
+	pendingEtxsRollupPrefix = []byte("pr") // pendingEtxsRollupPrefix + hash -> PendingEtxsRollup at block
+	manifestPrefix          = []byte("ma") // manifestPrefix + hash -> Manifest at block
+	interlinkPrefix         = []byte("il") // interlinkPrefix + hash -> Interlink at block
+	bloomPrefix             = []byte("bl") // bloomPrefix + hash -> bloom at block
 
 	txLookupPrefix        = []byte("l") // txLookupPrefix + hash -> transaction/receipt lookup metadata
 	bloomBitsPrefix       = []byte("B") // bloomBitsPrefix + bit (uint16 big endian) + section (uint64 big endian) + hash -> bloom bits
@@ -127,9 +125,6 @@ const (
 
 	// freezerDifficultyTable indicates the name of the freezer total difficulty table.
 	freezerDifficultyTable = "diffs"
-
-	// freezerEtxSetsTable indicates the name of the etx set table.
-	freezerEtxSetsTable = "etxSets"
 )
 
 // FreezerNoSnappy configures whether compression is disabled for the ancient-tables.
@@ -140,7 +135,6 @@ var FreezerNoSnappy = map[string]bool{
 	freezerBodiesTable:     false,
 	freezerReceiptTable:    false,
 	freezerDifficultyTable: true,
-	freezerEtxSetsTable:    false,
 }
 
 // LegacyTxLookupEntry is the legacy TxLookupEntry definition with some unnecessary
@@ -301,11 +295,6 @@ func IsCodeKey(key []byte) (bool, []byte) {
 // configKey = configPrefix + hash
 func configKey(hash common.Hash) []byte {
 	return append(configPrefix, hash.Bytes()...)
-}
-
-// etxSetKey = etxSetPrefix + num (uint64 big endian) + hash
-func etxSetKey(number uint64, hash common.Hash) []byte {
-	return append(append(etxSetHashesPrefix, encodeBlockNumber(number)...), hash.Bytes()...)
 }
 
 // pendingEtxsKey = pendingEtxsPrefix + hash

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -90,8 +90,8 @@ func (t *table) AncientSize(kind string) (uint64, error) {
 
 // AppendAncient is a noop passthrough that just forwards the request to the underlying
 // database.
-func (t *table) AppendAncient(number uint64, hash, header, body, receipts []byte) error {
-	return t.db.AppendAncient(number, hash, header, body, receipts)
+func (t *table) AppendAncient(number uint64, hash, receipts []byte) error {
+	return t.db.AppendAncient(number, hash, receipts)
 }
 
 // TruncateAncients is a noop passthrough that just forwards the request to the underlying

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -90,8 +90,8 @@ func (t *table) AncientSize(kind string) (uint64, error) {
 
 // AppendAncient is a noop passthrough that just forwards the request to the underlying
 // database.
-func (t *table) AppendAncient(number uint64, hash, header, body, receipts, etxSet []byte) error {
-	return t.db.AppendAncient(number, hash, header, body, receipts, etxSet)
+func (t *table) AppendAncient(number uint64, hash, header, body, receipts []byte) error {
+	return t.db.AppendAncient(number, hash, header, body, receipts)
 }
 
 // TruncateAncients is a noop passthrough that just forwards the request to the underlying

--- a/core/slice.go
+++ b/core/slice.go
@@ -1776,7 +1776,6 @@ func (sl *Slice) cleanCacheAndDatabaseTillBlock(hash common.Hash) {
 		rawdb.DeleteCanonicalHash(sl.sliceDb, header.NumberU64(nodeCtx))
 		rawdb.DeleteHeaderNumber(sl.sliceDb, header.Hash())
 		rawdb.DeleteTermini(sl.sliceDb, header.Hash())
-		rawdb.DeleteEtxSet(sl.sliceDb, header.Hash(), header.NumberU64(nodeCtx))
 		if nodeCtx != common.ZONE_CTX {
 			rawdb.DeletePendingEtxs(sl.sliceDb, header.Hash())
 			rawdb.DeletePendingEtxsRollup(sl.sliceDb, header.Hash())

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -100,7 +100,7 @@ type AncientReader interface {
 type AncientWriter interface {
 	// AppendAncient injects all binary blobs belong to block at the end of the
 	// append-only immutable table files.
-	AppendAncient(number uint64, hash, header, body, receipt []byte) error
+	AppendAncient(number uint64, hash, receipt []byte) error
 
 	// TruncateAncients discards all but the first n ancient data from the ancient store.
 	TruncateAncients(n uint64) error

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -100,7 +100,7 @@ type AncientReader interface {
 type AncientWriter interface {
 	// AppendAncient injects all binary blobs belong to block at the end of the
 	// append-only immutable table files.
-	AppendAncient(number uint64, hash, header, body, receipt, etxSet []byte) error
+	AppendAncient(number uint64, hash, header, body, receipt []byte) error
 
 	// TruncateAncients discards all but the first n ancient data from the ancient store.
 	TruncateAncients(n uint64) error


### PR DESCRIPTION
closes #1826 

Few points to consider on this pr

- HasHeader and HasBody
 on the commits 6622c1d and 19eb146 I changed the hasBody and hasHeader keys to workobjects ones since they were not working properly, would this be the right way to solve this?

  Functions are referenced on
  HasHeader on [sliceAppend]( https://github.com/dominant-strategies/go-quai/blob/main/core/slice.go#L207)
  HasBody on api [ImportChain](https://github.com/dominant-strategies/go-quai/blob/main/quai/api.go#L220)

-  ReadAllHashes functions is not working properly. 

      It was supposed to read all hashes associated with a number.
      Previously in order to write headers header key which had the headerPrefix and blockNumber and hash appended was used
      but now workobjects write method only append by hash.
      Now ReadAllHashes always returns empty since we cant search into workobjects by number
      ReadAllHashes in referenced only at [freezer](https://github.com/dominant-strategies/go-quai/blob/main/core/rawdb/freezer.go#L306)


- I left badBlock storage out of tests since it only have a read method (not write or delete)
May I create a write method for it to be included on tests?

- For similar reason I left DeleteAddressUtxos out, there is no read method for it