### PR TITLE
fix http2-goaway

### DIFF
--- a/rpc/http.go
+++ b/rpc/http.go
@@ -174,7 +174,7 @@ func (hc *httpConn) doRequest(ctx context.Context, msg interface{}) (io.ReadClos
 		return nil, err
 	}
 	req.ContentLength = int64(len(body))
-
+	req.GetBody = func() (io.ReadCloser, error) { return ioutil.NopCloser(bytes.NewReader(body)), nil }
 	// set headers
 	hc.mu.Lock()
 	req.Header = hc.headers.Clone()


### PR DESCRIPTION
During my usage, I have encountered this error multiple times:

http2: Transport: cannot retry err [http2: Transport received Server's graceful shutdown GOAWAY] after Request.Body was written; define Request.GetBody to avoid this error
This PR [#24292](https://github.com/ethereum/go-ethereum/pull/24292) provides a detailed explanation of the root cause and how to fix it. I recommend that go-quai also incorporates this modification to resolve the issue.

This description clearly explains the problem, references the relevant fix from another repository, and suggests applying the same changes to go-quai.