### PR TITLE
Bugfix: Make empty quai transaction hash consistently during unmarshalling

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -97,12 +97,9 @@ func NewEmptyQuaiTx() *Transaction {
 			StorageKeys: []common.Hash{},
 		},
 		},
-		V:          new(big.Int),
-		R:          new(big.Int),
-		S:          new(big.Int),
-		ParentHash: &common.Hash{},
-		MixHash:    &common.Hash{},
-		WorkNonce:  &BlockNonce{},
+		V: new(big.Int),
+		R: new(big.Int),
+		S: new(big.Int),
 	}
 	return NewTx(inner)
 }

--- a/quaiclient/ethclient/ethclient.go
+++ b/quaiclient/ethclient/ethclient.go
@@ -85,7 +85,7 @@ func (ec *Client) BlockByHash(ctx context.Context, hash common.Hash) (*types.Wor
 // Note that loading full blocks requires two requests. Use HeaderByNumber
 // if you don't need all transactions or uncle headers.
 func (ec *Client) BlockByNumber(ctx context.Context, number *big.Int) (*types.WorkObject, error) {
-	return ec.getBlock(ctx, "eth_getBlockByNumber", toBlockNumArg(number), true)
+	return ec.getBlock(ctx, "quai_getBlockByNumber", toBlockNumArg(number), true)
 }
 
 func (ec *Client) BlockOrCandidateByHash(ctx context.Context, hash common.Hash) (*types.WorkObject, error) {


### PR DESCRIPTION
Bugfix:
for transactions initialized from `NewEmptyQuaiTx`, `quai_getBlockByNumber` RPC will fail to check hash consistently.