### PR TITLE
use dns for bootnodes instead of ip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # First stage: build the Go binary
-FROM golang:1.21-alpine AS builder
+FROM golang:1.23-alpine AS builder
 
 # Install make and other build dependencies
 RUN apk --no-cache add make gcc musl-dev

--- a/common/bootnodes.go
+++ b/common/bootnodes.go
@@ -3,18 +3,18 @@ package common
 var (
 	BootstrapPeers = map[string][]string{
 		"colosseum": {
-			"/ip4/35.222.139.95/tcp/4001/p2p/12D3KooWK3nVCWjToi3igfs8oyJscVQYLd4SmQanohAuF8M6eZBn",
+			"/dns4/bootnode.colosseum0.quai.network/tcp/4001/p2p/12D3KooWK3nVCWjToi3igfs8oyJscVQYLd4SmQanohAuF8M6eZBn",
 		},
 		"garden": {
-			"/ip4/146.148.66.22/tcp/4001/p2p/12D3KooWRQrLVEeJtfyKoJDYWYjryBKR8qxkDooMMzyf2ZpLaZRR",
-			"/ip4/35.190.147.237/tcp/4001/p2p/12D3KooWSb49ccXFWPCsvi7rzCbqBUK2xfuRC2xbo6KnUZk3YaVg",
-			"/ip4/35.194.7.78/tcp/4001/p2p/12D3KooWR3xMB6sCpsowQcvtdMKmKbTaiDcDFAXuWABdZVPWaVuo",
-			"/ip4/34.136.140.151/tcp/4001/p2p/12D3KooWJnWmBukEbZtGPPJvT1r4tQ97CRSGmnjHewcrjNB8oRxU",
+			"/dns4/bootnode.garden0.quai.network/tcp/4001/p2p/12D3KooWRQrLVEeJtfyKoJDYWYjryBKR8qxkDooMMzyf2ZpLaZRR",
+			"/dns4/bootnode.garden1.quai.network/tcp/4001/p2p/12D3KooWSb49ccXFWPCsvi7rzCbqBUK2xfuRC2xbo6KnUZk3YaVg",
+			"/dns4/bootnode.garden2.quai.network/tcp/4001/p2p/12D3KooWR3xMB6sCpsowQcvtdMKmKbTaiDcDFAXuWABdZVPWaVuo",
+			"/dns4/bootnode.garden3.quai.network/tcp/4001/p2p/12D3KooWJnWmBukEbZtGPPJvT1r4tQ97CRSGmnjHewcrjNB8oRxU",
 		},
 		"orchard": {
-			"/ip4/34.23.101.139/tcp/4001/p2p/12D3KooWKm7ofNnBKDL2ETzfuaKHHxFxdZxgSk45HAepn1m9Y4kq",
-			"/ip4/34.122.101.50/tcp/4001/p2p/12D3KooWMCLAgSHLnfiKBXKprRP4KDjP3aqoVeHY1KVLahCHdKp5",
-			"/ip4/34.136.175.169/tcp/4001/p2p/12D3KooWNhJWXsu2G19QV75D6UPsRmRNvGQL4JWA37SUjxubpVdj",
+			"/dns4/bootnode.orchard0.quai.network/tcp/4001/p2p/12D3KooWSu4bS67yLVUcFRdbrUbjQJdNeqe1cJ4pjHf77zwX5AHy",
+			"/dns4/bootnode.orchard1.quai.network/tcp/4001/p2p/12D3KooWBdtyVjqXSG3zE7qEz6K1wu3Cjc9B6A9bsh9A7xRwg1nP",
+			"/dns4/bootnode.orchard2.quai.network/tcp/4001/p2p/12D3KooWRdAA7rCedzbRewzw2R8zAY1QDiiA1KhDRxHXsZvukeBC",
 		},
 		"lighthouse": {
 			"/dns4/host-go-quai/tcp/4001/p2p/12D3KooWS83uhvCfyNeAV24nEsp3DHrygDD39rZiVy6Gabv6pqxt",


### PR DESCRIPTION
The dns is already made in cloud flare. this makes it easier to change the bootnode ips without changing the source code.