### PR TITLE
bugfix: use MaxRegions variable for the region api backends

### DIFF
--- a/quai/p2p_backend.go
+++ b/quai/p2p_backend.go
@@ -53,7 +53,7 @@ func NewQuaiBackend() (*QuaiBackend, error) {
 	for i := 0; i < common.MaxRegions; i++ {
 		zoneBackends[i] = make([]*quaiapi.Backend, common.MaxZones)
 	}
-	return &QuaiBackend{regionApiBackends: make([]*quaiapi.Backend, common.MaxZones), zoneApiBackends: zoneBackends}, nil
+	return &QuaiBackend{regionApiBackends: make([]*quaiapi.Backend, common.MaxRegions), zoneApiBackends: zoneBackends}, nil
 }
 
 // Adds the p2pBackend into the given QuaiBackend


### PR DESCRIPTION
Initially noted by: https://github.com/dominant-strategies/go-quai/pull/2410