### PR TITLE
Save a duplicate of the UTXO set every 100 blocks if flag is enabled

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -112,6 +112,7 @@ var NodeFlags = []Flag{
 	QuaiStatsURLFlag,
 	SendFullStatsFlag,
 	IndexAddressUtxos,
+	DuplicateUTXOSetFlag,
 	StartingExpansionNumberFlag,
 	NodeLogLevelFlag,
 	GenesisNonce,
@@ -528,6 +529,12 @@ var (
 		Name:  c_NodeFlagPrefix + "index-address-utxos",
 		Value: false,
 		Usage: "Index address utxos" + generateEnvDoc(c_NodeFlagPrefix+"index-address-utxos"),
+	}
+
+	DuplicateUTXOSetFlag = Flag{
+		Name:  c_NodeFlagPrefix + "duplicate-utxo-set",
+		Value: false,
+		Usage: "Store a copy of the UTXO set every DuplicateUtxoSetFrequency blocks" + generateEnvDoc(c_NodeFlagPrefix+"duplicate-utxo-set"),
 	}
 
 	EnvironmentFlag = Flag{
@@ -1351,6 +1358,8 @@ func SetQuaiConfig(stack *node.Node, cfg *quaiconfig.Config, slicesRunning []com
 		cfg.EnablePreimageRecording = viper.GetBool(VMEnableDebugFlag.Name)
 	}
 	cfg.IndexAddressUtxos = viper.GetBool(IndexAddressUtxos.Name)
+
+	cfg.DuplicateUTXOSet = viper.GetBool(DuplicateUTXOSetFlag.Name)
 
 	if viper.IsSet(RPCGlobalGasCapFlag.Name) {
 		cfg.RPCGasCap = viper.GetUint64(RPCGlobalGasCapFlag.Name)

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -88,6 +88,8 @@ var (
 	tokenChoicePrefix       = []byte("tc")    // tokenChoicePrefix + hash -> tokenChoices
 	betasPrefix             = []byte("betas") // tokenChoicePrefix + hash -> tokenChoices
 	utxoPrefix              = []byte("ut")    // outpointPrefix + hash -> types.Outpoint
+	DuplicateUtxoSetPrefix  = []byte("du")    // duplicateUtxoSetPrefix + hash -> multiset
+	duplicateUtxoKeysPrefix = []byte("dk")    // duplicateUtxoKeysPrefix + hash -> [][]byte
 	spentUTXOsPrefix        = []byte("sutxo") // spentUTXOsPrefix + hash -> []types.SpentTxOut
 	trimmedUTXOsPrefix      = []byte("tutxo") // trimmedUTXOsPrefix + hash -> []types.SpentTxOut
 	trimDepthsPrefix        = []byte("td")    // trimDepthsPrefix + hash -> uint64
@@ -326,7 +328,7 @@ func UtxoKeyWithDenomination(hash common.Hash, index uint16, denomination uint8)
 }
 
 func ReverseUtxoKey(key []byte) (common.Hash, uint16, error) {
-	if len(key) != len(UtxoPrefix)+common.HashLength+2 {
+	if len(key) != UtxoKeyLength {
 		return common.Hash{}, 0, fmt.Errorf("invalid key length %d", len(key))
 	}
 	hash := common.BytesToHash(key[len(UtxoPrefix) : common.HashLength+len(UtxoPrefix)])
@@ -380,4 +382,12 @@ func tokenChoiceSetKey(hash common.Hash) []byte {
 
 func betasKey(hash common.Hash) []byte {
 	return append(betasPrefix, hash.Bytes()...)
+}
+
+func duplicateUtxoSetKey(hash []byte) []byte {
+	return append(DuplicateUtxoSetPrefix, hash...)
+}
+
+func duplicateUtxoKeysKey(hash []byte) []byte {
+	return append(duplicateUtxoKeysPrefix, hash...)
 }

--- a/internal/quaiapi/quai_api.go
+++ b/internal/quaiapi/quai_api.go
@@ -530,6 +530,10 @@ func (s *PublicBlockChainQuaiAPI) EstimateFeeForQi(ctx context.Context, args Tra
 	return (*hexutil.Big)(feeInQi), nil
 }
 
+func (s *PublicBlockChainQuaiAPI) GetLatestUTXOSetSize(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (hexutil.Uint64, error) {
+	return hexutil.Uint64(rawdb.ReadUTXOSetSize(s.b.Database(), s.b.CurrentBlock().Hash())), nil
+}
+
 // RPCMarshalBlock converts the given block to the RPC output which depends on fullTx. If inclTx is true transactions are
 // returned. When fullTx is true the returned block contains full transaction details, otherwise it will only contain
 // transaction hashes.

--- a/params/config.go
+++ b/params/config.go
@@ -112,9 +112,9 @@ var (
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllProgpowProtocolChanges = &ChainConfig{big.NewInt(1337), "progpow", new(Blake3powConfig), new(ProgpowConfig), common.Location{}, common.Hash{}, false}
+	AllProgpowProtocolChanges = &ChainConfig{big.NewInt(1337), "progpow", new(Blake3powConfig), new(ProgpowConfig), common.Location{}, common.Hash{}, false, false}
 
-	TestChainConfig = &ChainConfig{big.NewInt(1), "progpow", new(Blake3powConfig), new(ProgpowConfig), common.Location{}, common.Hash{}, false}
+	TestChainConfig = &ChainConfig{big.NewInt(1), "progpow", new(Blake3powConfig), new(ProgpowConfig), common.Location{}, common.Hash{}, false, false}
 	TestRules       = TestChainConfig.Rules(new(big.Int))
 )
 
@@ -132,6 +132,7 @@ type ChainConfig struct {
 	Location           common.Location
 	DefaultGenesisHash common.Hash
 	IndexAddressUtxos  bool
+	DuplicateUTXOSet   bool
 }
 
 // SetLocation sets the location on the chain config

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -155,6 +155,8 @@ const (
 	SoftMaxUTXOSetSize                   = 10000000         // The soft maximum number of UTXOs that can be stored in the UTXO set
 	MinimumTrimDepth                     = math.MaxInt      // The minimum block depth of the chain to begin trimming
 	QiToQuaiConversionGas                = 100000           // The gas used to convert Qi to Quai
+	DuplicateUtxoSetFrequency            = 100              // The frequency in Prime blocks at which a new duplicate UTXO set is created and old one deleted
+	MaxDuplicateUtxoSets                 = 100              // The maximum number of duplicate UTXO sets that can be stored
 )
 
 var (

--- a/quai/backend.go
+++ b/quai/backend.go
@@ -181,6 +181,7 @@ func New(stack *node.Node, p2p NetworkingAPI, config *quaiconfig.Config, nodeCtx
 	chainConfig.Location = config.NodeLocation // TODO: See why this is necessary
 	chainConfig.DefaultGenesisHash = config.DefaultGenesisHash
 	chainConfig.IndexAddressUtxos = config.IndexAddressUtxos
+	chainConfig.DuplicateUTXOSet = config.DuplicateUTXOSet
 	logger.WithFields(log.Fields{
 		"Ctx":          nodeCtx,
 		"NodeLocation": config.NodeLocation,
@@ -255,6 +256,7 @@ func New(stack *node.Node, p2p NetworkingAPI, config *quaiconfig.Config, nodeCtx
 	if quai.core.ProcessingState() && nodeCtx == common.ZONE_CTX {
 		quai.bloomIndexer = core.NewBloomIndexer(chainDb, params.BloomBitsBlocks, params.BloomConfirms, chainConfig.Location.Context(), logger, config.IndexAddressUtxos)
 		quai.bloomIndexer.Start(quai.Core().Slice().HeaderChain(), newChainConfig)
+		quai.Core().Slice().HeaderChain().SetIndexer(quai.bloomIndexer)
 	}
 
 	// Set the p2p Networking API

--- a/quai/quaiconfig/config.go
+++ b/quai/quaiconfig/config.go
@@ -158,6 +158,9 @@ type Config struct {
 	// IndexAddressUtxos enables or disables address utxo indexing
 	IndexAddressUtxos bool
 
+	// DuplicateUTXOSet enables or disables copying utxo set every DuplicateUtxoSetFrequency blocks
+	DuplicateUTXOSet bool
+
 	// DefaultGenesisHash is the hard coded genesis hash
 	DefaultGenesisHash common.Hash
 }

--- a/quaiclient/ethclient/ethclient.go
+++ b/quaiclient/ethclient/ethclient.go
@@ -510,6 +510,15 @@ func (ec *Client) EstimateFeeForQi(ctx context.Context, tx *types.Transaction) (
 	return (*big.Int)(&result), nil
 }
 
+func (ec *Client) GetLatestUTXOSetSize(ctx context.Context) (uint64, error) {
+	var result hexutil.Uint64
+	err := ec.c.CallContext(ctx, &result, "quai_getLatestUTXOSetSize")
+	if err != nil {
+		return 0, err
+	}
+	return uint64(result), nil
+}
+
 // AccessListResult returns an optional accesslist
 // Its the result of the `quai_createAccessList` RPC call.
 // It contains an error if the transaction itself failed.


### PR DESCRIPTION
Max 10 duplicate sets, configurable
Includes DeleteUTXOSetAndReplaceFromLatest() function that can be called if necessary (but is currently unused)