### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
 	"math/big"
 	"net/http"
 	_ "net/http/pprof"
@@ -1372,7 +1371,7 @@ func SetQuaiConfig(stack *node.Node, cfg *quaiconfig.Config, slicesRunning []com
 	}
 	// Ensure Go's GC ignores the database cache for trigger percentage
 	cache := viper.GetInt(CacheFlag.Name)
-	gogc := math.Max(20, math.Min(100, 100/(float64(cache)/1024)))
+	gogc := max(20, min(100, 100/(float64(cache)/1024)))
 
 	logger.WithField("gogc", int(gogc)).Debug("Sanitizing Go's GC trigger")
 	godebug.SetGCPercent(int(gogc))

--- a/common/math/integer.go
+++ b/common/math/integer.go
@@ -96,19 +96,3 @@ func SafeMul(x, y uint64) (uint64, bool) {
 	hi, lo := bits.Mul64(x, y)
 	return lo, hi != 0
 }
-
-// Minimum returns the minimum of two integers.
-func Min(x, y int) int {
-	if x < y {
-		return x
-	}
-	return y
-}
-
-// Maximum returns the maximum of two integers.
-func Max(x, y int) int {
-	if x > y {
-		return x
-	}
-	return y
-}

--- a/core/core.go
+++ b/core/core.go
@@ -17,7 +17,6 @@ import (
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 
 	"github.com/dominant-strategies/go-quai/common"
-	"github.com/dominant-strategies/go-quai/common/math"
 	"github.com/dominant-strategies/go-quai/consensus"
 	"github.com/dominant-strategies/go-quai/consensus/misc"
 	"github.com/dominant-strategies/go-quai/core/rawdb"
@@ -516,7 +515,7 @@ func (c *Core) printStats() {
 	}).Info("Blocks waiting to be appended")
 
 	// Print hashes & heights of all queue entries.
-	for _, hash := range c.appendQueue.Keys()[:math.Min(len(c.appendQueue.Keys()), c_appendQueuePrintSize)] {
+	for _, hash := range c.appendQueue.Keys()[:min(len(c.appendQueue.Keys()), c_appendQueuePrintSize)] {
 		if value, exist := c.appendQueue.Peek(hash); exist {
 			hashNumber := types.HashAndNumber{Hash: hash, Number: value.number}
 			c.logger.WithFields(log.Fields{


### PR DESCRIPTION
Use the built-in max/min from the standard library in Go 1.21 to simplify the code.  https://pkg.go.dev/builtin@go1.21.0#max