### PR TITLE
fix: return nil instead of error directly

### DIFF
--- a/rlp/raw.go
+++ b/rlp/raw.go
@@ -155,7 +155,7 @@ func readKind(buf []byte) (k Kind, tagsize, contentsize uint64, err error) {
 	if contentsize > uint64(len(buf))-tagsize {
 		return 0, 0, 0, ErrValueTooLarge
 	}
-	return k, tagsize, contentsize, err
+	return k, tagsize, contentsize, nil
 }
 
 func readSize(b []byte, slen byte) (uint64, error) {

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -172,7 +172,7 @@ func (t *Trie) TryGetNode(path []byte) ([]byte, int, error) {
 	if item == nil {
 		return nil, resolved, nil
 	}
-	return item, resolved, err
+	return item, resolved, nil
 }
 
 func (t *Trie) tryGetNode(origNode node, path []byte, pos int) (item []byte, newnode node, resolved int, err error) {


### PR DESCRIPTION
The logic of err not being nil has been processed and returned before, so err must be nil here.