### PR TITLE
Fix grind address on Create miss

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -352,7 +352,8 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 
 	// Set up the initial access list.
 	rules := st.evm.ChainConfig().Rules(st.evm.Context.BlockNumber)
-	st.state.PrepareAccessList(msg.From(), msg.To(), vm.ActivePrecompiles(rules, st.evm.ChainConfig().Location), msg.AccessList())
+	activePrecompiles := vm.ActivePrecompiles(rules, st.evm.ChainConfig().Location)
+	st.state.PrepareAccessList(msg.From(), msg.To(), activePrecompiles, msg.AccessList(), st.evm.Config.Debug)
 
 	var (
 		ret          []byte

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -21,6 +21,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+
 	"math/big"
 
 	"github.com/dominant-strategies/go-quai/common"
@@ -50,16 +51,23 @@ var (
 )
 
 func InitializePrecompiles(nodeLocation common.Location) {
-	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%x00000000000000000000000000000000000001", nodeLocation.BytePrefix()))] = &ecrecover{}
-	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%x00000000000000000000000000000000000002", nodeLocation.BytePrefix()))] = &sha256hash{}
-	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%x00000000000000000000000000000000000003", nodeLocation.BytePrefix()))] = &ripemd160hash{}
-	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%x00000000000000000000000000000000000004", nodeLocation.BytePrefix()))] = &dataCopy{}
-	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%x00000000000000000000000000000000000005", nodeLocation.BytePrefix()))] = &bigModExp{}
-	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%x00000000000000000000000000000000000006", nodeLocation.BytePrefix()))] = &bn256Add{}
-	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%x00000000000000000000000000000000000007", nodeLocation.BytePrefix()))] = &bn256ScalarMul{}
-	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%x00000000000000000000000000000000000008", nodeLocation.BytePrefix()))] = &bn256Pairing{}
-	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%x00000000000000000000000000000000000009", nodeLocation.BytePrefix()))] = &blake2F{}
-	LockupContractAddresses[[2]byte{nodeLocation[0], nodeLocation[1]}] = common.HexToAddress(fmt.Sprintf("0x%x0000000000000000000000000000000000000A", nodeLocation.BytePrefix()), nodeLocation)
+	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%02x00000000000000000000000000000000000001", nodeLocation.BytePrefix()))] = &ecrecover{}
+	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%02x00000000000000000000000000000000000002", nodeLocation.BytePrefix()))] = &sha256hash{}
+	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%02x00000000000000000000000000000000000003", nodeLocation.BytePrefix()))] = &ripemd160hash{}
+	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%02x00000000000000000000000000000000000004", nodeLocation.BytePrefix()))] = &dataCopy{}
+	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%02x00000000000000000000000000000000000005", nodeLocation.BytePrefix()))] = &bigModExp{}
+	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%02x00000000000000000000000000000000000006", nodeLocation.BytePrefix()))] = &bn256Add{}
+	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%02x00000000000000000000000000000000000007", nodeLocation.BytePrefix()))] = &bn256ScalarMul{}
+	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%02x00000000000000000000000000000000000008", nodeLocation.BytePrefix()))] = &bn256Pairing{}
+	PrecompiledContracts[common.HexToAddressBytes(fmt.Sprintf("0x%02x00000000000000000000000000000000000009", nodeLocation.BytePrefix()))] = &blake2F{}
+	LockupContractAddresses[[2]byte{nodeLocation[0], nodeLocation[1]}] = common.HexToAddress(fmt.Sprintf("0x%02x0000000000000000000000000000000000000A", nodeLocation.BytePrefix()), nodeLocation)
+
+	for address, _ := range PrecompiledContracts {
+		if address.Location().Equal(nodeLocation) {
+			PrecompiledAddresses[nodeLocation.Name()] = append(PrecompiledAddresses[nodeLocation.Name()], common.BytesToAddress(address[:], nodeLocation))
+			PrecompiledAddresses[nodeLocation.Name()] = append(PrecompiledAddresses[nodeLocation.Name()], common.HexToAddress(fmt.Sprintf("0x00000000000000000000000000000000000000%02x", address[19]), nodeLocation))
+		}
+	}
 }
 
 // ActivePrecompiles returns the precompiles enabled with the current configuration.

--- a/core/vm/errors.go
+++ b/core/vm/errors.go
@@ -35,6 +35,7 @@ var (
 	ErrReturnDataOutOfBounds    = errors.New("return data out of bounds")
 	ErrGasUintOverflow          = errors.New("gas uint64 overflow")
 	ErrInvalidCode              = errors.New("invalid code: must not begin with 0xef")
+	ErrInvalidAccessList        = errors.New("invalid access list")
 )
 
 // ErrStackUnderflow wraps an evm error when the items on the stack less

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -55,7 +55,7 @@ func (evm *EVM) precompile(addr common.Address) (PrecompiledContract, bool, comm
 	if !ok {
 		// to translate the address, we add the last byte of the address to the location-specific zero address
 		// to support more than 255 precompiles, we could use the last two bytes, but it's likely unnecessary
-		translatedAddress := common.HexToAddressBytes(fmt.Sprintf("0x%x000000000000000000000000000000000000%02x", evm.chainConfig.Location.BytePrefix(), addr.Bytes20()[19]))
+		translatedAddress := common.HexToAddressBytes(fmt.Sprintf("0x%02x000000000000000000000000000000000000%02x", evm.chainConfig.Location.BytePrefix(), addr.Bytes20()[19]))
 		p, ok = PrecompiledContracts[translatedAddress]
 		if ok {
 			addr = common.Bytes20ToAddress(translatedAddress, evm.chainConfig.Location)

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -266,6 +266,9 @@ func opBalance(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]
 	if err != nil { // if an ErrInvalidScope error is returned, the caller (usually interpreter.go/Run) will return the error to Call which will eventually set ReceiptStatusFailed in the tx receipt (state_processor.go/applyTransaction)
 		return nil, err
 	}
+	if addressOk := interpreter.evm.StateDB.AddressInAccessList(address.Bytes20()); !addressOk {
+		return nil, ErrInvalidAccessList
+	}
 	slot.SetFromBig(interpreter.evm.StateDB.GetBalance(address))
 	return nil, nil
 }
@@ -353,6 +356,9 @@ func opReturnDataCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeConte
 
 func opExtCodeSize(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	slot := scope.Stack.peek()
+	if addressOk := interpreter.evm.StateDB.AddressInAccessList(slot.Bytes20()); !addressOk {
+		return nil, ErrInvalidAccessList
+	}
 	slot.SetUint64(uint64(interpreter.evm.StateDB.GetCodeSize(slot.Bytes20())))
 	return nil, nil
 }
@@ -395,6 +401,9 @@ func opExtCodeCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext)
 	addr, err := common.Bytes20ToAddress(a.Bytes20(), interpreter.evm.chainConfig.Location).InternalAndQuaiAddress()
 	if err != nil {
 		return nil, err
+	}
+	if addressOk := interpreter.evm.StateDB.AddressInAccessList(addr.Bytes20()); !addressOk {
+		return nil, ErrInvalidAccessList
 	}
 	codeCopy := getData(interpreter.evm.StateDB.GetCode(addr), uint64CodeOffset, length.Uint64())
 	scope.Memory.Set(memOffset.Uint64(), length.Uint64(), codeCopy)
@@ -440,6 +449,9 @@ func opExtCodeHash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext)
 	address, err := common.Bytes20ToAddress(slot.Bytes20(), interpreter.evm.chainConfig.Location).InternalAndQuaiAddress()
 	if err != nil {
 		return nil, err
+	}
+	if addressOk := interpreter.evm.StateDB.AddressInAccessList(address.Bytes20()); !addressOk {
+		return nil, ErrInvalidAccessList
 	}
 	if interpreter.evm.StateDB.Empty(address) {
 		slot.Clear()
@@ -537,6 +549,9 @@ func opSload(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 	if err != nil {
 		return nil, err
 	}
+	if addressOk, slotOk := interpreter.evm.StateDB.SlotInAccessList(addr.Bytes20(), hash); !addressOk || !slotOk {
+		return nil, ErrInvalidAccessList
+	}
 	val := interpreter.evm.StateDB.GetState(addr, hash)
 	loc.SetBytes(val.Bytes())
 	return nil, nil
@@ -548,6 +563,9 @@ func opSstore(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 	addr, err := scope.Contract.Address().InternalAndQuaiAddress()
 	if err != nil {
 		return nil, err
+	}
+	if addressOk, slotOk := interpreter.evm.StateDB.SlotInAccessList(addr.Bytes20(), common.Hash(loc.Bytes32())); !addressOk || !slotOk {
+		return nil, ErrInvalidAccessList
 	}
 	interpreter.evm.StateDB.SetState(addr,
 		loc.Bytes32(), val.Bytes32())
@@ -683,6 +701,9 @@ func opCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 		gas += params.CallStipend
 		bigVal = value.ToBig()
 	}
+	if addressOk := interpreter.evm.StateDB.AddressInAccessList(toAddr.Bytes20()); !addressOk {
+		return nil, ErrInvalidAccessList
+	}
 
 	ret, returnGas, err := interpreter.evm.Call(scope.Contract, toAddr, args, gas, bigVal, nil)
 
@@ -721,7 +742,9 @@ func opCallCode(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 		gas += params.CallStipend
 		bigVal = value.ToBig()
 	}
-
+	if addressOk := interpreter.evm.StateDB.AddressInAccessList(addr.Bytes20()); !addressOk {
+		return nil, ErrInvalidAccessList
+	}
 	ret, returnGas, err := interpreter.evm.CallCode(scope.Contract, toAddr, args, gas, bigVal)
 	if err != nil {
 		temp.Clear()
@@ -751,7 +774,9 @@ func opDelegateCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 	toAddr := common.Bytes20ToAddress(addr.Bytes20(), interpreter.evm.chainConfig.Location)
 	// Get arguments from the memory.
 	args := scope.Memory.GetPtr(int64(inOffset.Uint64()), int64(inSize.Uint64()))
-
+	if addressOk := interpreter.evm.StateDB.AddressInAccessList(toAddr.Bytes20()); !addressOk {
+		return nil, ErrInvalidAccessList
+	}
 	ret, returnGas, err := interpreter.evm.DelegateCall(scope.Contract, toAddr, args, gas)
 	if err != nil {
 		temp.Clear()
@@ -781,7 +806,9 @@ func opStaticCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) 
 	toAddr := common.Bytes20ToAddress(addr.Bytes20(), interpreter.evm.chainConfig.Location)
 	// Get arguments from the memory.
 	args := scope.Memory.GetPtr(int64(inOffset.Uint64()), int64(inSize.Uint64()))
-
+	if addressOk := interpreter.evm.StateDB.AddressInAccessList(toAddr.Bytes20()); !addressOk {
+		return nil, ErrInvalidAccessList
+	}
 	ret, returnGas, err := interpreter.evm.StaticCall(scope.Contract, toAddr, args, gas)
 	if err != nil {
 		temp.Clear()
@@ -827,6 +854,12 @@ func opSuicide(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]
 	beneficiaryAddr, err := common.Bytes20ToAddress(beneficiary.Bytes20(), interpreter.evm.chainConfig.Location).InternalAndQuaiAddress()
 	if err != nil {
 		return nil, err
+	}
+	if addressOk := interpreter.evm.StateDB.AddressInAccessList(addr.Bytes20()); !addressOk { // this may be unnecessary since the contract address ('to') is always in the access list implicitly
+		return nil, ErrInvalidAccessList
+	}
+	if addressOk := interpreter.evm.StateDB.AddressInAccessList(beneficiaryAddr.Bytes20()); !addressOk {
+		return nil, ErrInvalidAccessList
 	}
 	balance := interpreter.evm.StateDB.GetBalance(addr)
 	interpreter.evm.StateDB.AddBalance(beneficiaryAddr, balance)

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -57,15 +57,15 @@ type StateDB interface {
 	// is defined according to (balance = nonce = code = 0).
 	Empty(common.InternalAddress) bool
 
-	PrepareAccessList(sender common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList)
-	AddressInAccessList(addr common.Address) bool
-	SlotInAccessList(addr common.Address, slot common.Hash) (addressOk bool, slotOk bool)
+	PrepareAccessList(sender common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList, debug bool)
+	AddressInAccessList(addr common.AddressBytes) bool
+	SlotInAccessList(addr common.AddressBytes, slot common.Hash) (addressOk bool, slotOk bool)
 	// AddAddressToAccessList adds the given address to the access list. This operation is safe to perform
 	// even if the feature/fork is not active yet
-	AddAddressToAccessList(addr common.Address)
+	AddAddressToAccessList(addr common.AddressBytes)
 	// AddSlotToAccessList adds the given (address,slot) to the access list. This operation is safe to perform
 	// even if the feature/fork is not active yet
-	AddSlotToAccessList(addr common.Address, slot common.Hash)
+	AddSlotToAccessList(addr common.AddressBytes, slot common.Hash)
 
 	RevertToSnapshot(int)
 	Snapshot() int

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -121,7 +121,7 @@ func Execute(code, input []byte, cfg *Config) ([]byte, *state.StateDB, error) {
 		return []byte{}, nil, err
 	}
 	rules := cfg.ChainConfig.Rules(vmenv.Context.BlockNumber)
-	cfg.State.PrepareAccessList(cfg.Origin, &address, vm.ActivePrecompiles(rules, cfg.ChainConfig.Location), nil)
+	cfg.State.PrepareAccessList(cfg.Origin, &address, vm.ActivePrecompiles(rules, cfg.ChainConfig.Location), nil, true)
 
 	cfg.State.CreateAccount(internal)
 	// set the receiver's (the executing contract) code for execution.
@@ -154,7 +154,7 @@ func Create(input []byte, cfg *Config) ([]byte, common.Address, uint64, error) {
 		sender = vm.AccountRef(cfg.Origin)
 	)
 	rules := cfg.ChainConfig.Rules(vmenv.Context.BlockNumber)
-	cfg.State.PrepareAccessList(cfg.Origin, nil, vm.ActivePrecompiles(rules, cfg.ChainConfig.Location), nil)
+	cfg.State.PrepareAccessList(cfg.Origin, nil, vm.ActivePrecompiles(rules, cfg.ChainConfig.Location), nil, true)
 
 	// Call the code with the given configuration.
 	code, address, leftOverGas, err := vmenv.Create(
@@ -183,7 +183,7 @@ func Call(address common.Address, input []byte, cfg *Config) ([]byte, uint64, er
 	statedb := cfg.State
 
 	rules := cfg.ChainConfig.Rules(vmenv.Context.BlockNumber)
-	statedb.PrepareAccessList(cfg.Origin, &address, vm.ActivePrecompiles(rules, cfg.ChainConfig.Location), nil)
+	statedb.PrepareAccessList(cfg.Origin, &address, vm.ActivePrecompiles(rules, cfg.ChainConfig.Location), nil, true)
 
 	// Call the code with the given configuration.
 	ret, leftOverGas, err := vmenv.Call(

--- a/internal/quaiapi/api.go
+++ b/internal/quaiapi/api.go
@@ -1266,13 +1266,16 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 	} else {
 		to = crypto.CreateAddress(args.from(nodeLocation), uint64(*args.Nonce), *args.Data, nodeLocation)
 		if _, err := to.InternalAndQuaiAddress(); err != nil {
-			var salt [32]byte
-			binary.BigEndian.PutUint64(salt[24:], uint64(*args.Nonce))
+			var salt [4]byte
+			binary.BigEndian.PutUint32(salt[:], uint32(*args.Nonce))
+
 			// Iterate through possible nonce values to find a suitable contract address.
 			for i := 0; i < params.MaxAddressGrindAttempts; i++ {
+				// Increment the salt
+				saltValue := binary.BigEndian.Uint32(salt[:])
+				saltValue++
+				binary.BigEndian.PutUint32(salt[:], saltValue)
 
-				// Place i in the [32]byte array.
-				binary.BigEndian.PutUint64(salt[16:24], uint64(i))
 				codeSalt := append(*args.Data, salt[:]...)
 
 				// Generate a potential contract address.

--- a/internal/quaiapi/api.go
+++ b/internal/quaiapi/api.go
@@ -647,7 +647,8 @@ func DoCall(ctx context.Context, b Backend, args TransactionArgs, blockNrOrHash 
 	if err != nil {
 		return nil, err
 	}
-	evm, vmError, err := b.GetEVM(ctx, msg, state, header, parent, &vm.Config{NoBaseFee: true})
+	tracer := vm.NewAccessListTracer(types.AccessList{}, common.ZeroAddress(b.NodeLocation()), common.ZeroAddress(b.NodeLocation()), vm.ActivePrecompiles(b.ChainConfig().Rules(header.Number(nodeCtx)), b.NodeLocation()))
+	evm, vmError, err := b.GetEVM(ctx, msg, state, header, parent, &vm.Config{Tracer: tracer, NoBaseFee: true, Debug: true})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/quaiapi/api.go
+++ b/internal/quaiapi/api.go
@@ -1273,9 +1273,10 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 
 				// Place i in the [32]byte array.
 				binary.BigEndian.PutUint64(salt[16:24], uint64(i))
+				codeSalt := append(*args.Data, salt[:]...)
 
 				// Generate a potential contract address.
-				contractAddr := crypto.CreateAddress2(args.from(nodeLocation), salt, crypto.Keccak256Hash(*args.Data).Bytes(), nodeLocation)
+				contractAddr := crypto.CreateAddress(args.from(nodeLocation), uint64(*args.Nonce), codeSalt, nodeLocation)
 
 				// Check if the generated address is valid.
 				if _, err := contractAddr.InternalAndQuaiAddress(); err == nil {

--- a/internal/quaiapi/quai_api.go
+++ b/internal/quaiapi/quai_api.go
@@ -658,7 +658,7 @@ func (s *PublicBlockChainQuaiAPI) CreateAccessList(ctx context.Context, args Tra
 	if !s.b.ProcessingState() {
 		return nil, errors.New("createAccessList call can only be made on chain processing the state")
 	}
-	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
+	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 	if blockNrOrHash != nil {
 		bNrOrHash = *blockNrOrHash
 	}

--- a/internal/quaiapi/transaction_args.go
+++ b/internal/quaiapi/transaction_args.go
@@ -158,13 +158,13 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend) error {
 			Data:                 args.Data,
 			AccessList:           args.AccessList,
 		}
-		pendingBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
+		pendingBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 		estimated, err := DoEstimateGas(ctx, b, callArgs, pendingBlockNr, b.RPCGasCap())
 		if err != nil {
 			return err
 		}
 		args.Gas = &estimated
-		log.Global.WithField("gas", args.Gas).Trace("Estimate gas usage automatically")
+		log.Global.WithField("gas", args.Gas).Debug("Estimate gas usage automatically")
 	}
 	if args.ChainID == nil {
 		id := (*hexutil.Big)(b.ChainConfig().ChainID)

--- a/quai/api_backend.go
+++ b/quai/api_backend.go
@@ -262,6 +262,9 @@ func (b *QuaiAPIBackend) GetEVM(ctx context.Context, msg core.Message, state *st
 	if nodeCtx != common.ZONE_CTX {
 		return nil, vmError, errors.New("getEvm can only be called in zone chain")
 	}
+	if parent == nil {
+		return nil, nil, errors.New("parent block not found, parenthash: " + header.ParentHash(b.NodeCtx()).String())
+	}
 	if vmConfig == nil {
 		vmConfig = b.quai.core.GetVMConfig()
 	}

--- a/quai/quaiconfig/config.go
+++ b/quai/quaiconfig/config.go
@@ -85,7 +85,7 @@ var Defaults = Config{
 		Recommit: 3 * time.Second,
 	},
 	TxPool:      core.DefaultTxPoolConfig,
-	RPCGasCap:   50000000,
+	RPCGasCap:   params.GasCeil,
 	GPO:         FullNodeGPO,
 	RPCTxFeeCap: 1, // 1 ether
 }

--- a/quaiclient/ethclient/ethclient.go
+++ b/quaiclient/ethclient/ethclient.go
@@ -476,6 +476,25 @@ func (ec *Client) EstimateGas(ctx context.Context, msg quai.CallMsg) (uint64, er
 	return uint64(hex), nil
 }
 
+// AccessListResult returns an optional accesslist
+// Its the result of the `quai_createAccessList` RPC call.
+// It contains an error if the transaction itself failed.
+type AccessListResult struct {
+	Accesslist *types.AccessList `json:"accessList"`
+	Error      string            `json:"error,omitempty"`
+	GasUsed    hexutil.Uint64    `json:"gasUsed"`
+}
+
+// CreateAccessList creates an access list for a transaction.
+func (ec *Client) CreateAccessList(ctx context.Context, msg quai.CallMsg) (AccessListResult, error) {
+	var accessList AccessListResult
+	err := ec.c.CallContext(ctx, &accessList, "quai_createAccessList", toCallArg(msg))
+	if err != nil {
+		return accessList, err
+	}
+	return accessList, nil
+}
+
 // SendTransaction injects a signed transaction into the pending pool for execution.
 //
 // If the transaction was a contract creation use the TransactionReceipt method to get the


### PR DESCRIPTION
this change is required since when deploying bytecode for a contract the address should be able to be known ahead of time. If Create2 were to be used alone, the salt would only be known at runtime. This means when creating access lists or interpreting deployment transactions the contract address would need to be simulated to get a salt.
