### PR TITLE
Adjusted Starting and Min Conversion flow by 5x

### DIFF
--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -212,8 +212,8 @@ var (
 
 	// Controller related constants
 	StartingKQuaiDiscount               = big.NewInt(100)
-	StartingConversionFlowAmount        = new(big.Int).Mul(big.NewInt(10000), big.NewInt(Ether)) // Starting conversion flow amount in Quai
-	MinConversionFlowAmount             = new(big.Int).Mul(big.NewInt(100), big.NewInt(Ether))   // Min conversion flow amount in Quai
+	StartingConversionFlowAmount        = new(big.Int).Mul(big.NewInt(50000), big.NewInt(Ether)) // Starting conversion flow amount in Quai
+	MinConversionFlowAmount             = new(big.Int).Mul(big.NewInt(500), big.NewInt(Ether))   // Min conversion flow amount in Quai
 	MinerDifficultyWindow        uint64 = 4000
 	KQuaiDiscountMultiplier      int64  = 100000
 	MinCubicDiscountBasisPoint   uint64 = 20


### PR DESCRIPTION
Conversion fees for 100 quai is 10 quai, 10% fee, so Qi cannot accurately be priced in under current conversion flow at this stage of adoption. 

Adoption of Qi is far out, and no conversion flow is being sustained. 