### PR TITLE
p2p/protocol: fix goroutine leak in inbound QuaiProtocolHandler

### DIFF
--- a/p2p/protocol/handler.go
+++ b/p2p/protocol/handler.go
@@ -149,6 +149,13 @@ func QuaiProtocolHandler(ctx context.Context, stream network.Stream, node QuaiP2
 	}()
 	defer stream.Close()
 
+	// Derive a per-stream context so the worker goroutine below exits when this
+	// handler returns (stream closed / peer gone), not only on node shutdown.
+	// Inbound streams are handled with the long-lived node context, so without
+	// this the worker leaks one goroutine per inbound stream that ever closed.
+	streamCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	log.Global.Debugf("Received a new stream from %s", stream.Conn().RemotePeer())
 
 	// if there is a protocol mismatch, close the stream
@@ -173,7 +180,7 @@ func QuaiProtocolHandler(ctx context.Context, stream network.Stream, node QuaiP2
 			select {
 			case message := <-msgChan:
 				handleMessage(message, stream, node)
-			case <-ctx.Done():
+			case <-streamCtx.Done():
 				return
 			}
 		}


### PR DESCRIPTION
## Problem

Inbound streams register the handler with the long-lived node context (`p2p/node/api.go`: `SetStreamHandler` → `QuaiProtocolHandler(p.ctx, …)`). The per-message worker goroutine spawned inside `QuaiProtocolHandler` only returns on `ctx.Done()`, i.e. node shutdown. When an inbound stream closes (peer disconnect), the read loop returns and `stream.Close()` runs, but the worker stays blocked forever on `select { <-msgChan; <-ctx.Done() }`.

Result: one leaked goroutine per inbound stream that ever closed. On a well-connected node with peer churn this grows unbounded (observed ~3700 leaked goroutines/day via pprof), pinning the closed `stream` object and channel buffers → steadily rising memory and GC pressure, eventually OOM on long-uptime nodes.

Outbound streams are unaffected: the stream manager already derives a cancellable context and cancels it on sever.

## Fix

Derive a per-stream context inside `QuaiProtocolHandler` and cancel it on return, so the worker goroutine exits when the stream closes:

```go
streamCtx, cancel := context.WithCancel(ctx)
defer cancel()
// worker selects on <-streamCtx.Done() instead of <-ctx.Done()
```

## Verification

`pprof /debug/pprof/goroutine` previously showed thousands of goroutines parked at the `handler.go` worker select; after the fix the goroutine count stays flat under the same peer churn. Builds clean (`make go-quai`).