### PR TITLE
bugfix: Removed the lookup cache for the data set item

### DIFF
--- a/consensus/progpow/algorithm_progpow.go
+++ b/consensus/progpow/algorithm_progpow.go
@@ -20,7 +20,6 @@ import (
 	"encoding/binary"
 	"math/bits"
 
-	goLRU "github.com/hashicorp/golang-lru/v2"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -38,16 +37,10 @@ const (
 )
 
 func progpowLight(size uint64, cache []uint32, hash []byte, nonce uint64,
-	blockNumber uint64, cDag []uint32, lookupCache *goLRU.Cache[uint32, []byte]) ([]byte, []byte) {
+	blockNumber uint64, cDag []uint32) ([]byte, []byte) {
 	keccak512 := makeHasher(sha3.NewLegacyKeccak512())
 	lookup := func(index uint32) []byte {
-		res, ok := lookupCache.Get(index)
-		if ok {
-			return res
-		}
-		datasetItem := generateDatasetItem(cache, index/16, keccak512)
-		lookupCache.Add(index, datasetItem)
-		return datasetItem
+		return generateDatasetItem(cache, index/16, keccak512)
 	}
 	return progpow(hash, nonce, size, blockNumber, cDag, lookup)
 }

--- a/consensus/progpow/consensus.go
+++ b/consensus/progpow/consensus.go
@@ -589,7 +589,7 @@ func (progpow *Progpow) ComputePowLight(header *types.WorkObjectHeader) (mixHash
 			generateCDag(cDag, ethashCache.cache, blockNumber/C_epochLength, progpow.logger)
 			ethashCache.cDag = cDag
 		}
-		return progpowLight(size, cache, hash.Bytes(), nonce, blockNumber, ethashCache.cDag, progpow.lookupCache)
+		return progpowLight(size, cache, hash.Bytes(), nonce, blockNumber, ethashCache.cDag)
 	}
 	cache := progpow.cache(header.PrimeTerminusNumber().Uint64())
 	size := datasetSize(header.PrimeTerminusNumber().Uint64())

--- a/consensus/progpow/progpow.go
+++ b/consensus/progpow/progpow.go
@@ -179,9 +179,8 @@ type mixHashWorkHash struct {
 type Progpow struct {
 	config Config
 
-	caches      *lru                         // In memory caches to avoid regenerating too often
-	lookupCache *goLRU.Cache[uint32, []byte] // Cache to store the last few block hashes
-	hashCache   *goLRU.Cache[common.Hash, mixHashWorkHash]
+	caches    *lru // In memory caches to avoid regenerating too often
+	hashCache *goLRU.Cache[common.Hash, mixHashWorkHash]
 
 	// Mining related fields
 	rand    *rand.Rand    // Properly seeded random source for nonces
@@ -205,7 +204,7 @@ type Progpow struct {
 func New(config Config, notify []string, noverify bool, logger *log.Logger) *Progpow {
 	if config.CachesInMem <= 0 {
 		logger.WithField("requested", config.CachesInMem).Warn("Invalid ethash caches in memory, defaulting to 1")
-		config.CachesInMem = 1
+		config.CachesInMem = 3
 	}
 	if config.CacheDir != "" && config.CachesOnDisk > 0 {
 		logger.WithFields(log.Fields{
@@ -214,25 +213,19 @@ func New(config Config, notify []string, noverify bool, logger *log.Logger) *Pro
 		}).Info("Disk storage enabled for ethash caches")
 	}
 
-	lookupCache, err := goLRU.New[uint32, []byte](c_dagItemsInCache)
-	if err != nil {
-		logger.WithField("err", err).Fatal("Failed to create ethash lookup cache")
-	}
-
 	hashCache, err := goLRU.New[common.Hash, mixHashWorkHash](c_dagItemsInCache)
 	if err != nil {
 		logger.WithField("err", err).Fatal("Failed to create ethash hash cache")
 	}
 
 	progpow := &Progpow{
-		config:      config,
-		caches:      newlru("cache", config.CachesInMem, newCache, logger),
-		lookupCache: lookupCache,
-		hashCache:   hashCache,
-		update:      make(chan struct{}),
-		logger:      logger,
-		rand:        rand.New(rand.NewSource(time.Now().UnixNano())),
-		threads:     config.NumThreads,
+		config:    config,
+		caches:    newlru("cache", config.CachesInMem, newCache, logger),
+		hashCache: hashCache,
+		update:    make(chan struct{}),
+		logger:    logger,
+		rand:      rand.New(rand.NewSource(time.Now().UnixNano())),
+		threads:   config.NumThreads,
 	}
 	if config.PowMode == ModeShared {
 		progpow.shared = sharedProgpow

--- a/consensus/progpow/sealer.go
+++ b/consensus/progpow/sealer.go
@@ -164,7 +164,7 @@ search:
 					generateCDag(cDag, ethashCache.cache, blockNumber/C_epochLength, progpow.logger)
 					ethashCache.cDag = cDag
 				}
-				return progpowLight(size, cache, hash, nonce, blockNumber, ethashCache.cDag, progpow.lookupCache)
+				return progpowLight(size, cache, hash, nonce, blockNumber, ethashCache.cDag)
 			}
 			cache := progpow.cache(workObject.PrimeTerminusNumber().Uint64())
 			size := datasetSize(workObject.PrimeTerminusNumber().Uint64())


### PR DESCRIPTION
This lookup cache was added 10 months back to save generating the data set item for a given index. But the index is not unique between epochs, so this cache introduces a bug where the progpow verification fails. As this didnt exist in the original go-ethereum or the progpow PR that was made to the ethereum, removing it is a safer option. The function to generate the dataset item is very simple and has some simple math operations and few keccack hashes. So time saved by introducing this is not enough to justify this code.