### PR TITLE
Enable WS and HTTP by default (limited to local)

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -575,7 +575,7 @@ var (
 	// ****************************************
 	HTTPEnabledFlag = Flag{
 		Name:  c_RPCFlagPrefix + "http",
-		Value: false,
+		Value: true,
 		Usage: "Enable the HTTP-RPC server" + generateEnvDoc(c_RPCFlagPrefix+"http"),
 	}
 
@@ -617,7 +617,7 @@ var (
 
 	WSEnabledFlag = Flag{
 		Name:  c_RPCFlagPrefix + "ws",
-		Value: false,
+		Value: true,
 		Usage: "Enable the WS-RPC server" + generateEnvDoc(c_RPCFlagPrefix+"ws"),
 	}
 


### PR DESCRIPTION
This enables the required RPCs for mining by default, which many are doing on the devnet. There is no security concern as the corsdomain is still local by default which blocks external connections.