### PR TITLE
Remove Access List Storage Slot Checks

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -550,7 +550,7 @@ func opSload(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 	if err != nil {
 		return nil, err
 	}
-	if addressOk, slotOk := interpreter.evm.StateDB.SlotInAccessList(addr.Bytes20(), hash); !addressOk || !slotOk {
+	if addressOk := interpreter.evm.StateDB.AddressInAccessList(addr.Bytes20()); !addressOk {
 		return nil, ErrInvalidAccessList
 	}
 	val := interpreter.evm.StateDB.GetState(addr, hash)
@@ -565,7 +565,7 @@ func opSstore(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 	if err != nil {
 		return nil, err
 	}
-	if addressOk, slotOk := interpreter.evm.StateDB.SlotInAccessList(addr.Bytes20(), common.Hash(loc.Bytes32())); !addressOk || !slotOk {
+	if addressOk := interpreter.evm.StateDB.AddressInAccessList(addr.Bytes20()); !addressOk {
 		return nil, ErrInvalidAccessList
 	}
 	interpreter.evm.StateDB.SetState(addr,


### PR DESCRIPTION
Accesslist storage slot checks are not necessary for parallelization, rather just the address checks are necessary. And, in fact, it is virtually impossible to guarantee that a user will get a specific storage slot before the transaction confirms.