### PR TITLE
feat: avoid unmarshal ConversionType transaction failed

### DIFF
--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -223,10 +223,10 @@ func (t *Transaction) UnmarshalJSON(input []byte) error {
 			return errors.New("missing required field 'etxIndex' in external transaction")
 		}
 		etx.ETXIndex = uint16(*dec.ETXIndex)
-		if dec.Gas == nil {
-			return errors.New("missing required field 'gas' in external transaction")
+		if dec.Gas != nil {
+			//return errors.New("missing required field 'gas' in external transaction")
+			etx.Gas = uint64(*dec.Gas)
 		}
-		etx.Gas = uint64(*dec.Gas)
 		if dec.Value == nil {
 			return errors.New("missing required field 'value' in external transaction")
 		}


### PR DESCRIPTION
Hi team, I hope this message finds you well. I've encountered an issue while working on the project that I believe requires our attention.

Upon deserializing the ConversionType JSON transaction, I encountered an error stating, "missing required field 'gas' in external transaction." This error occurred when the gas value was set to 0, which is not represented in the JSON structure, leading to a deserialization failure.

To reproduce the issue, I used the following curl command to interact with the RPC endpoint:
```
curl --location 'https://rpc.quai.network/cyprus1/' \
--header 'Content-Type: application/json' \
--data '{
    "jsonrpc": "2.0",
    "method": "quai_getBlockByNumber",
    "params": [
        "0x8f9fb",
        true
    ],
    "id": 1
}'

```
The originating transaction with hash 0x008a00b23961a92dc06539fa42b6ea5490767adb4334aa1edacc4129fd1d9eed failed to serialize correctly due to the absence of a gas value in the JSON.

```
{
    "blockHash": "0x505607541c5941cbf13a23800acbb11051e17594b0f25759fdd5dd80e34f4aaa",
    "blockNumber": "0x8f9fb",
    "from": "0x0000000000000000000000000000000000000000",
    "hash": "0x000900592deb5254dc4331cff2447ee4f68b0d2f4ae51f7243719dbfe512c2db",
    "input": "0x",
    "nonce": "0x0",
    "to": "0x007933d434b22C0bC8D0Bab1798E4Df37D06CA17",
    "transactionIndex": "0x0",
    "value": "0x35c497cad2336e10",
    "type": "0x1",
    "accessList": [],
    "originatingTxHash": "0x008a00b23961a92dc06539fa42b6ea5490767adb4334aa1edacc4129fd1d9eed",
    "etxIndex": "0x0",
    "etxType": "0x2"
}
```
Coinbase transaction compared to it, it has gas field:
```
{
    "blockHash": "0x505607541c5941cbf13a23800acbb11051e17594b0f25759fdd5dd80e34f4aaa",
    "blockNumber": "0x8f9fb",
    "from": "0x003987CAff711C90D3C1D1C6b6Ee8b7bF8685086",
    "gas": "0x5208",
    "hash": "0x007b000a0a839273c2d0bfe65deb509f7ffbe000b0ac8ca196cd1101109cfb6f",
    "input": "0x00",
    "nonce": "0x0",
    "to": "0x003987CAff711C90D3C1D1C6b6Ee8b7bF8685086",
    "transactionIndex": "0x1",
    "value": "0x1967ebe4278fab11",
    "type": "0x1",
    "accessList": [],
    "originatingTxHash": "0x000400069fae9a14c326cc98d771dbdccb45693684ce44c6bd70528779c24c27",
    "etxIndex": "0x1",
    "etxType": "0x1"
}
```