### PR TITLE
Remove unused bootnode bool flag

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -72,7 +72,6 @@ var GlobalFlags = []Flag{
 var NodeFlags = []Flag{
 	IPAddrFlag,
 	P2PPortFlag,
-	BootNodeFlag,
 	BootPeersFlag,
 	PortMapFlag,
 	KeyFileFlag,
@@ -228,13 +227,6 @@ var (
 		Abbreviation: "p",
 		Value:        "4001",
 		Usage:        "p2p port to listen on" + generateEnvDoc(c_NodeFlagPrefix+"port"),
-	}
-
-	BootNodeFlag = Flag{
-		Name:         c_NodeFlagPrefix + "bootnode",
-		Abbreviation: "b",
-		Value:        false,
-		Usage:        "start the node as a boot node (no static peers required)" + generateEnvDoc(c_NodeFlagPrefix+"bootnode"),
 	}
 
 	BootPeersFlag = Flag{


### PR DESCRIPTION
This flag was misinterpreted since it was opened. This flag is a true/false bool that used to indicate to the node whether it should act as a "server" in the kademlia DHT or not. Since the introduction of this flag we decided that all nodes should act as servers by default. Therefore this flag is now deprecated.

The "bootpeers" flag is still available and used.