### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 
@@ -223,12 +224,7 @@ func (n *Node) openEndpoints() error {
 
 // containsLifecycle checks if 'lfs' contains 'l'.
 func containsLifecycle(lfs []Lifecycle, l Lifecycle) bool {
-	for _, obj := range lfs {
-		if obj == l {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(lfs, l)
 }
 
 // stopServices terminates running services, RPC and p2p networking.

--- a/quai/filters/filter.go
+++ b/quai/filters/filter.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"slices"
 	"sync"
 
 	"github.com/dominant-strategies/go-quai/common"
@@ -378,13 +379,7 @@ Logs:
 			continue Logs
 		}
 		for i, sub := range topics {
-			match := len(sub) == 0 // empty rule set == wildcard
-			for _, topic := range sub {
-				if log.Topics[i] == topic {
-					match = true
-					break
-				}
-			}
+			match := slices.Contains(sub, log.Topics[i])
 			if !match {
 				continue Logs
 			}

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -27,6 +27,7 @@ import (
 	"mime"
 	"net/http"
 	"net/url"
+	"slices"
 	"sync"
 	"time"
 )
@@ -272,10 +273,8 @@ func validateRequest(r *http.Request) (int, error) {
 	}
 	// Check content-type
 	if mt, _, err := mime.ParseMediaType(r.Header.Get("content-type")); err == nil {
-		for _, accepted := range acceptedContentTypes {
-			if accepted == mt {
-				return 0, nil
-			}
+		if slices.Contains(acceptedContentTypes, mt) {
+			return 0, nil
 		}
 	}
 	// Invalid content-type


### PR DESCRIPTION

There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.