### PR TITLE
Added tx filtering in worker so an account can have multiple txs per block

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -1324,8 +1324,8 @@ func (c *Core) AddRemotes(txs types.Transactions) {
 	}
 }
 
-func (c *Core) TxPoolPending(enforceTips bool) (map[common.AddressBytes]types.Transactions, error) {
-	return c.sl.txPool.TxPoolPending(enforceTips)
+func (c *Core) TxPoolPending() (map[common.AddressBytes]types.Transactions, error) {
+	return c.sl.txPool.TxPoolPending()
 }
 
 func (c *Core) Get(hash common.Hash) *types.Transaction {

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -742,7 +742,7 @@ func (pool *TxPool) GetTxsFromBroadcastSet(hash common.Hash) (types.Transactions
 // The enforceTips parameter can be used to do an extra filtering on the pending
 // transactions and only return those whose **effective** tip is large enough in
 // the next pending execution environment.
-func (pool *TxPool) TxPoolPending(enforceTips bool) (map[common.AddressBytes]types.Transactions, error) {
+func (pool *TxPool) TxPoolPending() (map[common.AddressBytes]types.Transactions, error) {
 	pool.mu.RLock()
 	defer pool.mu.RUnlock()
 

--- a/core/worker.go
+++ b/core/worker.go
@@ -2081,7 +2081,7 @@ func (w *worker) fillTransactions(env *environment, primeTerminus *types.WorkObj
 		return nil
 	}
 
-	pending, err := w.txPool.TxPoolPending(false)
+	pending, err := w.txPool.TxPoolPending()
 	if err != nil {
 		w.logger.WithField("err", err).Error("Failed to get pending transactions")
 		return fmt.Errorf("failed to get pending transactions: %w", err)

--- a/internal/quaiapi/quai_api.go
+++ b/internal/quaiapi/quai_api.go
@@ -106,7 +106,7 @@ func (s *PublicBlockChainQuaiAPI) GetBalance(ctx context.Context, address common
 	}
 	nodeCtx := s.b.NodeCtx()
 	if nodeCtx != common.ZONE_CTX {
-		return nil, errors.New("getBalance call can only be made in zone chain")
+		return nil, fmt.Errorf("getBalance call can only be made in zone chain, current context is %d", nodeCtx)
 	}
 	if !s.b.ProcessingState() {
 		return nil, errors.New("getBalance call can only be made on chain processing the state")

--- a/quai/api_backend.go
+++ b/quai/api_backend.go
@@ -363,7 +363,7 @@ func (b *QuaiAPIBackend) GetPoolTransactions() (types.Transactions, error) {
 	if nodeCtx != common.ZONE_CTX {
 		return nil, errors.New("getPoolTransactions can only be called in zone chain")
 	}
-	pending, err := b.quai.core.TxPoolPending(false)
+	pending, err := b.quai.core.TxPoolPending()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Rule: all transactions in a block must be sorted by ascending nonce and descending gas price.
We can have multiple txs for a given account in a block as long as this rule is followed. This PR makes the worker follow this (already enforced) rule when sorting transactions in the worker.