### PR TITLE
feat(core): add read-only Prime NiPoPoW proof engine

### DIFF
--- a/cmd/nipopow-prime-validate/main.go
+++ b/cmd/nipopow-prime-validate/main.go
@@ -1,0 +1,405 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/core/nipopow"
+	"github.com/dominant-strategies/go-quai/core/rawdb"
+	"github.com/dominant-strategies/go-quai/core/types"
+	"github.com/dominant-strategies/go-quai/ethdb"
+	"github.com/dominant-strategies/go-quai/log"
+	"github.com/dominant-strategies/go-quai/trie"
+)
+
+const defaultTailLengths = "16,64,256,1024"
+
+type validationConfig struct {
+	M           uint64
+	Ranges      []nipopow.ValidationRange
+	TailLengths []uint64
+	Limits      nipopow.BuildLimits
+	Timeout     time.Duration
+}
+
+type cliConfig struct {
+	DBPath      string
+	AncientPath string
+	DBEngine    string
+	OutPath     string
+	Validation  validationConfig
+}
+
+type validationOutput struct {
+	StartedAtUTC        string                    `json:"startedAtUtc"`
+	FinishedAtUTC       string                    `json:"finishedAtUtc"`
+	DBPath              string                    `json:"dbPath,omitempty"`
+	AncientPath         string                    `json:"ancientPath,omitempty"`
+	ReadOnly            bool                      `json:"readOnly"`
+	Location            string                    `json:"location"`
+	HeadHash            common.Hash               `json:"headHash"`
+	HeadNumber          uint64                    `json:"headNumber"`
+	GenesisHashes       []common.Hash             `json:"genesisHashes"`
+	SelectedRanges      []nipopow.ValidationRange `json:"selectedRanges"`
+	M                   uint64                    `json:"m"`
+	Limits              nipopow.BuildLimits       `json:"limits"`
+	OpenElapsedMS       int64                     `json:"openElapsedMs,omitempty"`
+	ValidationElapsedMS int64                     `json:"validationElapsedMs"`
+	Report              *nipopow.ValidationReport `json:"report,omitempty"`
+	OK                  bool                      `json:"ok"`
+	Error               string                    `json:"error,omitempty"`
+}
+
+type rawPrimeSource struct {
+	db      ethdb.Database
+	genesis map[common.Hash]struct{}
+}
+
+func main() {
+	os.Exit(runCLI(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func runCLI(args []string, stdout io.Writer, stderr io.Writer) int {
+	log.Global.SetOutput(io.Discard)
+	log.Global.SetLevel(logrus.ErrorLevel)
+
+	cfg, err := parseCLI(args, stderr)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 2
+	}
+
+	out := validationOutput{
+		StartedAtUTC: time.Now().UTC().Format(time.RFC3339Nano),
+		DBPath:       cfg.DBPath,
+		AncientPath:  cfg.AncientPath,
+		ReadOnly:     true,
+		Location:     "prime",
+		M:            cfg.Validation.M,
+		Limits:       cfg.Validation.Limits,
+	}
+
+	openStarted := time.Now()
+	db, err := rawdb.Open(rawdb.OpenOptions{
+		Type:              cfg.DBEngine,
+		Directory:         cfg.DBPath,
+		AncientsDirectory: cfg.AncientPath,
+		Namespace:         "nipopow/prime-validate/",
+		Cache:             64,
+		Handles:           64,
+		ReadOnly:          true,
+	}, common.PRIME_CTX, log.Global, common.Location{})
+	out.OpenElapsedMS = time.Since(openStarted).Milliseconds()
+	if err != nil {
+		out.Error = fmt.Sprintf("open readonly db: %v", err)
+		out.FinishedAtUTC = time.Now().UTC().Format(time.RFC3339Nano)
+		_ = writeReport(stdout, cfg.OutPath, out)
+		return 1
+	}
+	defer db.Close()
+
+	report, err := runValidation(context.Background(), db, cfg.Validation)
+	out.FinishedAtUTC = time.Now().UTC().Format(time.RFC3339Nano)
+	out.HeadHash = report.HeadHash
+	out.HeadNumber = report.HeadNumber
+	out.GenesisHashes = report.GenesisHashes
+	out.SelectedRanges = report.SelectedRanges
+	out.M = report.M
+	out.Limits = report.Limits
+	out.ValidationElapsedMS = report.ValidationElapsedMS
+	out.Report = report.Report
+	out.OK = report.OK
+	if err != nil {
+		out.Error = err.Error()
+		out.OK = false
+	} else if !out.OK {
+		out.Error = "one or more validation ranges failed"
+	}
+	if err := writeReport(stdout, cfg.OutPath, out); err != nil {
+		fmt.Fprintf(stderr, "error writing report: %v\n", err)
+		return 1
+	}
+	if !out.OK {
+		return 1
+	}
+	return 0
+}
+
+func parseCLI(args []string, stderr io.Writer) (cliConfig, error) {
+	var rangesSpec string
+	var lengthsSpec string
+	cfg := cliConfig{}
+	fs := flag.NewFlagSet("nipopow-prime-validate", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.StringVar(&cfg.DBPath, "db", "", "Prime chaindata path to open read-only")
+	fs.StringVar(&cfg.AncientPath, "ancient", "", "Prime ancient freezer path; defaults to <db>/ancient when it exists")
+	fs.StringVar(&cfg.DBEngine, "db.engine", "leveldb", "Database engine: leveldb or pebble")
+	fs.StringVar(&cfg.OutPath, "out", "", "Optional JSON report output path; stdout is used when empty")
+	fs.Uint64Var(&cfg.Validation.M, "m", 16, "NiPoPoW suffix length")
+	fs.StringVar(&lengthsSpec, "lengths", defaultTailLengths, "Comma-separated tail lengths used when --ranges is empty")
+	fs.StringVar(&rangesSpec, "ranges", "", "Explicit ranges as name=anchor:tip,name2=anchor:tip; overrides --lengths")
+	fs.Uint64Var(&cfg.Validation.Limits.MaxChainLength, "max-chain", nipopow.DefaultMaxProofChainLength, "Maximum canonical chain walk length")
+	fs.Uint64Var(&cfg.Validation.Limits.MaxProofHeaders, "max-headers", nipopow.DefaultMaxProofHeaders, "Maximum compressed proof header count")
+	fs.Uint64Var(&cfg.Validation.Limits.MaxM, "max-m", nipopow.DefaultMaxProofM, "Maximum allowed m")
+	fs.DurationVar(&cfg.Validation.Timeout, "timeout", 2*time.Minute, "Validation timeout")
+	if err := fs.Parse(args); err != nil {
+		return cfg, err
+	}
+	if cfg.DBPath == "" {
+		return cfg, errors.New("missing required --db")
+	}
+	if cfg.AncientPath == "" {
+		candidate := filepath.Join(cfg.DBPath, "ancient")
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			cfg.AncientPath = candidate
+		}
+	}
+	if rangesSpec != "" {
+		ranges, err := parseRanges(rangesSpec)
+		if err != nil {
+			return cfg, err
+		}
+		cfg.Validation.Ranges = ranges
+		return cfg, nil
+	}
+	lengths, err := parseLengths(lengthsSpec)
+	if err != nil {
+		return cfg, err
+	}
+	cfg.Validation.TailLengths = lengths
+	return cfg, nil
+}
+
+func writeReport(stdout io.Writer, outPath string, report validationOutput) error {
+	payload, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return err
+	}
+	payload = append(payload, '\n')
+	if outPath == "" {
+		_, err = stdout.Write(payload)
+		return err
+	}
+	return os.WriteFile(outPath, payload, 0o644)
+}
+
+func runValidation(ctx context.Context, db ethdb.Database, cfg validationConfig) (validationOutput, error) {
+	out := validationOutput{
+		StartedAtUTC: time.Now().UTC().Format(time.RFC3339Nano),
+		ReadOnly:     true,
+		Location:     "prime",
+		M:            cfg.M,
+		Limits:       cfg.Limits,
+	}
+	defer func() {
+		out.FinishedAtUTC = time.Now().UTC().Format(time.RFC3339Nano)
+	}()
+	if db == nil {
+		return out, errors.New("nil database")
+	}
+	if cfg.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, cfg.Timeout)
+		defer cancel()
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	source := newRawPrimeSource(db)
+	out.GenesisHashes = source.genesisHashes()
+
+	head := rawdb.ReadHeadBlockHash(db)
+	if head == (common.Hash{}) {
+		head = rawdb.ReadHeadHeaderHash(db)
+	}
+	if head == (common.Hash{}) {
+		return out, errors.New("missing prime head hash")
+	}
+	headNumber := rawdb.ReadHeaderNumber(db, head)
+	if headNumber == nil {
+		return out, fmt.Errorf("missing prime head number for %s", head.Hex())
+	}
+	out.HeadHash = head
+	out.HeadNumber = *headNumber
+
+	ranges := cfg.Ranges
+	if len(ranges) == 0 {
+		maxChain := cfg.Limits.MaxChainLength
+		if maxChain == 0 {
+			maxChain = nipopow.DefaultMaxProofChainLength
+		}
+		ranges = selectTailRanges(*headNumber, cfg.M, maxChain, cfg.TailLengths)
+	}
+	out.SelectedRanges = ranges
+	if len(ranges) == 0 {
+		return out, fmt.Errorf("no validation ranges selected for head=%d m=%d", *headNumber, cfg.M)
+	}
+
+	started := time.Now()
+	report, err := nipopow.ValidatePrimeProofRanges(ctx, source, nipopow.ValidationOptions{
+		M:      cfg.M,
+		Ranges: ranges,
+		Limits: cfg.Limits,
+	})
+	out.ValidationElapsedMS = time.Since(started).Milliseconds()
+	if err != nil {
+		return out, err
+	}
+	out.Report = report
+	out.OK = !report.Failed()
+	return out, nil
+}
+
+func parseLengths(spec string) ([]uint64, error) {
+	if strings.TrimSpace(spec) == "" {
+		return nil, nil
+	}
+	parts := strings.Split(spec, ",")
+	lengths := make([]uint64, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		value, err := strconv.ParseUint(part, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid length %q: %w", part, err)
+		}
+		lengths = append(lengths, value)
+	}
+	return lengths, nil
+}
+
+func parseRanges(spec string) ([]nipopow.ValidationRange, error) {
+	if strings.TrimSpace(spec) == "" {
+		return nil, nil
+	}
+	parts := strings.Split(spec, ",")
+	ranges := make([]nipopow.ValidationRange, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		name := ""
+		rangeSpec := part
+		if before, after, ok := strings.Cut(part, "="); ok {
+			name = strings.TrimSpace(before)
+			rangeSpec = strings.TrimSpace(after)
+			if name == "" {
+				return nil, fmt.Errorf("invalid range %q: empty name", part)
+			}
+		}
+		anchorSpec, tipSpec, ok := strings.Cut(rangeSpec, ":")
+		if !ok {
+			return nil, fmt.Errorf("invalid range %q: expected anchor:tip", part)
+		}
+		anchor, err := strconv.ParseUint(strings.TrimSpace(anchorSpec), 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid range %q anchor: %w", part, err)
+		}
+		tip, err := strconv.ParseUint(strings.TrimSpace(tipSpec), 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid range %q tip: %w", part, err)
+		}
+		if name == "" {
+			name = fmt.Sprintf("%d-%d", anchor, tip)
+		}
+		ranges = append(ranges, nipopow.ValidationRange{Name: name, AnchorNumber: anchor, TipNumber: tip})
+	}
+	return ranges, nil
+}
+
+func selectTailRanges(headNumber uint64, m uint64, maxChain uint64, lengths []uint64) []nipopow.ValidationRange {
+	ranges := make([]nipopow.ValidationRange, 0, len(lengths))
+	for _, length := range lengths {
+		if length == 0 || length < m || length > maxChain || headNumber+1 < length {
+			continue
+		}
+		ranges = append(ranges, nipopow.ValidationRange{
+			Name:         fmt.Sprintf("tail-%d", length),
+			AnchorNumber: headNumber - length + 1,
+			TipNumber:    headNumber,
+		})
+	}
+	return ranges
+}
+
+func newRawPrimeSource(db ethdb.Database) *rawPrimeSource {
+	genesis := make(map[common.Hash]struct{})
+	for _, hash := range rawdb.ReadGenesisHashes(db) {
+		if hash != (common.Hash{}) {
+			genesis[hash] = struct{}{}
+		}
+	}
+	if hash := rawdb.ReadCanonicalHash(db, 0); hash != (common.Hash{}) {
+		genesis[hash] = struct{}{}
+	}
+	return &rawPrimeSource{db: db, genesis: genesis}
+}
+
+func (s *rawPrimeSource) GetCanonicalHash(number uint64) common.Hash {
+	return rawdb.ReadCanonicalHash(s.db, number)
+}
+
+func (s *rawPrimeSource) ProofHeader(hash common.Hash) (*types.WorkObject, error) {
+	number := rawdb.ReadHeaderNumber(s.db, hash)
+	if number == nil {
+		return nil, fmt.Errorf("header number not found for %s", hash.Hex())
+	}
+	header := rawdb.ReadHeader(s.db, *number, hash)
+	if header == nil {
+		return nil, fmt.Errorf("header not found for number=%d hash=%s", *number, hash.Hex())
+	}
+	if header.Hash() != hash {
+		return nil, fmt.Errorf("header hash mismatch number=%d expected=%s got=%s", *number, hash.Hex(), header.Hash().Hex())
+	}
+
+	proofHeader := types.CopyWorkObject(header)
+	interlinkSource := proofHeader.ParentHash(common.PRIME_CTX)
+	if s.isGenesis(hash) {
+		interlinkSource = hash
+	}
+	interlinks := rawdb.ReadInterlinkHashes(s.db, interlinkSource)
+	if interlinks == nil {
+		if !s.isGenesis(hash) {
+			return nil, fmt.Errorf("interlink hashes not found for source=%s header=%s number=%d", interlinkSource.Hex(), hash.Hex(), *number)
+		}
+		interlinks = common.Hashes{}
+	}
+	proofHeader.Body().SetInterlinkHashes(interlinks)
+
+	expected := types.DeriveSha(interlinks, trie.NewStackTrie(nil))
+	if proofHeader.InterlinkRootHash() != expected {
+		return nil, fmt.Errorf("interlink root mismatch for header=%s number=%d source=%s expected=%s got=%s interlinks=%d", hash.Hex(), *number, interlinkSource.Hex(), expected.Hex(), proofHeader.InterlinkRootHash().Hex(), len(interlinks))
+	}
+	return proofHeader, nil
+}
+
+func (s *rawPrimeSource) isGenesis(hash common.Hash) bool {
+	_, ok := s.genesis[hash]
+	return ok
+}
+
+func (s *rawPrimeSource) genesisHashes() []common.Hash {
+	hashes := make([]common.Hash, 0, len(s.genesis))
+	for hash := range s.genesis {
+		hashes = append(hashes, hash)
+	}
+	sort.Slice(hashes, func(i, j int) bool { return hashes[i].Hex() < hashes[j].Hex() })
+	return hashes
+}

--- a/cmd/nipopow-prime-validate/main_test.go
+++ b/cmd/nipopow-prime-validate/main_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/core/nipopow"
+	"github.com/dominant-strategies/go-quai/core/rawdb"
+	"github.com/dominant-strategies/go-quai/core/types"
+	"github.com/dominant-strategies/go-quai/ethdb"
+	"github.com/dominant-strategies/go-quai/log"
+	"github.com/dominant-strategies/go-quai/trie"
+)
+
+func TestParseRangesAcceptsNamedNumberPairs(t *testing.T) {
+	ranges, err := parseRanges("recent=10:20,older=30:40")
+	if err != nil {
+		t.Fatalf("parseRanges returned error: %v", err)
+	}
+	want := []nipopow.ValidationRange{
+		{Name: "recent", AnchorNumber: 10, TipNumber: 20},
+		{Name: "older", AnchorNumber: 30, TipNumber: 40},
+	}
+	if len(ranges) != len(want) {
+		t.Fatalf("range count mismatch: want %d got %d", len(want), len(ranges))
+	}
+	for i := range want {
+		if ranges[i] != want[i] {
+			t.Fatalf("range %d mismatch: want %+v got %+v", i, want[i], ranges[i])
+		}
+	}
+}
+
+func TestSelectTailRangesSkipsUnsafeLengths(t *testing.T) {
+	ranges := selectTailRanges(100, 16, 64, []uint64{0, 8, 16, 32, 65, 200})
+	want := []nipopow.ValidationRange{
+		{Name: "tail-16", AnchorNumber: 85, TipNumber: 100},
+		{Name: "tail-32", AnchorNumber: 69, TipNumber: 100},
+	}
+	if len(ranges) != len(want) {
+		t.Fatalf("range count mismatch: want %d got %d (%+v)", len(want), len(ranges), ranges)
+	}
+	for i := range want {
+		if ranges[i] != want[i] {
+			t.Fatalf("range %d mismatch: want %+v got %+v", i, want[i], ranges[i])
+		}
+	}
+}
+
+func TestRunValidationAgainstRawDBReportsSuccessfulRange(t *testing.T) {
+	db := rawdb.NewMemoryDatabase(log.Global)
+	blocks := writeLinearPrimeChain(t, db, 8)
+
+	report, err := runValidation(context.Background(), db, validationConfig{
+		M:       4,
+		Ranges:  []nipopow.ValidationRange{{Name: "fixture", AnchorNumber: 0, TipNumber: 7}},
+		Limits:  nipopow.BuildLimits{MaxChainLength: 16, MaxProofHeaders: 16, MaxM: 4},
+		Timeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("runValidation returned error: %v", err)
+	}
+	if !report.OK {
+		t.Fatalf("expected OK report: %+v", report)
+	}
+	if report.HeadHash != blocks[7].Hash() || report.HeadNumber != 7 {
+		t.Fatalf("unexpected head: number=%d hash=%s", report.HeadNumber, report.HeadHash)
+	}
+	if report.Report == nil || len(report.Report.Results) != 1 {
+		t.Fatalf("missing validation result: %+v", report.Report)
+	}
+	result := report.Report.Results[0]
+	if !result.OK || result.Anchor != blocks[0].Hash() || result.Tip != blocks[7].Hash() || result.ProofHeaders == 0 {
+		t.Fatalf("unexpected validation result: %+v", result)
+	}
+}
+
+func writeLinearPrimeChain(t *testing.T, db ethdb.Database, length int) []*types.WorkObject {
+	t.Helper()
+	blocks := make([]*types.WorkObject, 0, length)
+	committedInterlinks := common.Hashes{common.HexToHash("0x01")}
+	for i := 0; i < length; i++ {
+		var parent *types.WorkObject
+		if i > 0 {
+			parent = blocks[i-1]
+		}
+		block := testPrimeBlock(t, uint64(i), parent, committedInterlinks)
+		if i == 0 {
+			rawdb.WriteGenesisHashes(db, common.Hashes{block.Hash()})
+		}
+		rawdb.WriteInterlinkHashes(db, block.Hash(), committedInterlinks)
+		rawdb.WriteTermini(db, block.Hash(), types.EmptyTermini())
+		rawdb.WriteCanonicalHash(db, block.Hash(), uint64(i))
+		rawdb.WriteWorkObject(db, block.Hash(), block, types.BlockObject, common.PRIME_CTX)
+		blocks = append(blocks, block)
+	}
+	rawdb.WriteHeadBlockHash(db, blocks[len(blocks)-1].Hash())
+	rawdb.WriteHeadHeaderHash(db, blocks[len(blocks)-1].Hash())
+	return blocks
+}
+
+func testPrimeBlock(t *testing.T, number uint64, parent *types.WorkObject, committedInterlinks common.Hashes) *types.WorkObject {
+	t.Helper()
+	wo := types.EmptyWorkObject(common.PRIME_CTX)
+	wo.WorkObjectHeader().SetNumber(new(big.Int).SetUint64(number))
+	wo.WorkObjectHeader().SetDifficulty(big.NewInt(1))
+	wo.WorkObjectHeader().SetPrimeTerminusNumber(new(big.Int).SetUint64(number))
+	wo.WorkObjectHeader().SetPrimaryCoinbase(common.BytesToAddress(make([]byte, 20), common.Location{}))
+	wo.WorkObjectHeader().SetTime(number + 1)
+
+	header := wo.Header()
+	header.SetNumber(new(big.Int).SetUint64(number), common.PRIME_CTX)
+	header.SetParentDeltaEntropy(big.NewInt(1), common.PRIME_CTX)
+	header.SetExpansionNumber(0)
+	if parent != nil {
+		header.SetParentHash(parent.Hash(), common.PRIME_CTX)
+		wo.WorkObjectHeader().SetParentHash(parent.Hash())
+	}
+	header.SetInterlinkRootHash(types.DeriveSha(committedInterlinks, trie.NewStackTrie(nil)))
+	wo.Body().SetInterlinkHashes(nil)
+	wo.WorkObjectHeader().SetHeaderHash(header.Hash())
+	return wo
+}

--- a/core/core_nipopow.go
+++ b/core/core_nipopow.go
@@ -1,0 +1,13 @@
+package core
+
+import (
+	"context"
+
+	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/core/nipopow"
+)
+
+// GetNiPoPoWProof builds a read-only Prime NiPoPoW proof for RPC callers.
+func (c *Core) GetNiPoPoWProof(ctx context.Context, anchor common.Hash, tip common.Hash, m uint64) (*nipopow.Proof, error) {
+	return c.sl.hc.BuildPrimeNiPoPoWProof(ctx, anchor, tip, m)
+}

--- a/core/headerchain_nipopow.go
+++ b/core/headerchain_nipopow.go
@@ -1,0 +1,67 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/core/nipopow"
+	"github.com/dominant-strategies/go-quai/core/rawdb"
+	"github.com/dominant-strategies/go-quai/core/types"
+	"github.com/dominant-strategies/go-quai/trie"
+)
+
+var (
+	ErrNiPoPoWPrimeOnly       = errors.New("nipopow proof generation is only available in prime context")
+	ErrNiPoPoWHeaderNotFound  = errors.New("nipopow header not found")
+	ErrNiPoPoWInterlinkAbsent = errors.New("nipopow interlink hashes not found")
+)
+
+// ProofHeader returns a hydrated Prime proof header for nipopow.BuildPrimeProof.
+func (hc *HeaderChain) ProofHeader(hash common.Hash) (*types.WorkObject, error) {
+	return hc.GetPrimeNiPoPoWProofHeader(hash)
+}
+
+// GetPrimeNiPoPoWProofHeader returns a copy of a Prime header with the
+// interlink hashes committed to by its InterlinkRootHash populated in the body.
+// It is read-only and never calls CalculateInterlink, because CalculateInterlink
+// writes interlink state.
+func (hc *HeaderChain) GetPrimeNiPoPoWProofHeader(hash common.Hash) (*types.WorkObject, error) {
+	if hc.NodeCtx() != common.PRIME_CTX {
+		return nil, ErrNiPoPoWPrimeOnly
+	}
+	header := hc.GetHeaderByHash(hash)
+	if header == nil {
+		return nil, fmt.Errorf("%w: %s", ErrNiPoPoWHeaderNotFound, hash.Hex())
+	}
+
+	proofHeader := types.CopyWorkObject(header)
+	interlinkSource := proofHeader.ParentHash(common.PRIME_CTX)
+	if hc.IsGenesisHash(hash) {
+		interlinkSource = hash
+	}
+	interlinks := rawdb.ReadInterlinkHashes(hc.headerDb, interlinkSource)
+	if interlinks == nil {
+		if !hc.IsGenesisHash(hash) {
+			return nil, fmt.Errorf("%w for source %s", ErrNiPoPoWInterlinkAbsent, interlinkSource.Hex())
+		}
+		interlinks = common.Hashes{}
+	}
+	proofHeader.Body().SetInterlinkHashes(interlinks)
+
+	expected := types.DeriveSha(interlinks, trie.NewStackTrie(nil))
+	if proofHeader.InterlinkRootHash() != expected {
+		return nil, fmt.Errorf("%w: expected %s got %s", nipopow.ErrInterlinkRootMismatch, expected.Hex(), proofHeader.InterlinkRootHash().Hex())
+	}
+	return proofHeader, nil
+}
+
+// BuildPrimeNiPoPoWProof builds a read-only Prime NiPoPoW proof from anchor to
+// tip using headers and interlinks already stored by this node.
+func (hc *HeaderChain) BuildPrimeNiPoPoWProof(ctx context.Context, anchor common.Hash, tip common.Hash, m uint64) (*nipopow.Proof, error) {
+	if hc.NodeCtx() != common.PRIME_CTX {
+		return nil, ErrNiPoPoWPrimeOnly
+	}
+	return nipopow.BuildPrimeProofWithContext(ctx, hc, anchor, tip, m, nipopow.DefaultBuildLimits)
+}

--- a/core/headerchain_nipopow_test.go
+++ b/core/headerchain_nipopow_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/dominant-strategies/go-quai/trie"
 )
 
+var _ nipopow.PrimeValidationSource = (*HeaderChain)(nil)
+
 func testPrimeNiPoPoWHeaderChain(t *testing.T) *HeaderChain {
 	t.Helper()
 

--- a/core/headerchain_nipopow_test.go
+++ b/core/headerchain_nipopow_test.go
@@ -1,0 +1,150 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"reflect"
+	"testing"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+
+	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/core/nipopow"
+	"github.com/dominant-strategies/go-quai/core/rawdb"
+	"github.com/dominant-strategies/go-quai/core/types"
+	"github.com/dominant-strategies/go-quai/log"
+	"github.com/dominant-strategies/go-quai/params"
+	"github.com/dominant-strategies/go-quai/trie"
+)
+
+func testPrimeNiPoPoWHeaderChain(t *testing.T) *HeaderChain {
+	t.Helper()
+
+	db := rawdb.NewMemoryDatabase(log.Global)
+	chainConfig := *params.TestChainConfig
+	chainConfig.Location = common.Location{}
+
+	headerCache, err := lru.New[common.Hash, types.WorkObject](headerCacheLimit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	numberCache, err := lru.New[common.Hash, uint64](numberCacheLimit)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hc := NewTestHeaderChain()
+	hc.config = &chainConfig
+	hc.headerDb = db
+	hc.bc = NewTestBodyDb(db)
+	hc.bc.chainConfig = &chainConfig
+	hc.headerCache = headerCache
+	hc.numberCache = numberCache
+	hc.logger = log.Global
+	return hc
+}
+
+func testPrimeNiPoPoWBlock(t *testing.T, number uint64, parent *types.WorkObject, committedInterlinks common.Hashes) *types.WorkObject {
+	t.Helper()
+
+	wo := types.EmptyWorkObject(common.PRIME_CTX)
+	wo.WorkObjectHeader().SetNumber(new(big.Int).SetUint64(number))
+	wo.WorkObjectHeader().SetDifficulty(big.NewInt(1))
+	wo.WorkObjectHeader().SetPrimeTerminusNumber(new(big.Int).SetUint64(number))
+	wo.WorkObjectHeader().SetPrimaryCoinbase(common.BytesToAddress(make([]byte, 20), common.Location{}))
+	wo.WorkObjectHeader().SetTime(number)
+
+	header := wo.Header()
+	header.SetNumber(new(big.Int).SetUint64(number), common.PRIME_CTX)
+	header.SetParentDeltaEntropy(big.NewInt(1), common.PRIME_CTX)
+	header.SetExpansionNumber(0)
+	if parent != nil {
+		header.SetParentHash(parent.Hash(), common.PRIME_CTX)
+		wo.WorkObjectHeader().SetParentHash(parent.Hash())
+	}
+	header.SetInterlinkRootHash(types.DeriveSha(committedInterlinks, trie.NewStackTrie(nil)))
+	wo.Body().SetInterlinkHashes(nil)
+	wo.WorkObjectHeader().SetHeaderHash(header.Hash())
+	return wo
+}
+
+func writePrimeNiPoPoWBlock(t *testing.T, hc *HeaderChain, wo *types.WorkObject) {
+	t.Helper()
+	rawdb.WriteTermini(hc.headerDb, wo.Hash(), types.EmptyTermini())
+	rawdb.WriteCanonicalHash(hc.headerDb, wo.Hash(), wo.NumberU64(common.PRIME_CTX))
+	rawdb.WriteWorkObject(hc.headerDb, wo.Hash(), wo, types.BlockObject, common.PRIME_CTX)
+}
+
+func TestGetPrimeNiPoPoWProofHeaderHydratesGenesisInterlinksFromRawDB(t *testing.T) {
+	hc := testPrimeNiPoPoWHeaderChain(t)
+	genesisInterlinks := common.Hashes{common.HexToHash("0x01"), common.HexToHash("0x02")}
+	genesis := testPrimeNiPoPoWBlock(t, 0, nil, genesisInterlinks)
+
+	rawdb.WriteGenesisHashes(hc.headerDb, common.Hashes{genesis.Hash()})
+	rawdb.WriteInterlinkHashes(hc.headerDb, genesis.Hash(), genesisInterlinks)
+	writePrimeNiPoPoWBlock(t, hc, genesis)
+
+	proofHeader, err := hc.GetPrimeNiPoPoWProofHeader(genesis.Hash())
+	if err != nil {
+		t.Fatalf("expected genesis proof header to hydrate interlinks from rawdb: %v", err)
+	}
+	if !reflect.DeepEqual(proofHeader.InterlinkHashes(), genesisInterlinks) {
+		t.Fatalf("unexpected genesis interlinks: want %v got %v", genesisInterlinks, proofHeader.InterlinkHashes())
+	}
+}
+
+func TestGetPrimeNiPoPoWProofHeaderHydratesEmptyGenesisInterlinksWhenRawDBAbsent(t *testing.T) {
+	hc := testPrimeNiPoPoWHeaderChain(t)
+	genesis := testPrimeNiPoPoWBlock(t, 0, nil, nil)
+
+	rawdb.WriteGenesisHashes(hc.headerDb, common.Hashes{genesis.Hash()})
+	writePrimeNiPoPoWBlock(t, hc, genesis)
+
+	proofHeader, err := hc.GetPrimeNiPoPoWProofHeader(genesis.Hash())
+	if err != nil {
+		t.Fatalf("expected empty genesis proof header to hydrate without rawdb interlinks: %v", err)
+	}
+	if len(proofHeader.InterlinkHashes()) != 0 {
+		t.Fatalf("expected empty genesis interlinks, got %v", proofHeader.InterlinkHashes())
+	}
+}
+
+func TestBuildPrimeNiPoPoWProofFromGenesisUsesRawDBInterlinks(t *testing.T) {
+	hc := testPrimeNiPoPoWHeaderChain(t)
+	genesisInterlinks := common.Hashes{common.HexToHash("0x01"), common.HexToHash("0x02")}
+	genesis := testPrimeNiPoPoWBlock(t, 0, nil, genesisInterlinks)
+	child := testPrimeNiPoPoWBlock(t, 1, genesis, genesisInterlinks)
+
+	rawdb.WriteGenesisHashes(hc.headerDb, common.Hashes{genesis.Hash()})
+	rawdb.WriteInterlinkHashes(hc.headerDb, genesis.Hash(), genesisInterlinks)
+	writePrimeNiPoPoWBlock(t, hc, genesis)
+	writePrimeNiPoPoWBlock(t, hc, child)
+
+	proof, err := hc.BuildPrimeNiPoPoWProof(context.Background(), genesis.Hash(), child.Hash(), 1)
+	if err != nil {
+		t.Fatalf("expected proof from genesis to child to build from rawdb: %v", err)
+	}
+	if proof.Anchor != genesis.Hash() || proof.Tip() != child.Hash() {
+		t.Fatalf("unexpected proof endpoints: anchor=%s tip=%s", proof.Anchor, proof.Tip())
+	}
+	if err := nipopow.VerifyPrimeProof(proof); err != nil {
+		t.Fatalf("expected built proof to verify structurally: %v", err)
+	}
+}
+
+func TestGetPrimeNiPoPoWProofHeaderRejectsMissingRawDBInterlinks(t *testing.T) {
+	hc := testPrimeNiPoPoWHeaderChain(t)
+	parentInterlinks := common.Hashes{common.HexToHash("0x01")}
+	parent := testPrimeNiPoPoWBlock(t, 0, nil, parentInterlinks)
+	child := testPrimeNiPoPoWBlock(t, 1, parent, parentInterlinks)
+
+	rawdb.WriteGenesisHashes(hc.headerDb, common.Hashes{parent.Hash()})
+	writePrimeNiPoPoWBlock(t, hc, parent)
+	writePrimeNiPoPoWBlock(t, hc, child)
+
+	_, err := hc.GetPrimeNiPoPoWProofHeader(child.Hash())
+	if !errors.Is(err, ErrNiPoPoWInterlinkAbsent) {
+		t.Fatalf("expected missing interlinks error, got %v", err)
+	}
+}

--- a/core/nipopow/adversarial.go
+++ b/core/nipopow/adversarial.go
@@ -1,0 +1,145 @@
+package nipopow
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/dominant-strategies/go-quai/core/types"
+)
+
+var (
+	ErrNoAdversarialCases            = errors.New("no nipopow adversarial cases configured")
+	ErrNilAdversarialMutator         = errors.New("nil nipopow adversarial mutator")
+	ErrAdversarialCaseUnexpectedPass = errors.New("adversarial nipopow case unexpectedly verified")
+	ErrAdversarialCaseUnexpectedErr  = errors.New("adversarial nipopow case returned unexpected error")
+)
+
+// ProofMutation mutates a copied proof for adversarial validation. Mutators must
+// not mutate the baseline proof passed to ValidatePrimeProofAdversarialCases.
+type ProofMutation func(*Proof) error
+
+// AdversarialCase describes one malformed proof sample that must be rejected by
+// VerifyPrimeProof. If ExpectedError is nil, any verification error is accepted.
+type AdversarialCase struct {
+	Name          string
+	Mutate        ProofMutation
+	ExpectedError error
+}
+
+// AdversarialReport captures whether the baseline proof verifies and whether all
+// adversarial mutations were rejected with the expected verifier errors.
+type AdversarialReport struct {
+	BaselineOK    bool                `json:"baselineOk"`
+	BaselineError string              `json:"baselineError,omitempty"`
+	Results       []AdversarialResult `json:"results"`
+}
+
+// Failed reports whether the baseline failed or any adversarial case was not
+// rejected as expected.
+func (r *AdversarialReport) Failed() bool {
+	if r == nil || !r.BaselineOK {
+		return true
+	}
+	for _, result := range r.Results {
+		if !result.OK {
+			return true
+		}
+	}
+	return false
+}
+
+// AdversarialResult records one adversarial mutation outcome. OK means the
+// mutated proof was rejected, and when ExpectedError was configured the rejection
+// matched it via errors.Is.
+type AdversarialResult struct {
+	Name          string `json:"name"`
+	OK            bool   `json:"ok"`
+	ExpectedError string `json:"expectedError,omitempty"`
+	Error         string `json:"error,omitempty"`
+	Err           error  `json:"-"`
+}
+
+// ValidatePrimeProofAdversarialCases verifies a known-good baseline proof, then
+// clones and mutates it for each adversarial case. The function treats a mutated
+// proof that still verifies as a failed gate result.
+func ValidatePrimeProofAdversarialCases(baseline *Proof, cases []AdversarialCase) (*AdversarialReport, error) {
+	if len(cases) == 0 {
+		return nil, ErrNoAdversarialCases
+	}
+	for i, validationCase := range cases {
+		if validationCase.Mutate == nil {
+			return nil, fmt.Errorf("%w: case %d %q", ErrNilAdversarialMutator, i, validationCase.name(i))
+		}
+	}
+
+	report := &AdversarialReport{
+		Results: make([]AdversarialResult, 0, len(cases)),
+	}
+	if err := VerifyPrimeProof(baseline); err != nil {
+		report.BaselineError = err.Error()
+		return report, nil
+	}
+	report.BaselineOK = true
+
+	for i, validationCase := range cases {
+		report.Results = append(report.Results, runAdversarialCase(baseline, validationCase, i))
+	}
+	return report, nil
+}
+
+func runAdversarialCase(baseline *Proof, validationCase AdversarialCase, index int) AdversarialResult {
+	result := AdversarialResult{
+		Name: validationCase.name(index),
+	}
+	if validationCase.ExpectedError != nil {
+		result.ExpectedError = validationCase.ExpectedError.Error()
+	}
+
+	mutated := cloneProof(baseline)
+	if err := validationCase.Mutate(mutated); err != nil {
+		result.Err = err
+		result.Error = err.Error()
+		return result
+	}
+
+	err := VerifyPrimeProof(mutated)
+	if err == nil {
+		result.Err = fmt.Errorf("%w: %s", ErrAdversarialCaseUnexpectedPass, result.Name)
+		result.Error = result.Err.Error()
+		return result
+	}
+	result.Err = err
+	result.Error = err.Error()
+	if validationCase.ExpectedError != nil && !errors.Is(err, validationCase.ExpectedError) {
+		result.OK = false
+		result.Err = fmt.Errorf("%w: case %s expected %q got %q", ErrAdversarialCaseUnexpectedErr, result.Name, validationCase.ExpectedError.Error(), err.Error())
+		result.Error = result.Err.Error()
+		return result
+	}
+	result.OK = true
+	return result
+}
+
+func (c AdversarialCase) name(index int) string {
+	if c.Name != "" {
+		return c.Name
+	}
+	return fmt.Sprintf("case-%d", index)
+}
+
+func cloneProof(proof *Proof) *Proof {
+	if proof == nil {
+		return nil
+	}
+	clone := &Proof{
+		Anchor:  proof.Anchor,
+		M:       proof.M,
+		Headers: make([]*types.WorkObject, len(proof.Headers)),
+	}
+	for i, header := range proof.Headers {
+		if header != nil {
+			clone.Headers[i] = types.CopyWorkObject(header)
+		}
+	}
+	return clone
+}

--- a/core/nipopow/adversarial_test.go
+++ b/core/nipopow/adversarial_test.go
@@ -1,0 +1,164 @@
+package nipopow
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/core/types"
+)
+
+func TestValidatePrimeProofAdversarialCasesRejectsExpectedMutations(t *testing.T) {
+	proof := validAdversarialPrimeProof(t)
+
+	report, err := ValidatePrimeProofAdversarialCases(proof, []AdversarialCase{
+		{
+			Name:          "anchor-mismatch",
+			ExpectedError: ErrAnchorMismatch,
+			Mutate: func(proof *Proof) error {
+				proof.Anchor = common.HexToHash("0x01")
+				return nil
+			},
+		},
+		{
+			Name:          "nil-header",
+			ExpectedError: ErrNilHeader,
+			Mutate: func(proof *Proof) error {
+				proof.Headers[1] = nil
+				return nil
+			},
+		},
+		{
+			Name:          "swapped-body-header",
+			ExpectedError: ErrHeaderHashMismatch,
+			Mutate: func(proof *Proof) error {
+				proof.Headers[1].SetBody(types.CopyWorkObject(proof.Headers[0]).Body())
+				return nil
+			},
+		},
+		{
+			Name:          "bad-interlink-root",
+			ExpectedError: ErrInterlinkRootMismatch,
+			Mutate: func(proof *Proof) error {
+				proof.Headers[1].Body().SetInterlinkHashes(common.Hashes{})
+				return nil
+			},
+		},
+		{
+			Name:          "disconnected-prefix",
+			ExpectedError: ErrDisconnectedHeaders,
+			Mutate: func(proof *Proof) error {
+				proof.Headers[1] = testPrimeBlock(t, 9, nil, nil)
+				return nil
+			},
+		},
+		{
+			Name:          "nonlinear-suffix",
+			ExpectedError: ErrNonLinearSuffix,
+			Mutate: func(proof *Proof) error {
+				proof.Headers = []*types.WorkObject{proof.Headers[0], proof.Headers[1], proof.Headers[3]}
+				return nil
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected adversarial report, got error: %v", err)
+	}
+	if report.Failed() {
+		t.Fatalf("expected all adversarial cases to be rejected as expected: %+v", report.Results)
+	}
+	if !report.BaselineOK || report.BaselineError != "" {
+		t.Fatalf("expected valid baseline: %+v", report)
+	}
+	if len(report.Results) != 6 {
+		t.Fatalf("unexpected result count: %+v", report.Results)
+	}
+	for _, result := range report.Results {
+		if !result.OK || result.Error == "" || result.ExpectedError == "" {
+			t.Fatalf("unexpected adversarial result: %+v", result)
+		}
+	}
+}
+
+func TestValidatePrimeProofAdversarialCasesFailsWhenMutationStillVerifies(t *testing.T) {
+	proof := validAdversarialPrimeProof(t)
+
+	report, err := ValidatePrimeProofAdversarialCases(proof, []AdversarialCase{
+		{
+			Name:          "no-op",
+			ExpectedError: ErrDisconnectedHeaders,
+			Mutate: func(proof *Proof) error {
+				return nil
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected adversarial report, got error: %v", err)
+	}
+	if !report.Failed() || len(report.Results) != 1 {
+		t.Fatalf("expected failed adversarial report: %+v", report)
+	}
+	result := report.Results[0]
+	if result.OK || !errors.Is(result.Err, ErrAdversarialCaseUnexpectedPass) {
+		t.Fatalf("expected unexpected-pass result, got %+v", result)
+	}
+}
+
+func TestValidatePrimeProofAdversarialCasesRejectsInvalidHarnessConfig(t *testing.T) {
+	_, err := ValidatePrimeProofAdversarialCases(validAdversarialPrimeProof(t), nil)
+	if !errors.Is(err, ErrNoAdversarialCases) {
+		t.Fatalf("expected no-cases error, got %v", err)
+	}
+
+	_, err = ValidatePrimeProofAdversarialCases(validAdversarialPrimeProof(t), []AdversarialCase{{Name: "nil-mutator"}})
+	if !errors.Is(err, ErrNilAdversarialMutator) {
+		t.Fatalf("expected nil-mutator error, got %v", err)
+	}
+}
+
+func FuzzVerifyPrimeProofRejectsUnsafeMutations(f *testing.F) {
+	for seed := byte(0); seed < 8; seed++ {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, mutation byte) {
+		proof := validAdversarialPrimeProof(t)
+		switch mutation % 8 {
+		case 0:
+			proof.M = 0
+		case 1:
+			proof.Headers = nil
+		case 2:
+			proof.Anchor = common.HexToHash("0x02")
+		case 3:
+			proof.Headers[1] = nil
+		case 4:
+			proof.Headers[1].Header().SetExtra([]byte{mutation})
+		case 5:
+			proof.Headers[1].Body().SetInterlinkHashes(common.Hashes{})
+		case 6:
+			proof.Headers = []*types.WorkObject{proof.Headers[0], proof.Headers[1], proof.Headers[3]}
+		case 7:
+			proof.Headers[1] = testPrimeBlock(t, 9, nil, nil)
+		}
+		if err := VerifyPrimeProof(proof); err == nil {
+			t.Fatalf("mutation %d unexpectedly verified", mutation%8)
+		}
+	})
+}
+
+func validAdversarialPrimeProof(t *testing.T) *Proof {
+	t.Helper()
+	anchor := testPrimeBlock(t, 1, nil, nil)
+	jump := testPrimeBlock(t, 4, anchor, common.Hashes{anchor.Hash()})
+	suffix1 := testPrimeBlock(t, 5, jump, common.Hashes{anchor.Hash(), jump.Hash()})
+	suffix2 := testPrimeBlock(t, 6, suffix1, common.Hashes{jump.Hash()})
+	proof := &Proof{
+		Anchor:  anchor.Hash(),
+		M:       2,
+		Headers: []*types.WorkObject{anchor, jump, suffix1, suffix2},
+	}
+	if err := VerifyPrimeProof(proof); err != nil {
+		t.Fatalf("invalid adversarial baseline fixture: %v", err)
+	}
+	return proof
+}

--- a/core/nipopow/build.go
+++ b/core/nipopow/build.go
@@ -164,7 +164,10 @@ func compressPrimeChain(chain []*types.WorkObject, m int) []*types.WorkObject {
 	current := 0
 	for current < suffixStart {
 		farthest := current + 1
-		for candidate := suffixStart; candidate > current+1; candidate-- {
+		// Search the full chain (including suffix headers) for interlink jump
+		// targets. Suffix headers must remain linear in the proof regardless,
+		// but using them as jump targets can skip more prefix headers.
+		for candidate := len(chain) - 1; candidate > current; candidate-- {
 			if interlinksContain(chain[candidate].InterlinkHashes(), chain[current].Hash()) {
 				farthest = candidate
 				break

--- a/core/nipopow/build.go
+++ b/core/nipopow/build.go
@@ -1,0 +1,181 @@
+package nipopow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/core/types"
+)
+
+const (
+	DefaultMaxProofChainLength uint64 = 4096
+	DefaultMaxProofHeaders     uint64 = 1024
+	DefaultMaxProofM           uint64 = 1024
+)
+
+var (
+	ErrNilProofSource       = errors.New("nil nipopow proof source")
+	ErrInvalidProofEndpoint = errors.New("invalid nipopow proof endpoint")
+	ErrProofHeaderNotFound  = errors.New("nipopow proof header not found")
+	ErrAnchorNotFound       = errors.New("nipopow proof anchor is not an ancestor of tip")
+	ErrHeaderHashMismatch   = errors.New("nipopow proof source returned mismatched header")
+	ErrCycleDetected        = errors.New("nipopow proof walk detected a cycle")
+	ErrProofTooLarge        = errors.New("nipopow proof exceeds configured limits")
+)
+
+// BuildLimits bounds read-only proof construction for public RPC callers.
+type BuildLimits struct {
+	MaxChainLength  uint64
+	MaxProofHeaders uint64
+	MaxM            uint64
+}
+
+var DefaultBuildLimits = BuildLimits{
+	MaxChainLength:  DefaultMaxProofChainLength,
+	MaxProofHeaders: DefaultMaxProofHeaders,
+	MaxM:            DefaultMaxProofM,
+}
+
+func (limits BuildLimits) withDefaults() BuildLimits {
+	if limits.MaxChainLength == 0 {
+		limits.MaxChainLength = DefaultMaxProofChainLength
+	}
+	if limits.MaxProofHeaders == 0 {
+		limits.MaxProofHeaders = DefaultMaxProofHeaders
+	}
+	if limits.MaxM == 0 {
+		limits.MaxM = DefaultMaxProofM
+	}
+	return limits
+}
+
+// PrimeProofSource supplies hydrated Prime proof headers. Returned WorkObjects
+// must include the InterlinkHashes committed to by their InterlinkRootHash.
+type PrimeProofSource interface {
+	ProofHeader(hash common.Hash) (*types.WorkObject, error)
+}
+
+// BuildPrimeProof builds a Prime-chain proof from anchor to tip using default
+// public-RPC safety limits.
+func BuildPrimeProof(source PrimeProofSource, anchor common.Hash, tip common.Hash, m uint64) (*Proof, error) {
+	return BuildPrimeProofWithContext(context.Background(), source, anchor, tip, m, DefaultBuildLimits)
+}
+
+// BuildPrimeProofWithContext builds a Prime-chain proof from anchor to tip.
+//
+// The builder is read-only. It walks the canonical parent chain supplied by the
+// source, keeps the last M headers as a linear suffix, and greedily compresses
+// the prefix with committed interlink jumps when available. If no interlink jump
+// is available it falls back to a linear proof, which remains valid though less
+// compact. Context and limits bound public RPC use.
+func BuildPrimeProofWithContext(ctx context.Context, source PrimeProofSource, anchor common.Hash, tip common.Hash, m uint64, limits BuildLimits) (*Proof, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	limits = limits.withDefaults()
+
+	if source == nil {
+		return nil, ErrNilProofSource
+	}
+	if anchor == (common.Hash{}) || tip == (common.Hash{}) || m == 0 {
+		return nil, ErrInvalidProofEndpoint
+	}
+	if m > limits.MaxM {
+		return nil, fmt.Errorf("%w: m %d exceeds max %d", ErrProofTooLarge, m, limits.MaxM)
+	}
+
+	chain, err := collectPrimeChain(ctx, source, anchor, tip, limits.MaxChainLength)
+	if err != nil {
+		return nil, err
+	}
+	if uint64(len(chain)) < m {
+		return nil, ErrInsufficientSuffix
+	}
+
+	proof := &Proof{
+		Anchor:  anchor,
+		M:       m,
+		Headers: compressPrimeChain(chain, int(m)),
+	}
+	if uint64(len(proof.Headers)) > limits.MaxProofHeaders {
+		return nil, fmt.Errorf("%w: proof headers %d exceeds max %d", ErrProofTooLarge, len(proof.Headers), limits.MaxProofHeaders)
+	}
+	if err := VerifyPrimeProof(proof); err != nil {
+		return nil, err
+	}
+	return proof, nil
+}
+
+func collectPrimeChain(ctx context.Context, source PrimeProofSource, anchor common.Hash, tip common.Hash, maxChainLength uint64) ([]*types.WorkObject, error) {
+	visited := make(map[common.Hash]struct{})
+	reverse := make([]*types.WorkObject, 0)
+
+	for hash := tip; ; {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if maxChainLength > 0 && uint64(len(reverse)) >= maxChainLength {
+			return nil, fmt.Errorf("%w: chain length exceeds max %d", ErrProofTooLarge, maxChainLength)
+		}
+		if _, exists := visited[hash]; exists {
+			return nil, fmt.Errorf("%w: %s", ErrCycleDetected, hash.Hex())
+		}
+		visited[hash] = struct{}{}
+
+		header, err := source.ProofHeader(hash)
+		if err != nil || header == nil {
+			return nil, fmt.Errorf("%w: %s", ErrProofHeaderNotFound, hash.Hex())
+		}
+		if err := verifyUsableHeader(header); err != nil {
+			return nil, err
+		}
+		if header.Hash() != hash {
+			return nil, fmt.Errorf("%w: expected %s got %s", ErrHeaderHashMismatch, hash.Hex(), header.Hash().Hex())
+		}
+		reverse = append(reverse, header)
+
+		if hash == anchor {
+			break
+		}
+		if header.Number(common.PRIME_CTX).Sign() == 0 || header.ParentHash(common.PRIME_CTX) == (common.Hash{}) {
+			return nil, fmt.Errorf("%w: %s", ErrAnchorNotFound, anchor.Hex())
+		}
+		hash = header.ParentHash(common.PRIME_CTX)
+	}
+
+	chain := make([]*types.WorkObject, len(reverse))
+	for i := range reverse {
+		chain[len(reverse)-1-i] = reverse[i]
+	}
+	return chain, nil
+}
+
+func compressPrimeChain(chain []*types.WorkObject, m int) []*types.WorkObject {
+	if len(chain) <= m || m <= 0 {
+		return append([]*types.WorkObject(nil), chain...)
+	}
+
+	suffixStart := len(chain) - m
+	proof := make([]*types.WorkObject, 0, len(chain))
+	proof = append(proof, chain[0])
+
+	current := 0
+	for current < suffixStart {
+		farthest := current + 1
+		for candidate := suffixStart; candidate > current+1; candidate-- {
+			if interlinksContain(chain[candidate].InterlinkHashes(), chain[current].Hash()) {
+				farthest = candidate
+				break
+			}
+		}
+		proof = append(proof, chain[farthest])
+		current = farthest
+	}
+
+	for i := current + 1; i < len(chain); i++ {
+		proof = append(proof, chain[i])
+	}
+	return proof
+}

--- a/core/nipopow/build_test.go
+++ b/core/nipopow/build_test.go
@@ -1,0 +1,117 @@
+package nipopow
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/core/types"
+)
+
+type fakePrimeProofSource map[common.Hash]*types.WorkObject
+
+func (s fakePrimeProofSource) ProofHeader(hash common.Hash) (*types.WorkObject, error) {
+	if header := s[hash]; header != nil {
+		return header, nil
+	}
+	return nil, errors.New("missing header")
+}
+
+func sourceFromHeaders(headers ...*types.WorkObject) fakePrimeProofSource {
+	source := make(fakePrimeProofSource)
+	for _, header := range headers {
+		source[header.Hash()] = header
+	}
+	return source
+}
+
+func proofHashes(proof *Proof) []common.Hash {
+	hashes := make([]common.Hash, len(proof.Headers))
+	for i, header := range proof.Headers {
+		hashes[i] = header.Hash()
+	}
+	return hashes
+}
+
+func TestBuildPrimeProofUsesInterlinkJumpsBeforeLinearSuffix(t *testing.T) {
+	b1 := testPrimeBlock(t, 1, nil, nil)
+	b2 := testPrimeBlock(t, 2, b1, nil)
+	b3 := testPrimeBlock(t, 3, b2, nil)
+	b4 := testPrimeBlock(t, 4, b3, common.Hashes{b1.Hash()})
+	b5 := testPrimeBlock(t, 5, b4, nil)
+	b6 := testPrimeBlock(t, 6, b5, nil)
+	source := sourceFromHeaders(b1, b2, b3, b4, b5, b6)
+
+	proof, err := BuildPrimeProof(source, b1.Hash(), b6.Hash(), 2)
+	if err != nil {
+		t.Fatalf("expected proof to build: %v", err)
+	}
+	if err := VerifyPrimeProof(proof); err != nil {
+		t.Fatalf("expected built proof to verify: %v", err)
+	}
+
+	want := []common.Hash{b1.Hash(), b4.Hash(), b5.Hash(), b6.Hash()}
+	if got := proofHashes(proof); !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected proof headers:\nwant %v\n got %v", want, got)
+	}
+}
+
+func TestBuildPrimeProofFallsBackToLinearChainWithoutInterlinkJump(t *testing.T) {
+	b1 := testPrimeBlock(t, 1, nil, nil)
+	b2 := testPrimeBlock(t, 2, b1, nil)
+	b3 := testPrimeBlock(t, 3, b2, nil)
+	source := sourceFromHeaders(b1, b2, b3)
+
+	proof, err := BuildPrimeProof(source, b1.Hash(), b3.Hash(), 2)
+	if err != nil {
+		t.Fatalf("expected proof to build: %v", err)
+	}
+
+	want := []common.Hash{b1.Hash(), b2.Hash(), b3.Hash()}
+	if got := proofHashes(proof); !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected fallback proof headers:\nwant %v\n got %v", want, got)
+	}
+}
+
+func TestBuildPrimeProofErrorsWhenAnchorIsNotAncestor(t *testing.T) {
+	anchor := testPrimeBlock(t, 1, nil, nil)
+	other := testPrimeBlock(t, 9, nil, nil)
+	tip := testPrimeBlock(t, 10, other, nil)
+	source := sourceFromHeaders(anchor, other, tip)
+
+	if _, err := BuildPrimeProof(source, anchor.Hash(), tip.Hash(), 1); err == nil {
+		t.Fatal("expected missing-anchor error")
+	}
+}
+
+func TestBuildPrimeProofWithContextRejectsCanceledContext(t *testing.T) {
+	anchor := testPrimeBlock(t, 1, nil, nil)
+	tip := testPrimeBlock(t, 2, anchor, nil)
+	source := sourceFromHeaders(anchor, tip)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := BuildPrimeProofWithContext(ctx, source, anchor.Hash(), tip.Hash(), 1, DefaultBuildLimits)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled error, got %v", err)
+	}
+}
+
+func TestBuildPrimeProofWithLimitsRejectsLongWalk(t *testing.T) {
+	anchor := testPrimeBlock(t, 1, nil, nil)
+	mid := testPrimeBlock(t, 2, anchor, nil)
+	tip := testPrimeBlock(t, 3, mid, nil)
+	source := sourceFromHeaders(anchor, mid, tip)
+
+	_, err := BuildPrimeProofWithContext(context.Background(), source, anchor.Hash(), tip.Hash(), 1, BuildLimits{
+		MaxChainLength:  2,
+		MaxProofHeaders: 2,
+		MaxM:            2,
+	})
+	if !errors.Is(err, ErrProofTooLarge) {
+		t.Fatalf("expected proof-too-large error, got %v", err)
+	}
+}

--- a/core/nipopow/pow.go
+++ b/core/nipopow/pow.go
@@ -1,0 +1,91 @@
+package nipopow
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/core/types"
+)
+
+var (
+	ErrNilPoWVerifier    = errors.New("nil nipopow proof pow verifier")
+	ErrInvalidDifficulty = errors.New("nipopow proof header has invalid difficulty")
+	ErrInvalidPoW        = errors.New("nipopow proof header has invalid proof-of-work")
+)
+
+// PrimePoWVerifier supplies a consensus-engine PoW hash for a proof header.
+// It intentionally matches consensus.Engine.ComputePowHash and the public API
+// backend method so proof validation can be layered onto existing engine access.
+type PrimePoWVerifier interface {
+	ComputePowHash(header *types.WorkObjectHeader) (common.Hash, error)
+}
+
+// HeaderWork is the verified PoW metadata for one proof header.
+type HeaderWork struct {
+	Hash    common.Hash `json:"hash"`
+	PowHash common.Hash `json:"powHash"`
+	Rank    uint64      `json:"rank"`
+}
+
+// VerifyPrimeProofWithPoW validates the Prime proof structure and each header's
+// proof-of-work against its declared difficulty.
+func VerifyPrimeProofWithPoW(proof *Proof, verifier PrimePoWVerifier) error {
+	_, err := VerifyPrimeProofWork(proof, verifier)
+	return err
+}
+
+// VerifyPrimeProofWork validates a Prime proof and returns per-header PoW rank.
+// Rank is floor(log2(target / powHash)), where target = 2^256 / difficulty.
+// Valid block proofs have rank >= 0; larger ranks indicate better-than-required
+// work and are the primitive needed for later proof scoring.
+func VerifyPrimeProofWork(proof *Proof, verifier PrimePoWVerifier) ([]HeaderWork, error) {
+	if verifier == nil {
+		return nil, ErrNilPoWVerifier
+	}
+	if err := VerifyPrimeProof(proof); err != nil {
+		return nil, err
+	}
+
+	work := make([]HeaderWork, len(proof.Headers))
+	for i, header := range proof.Headers {
+		powHash, err := verifier.ComputePowHash(header.WorkObjectHeader())
+		if err != nil {
+			return nil, fmt.Errorf("header %d: compute pow hash: %w", i, err)
+		}
+		rank, err := CalcRank(powHash, header.Difficulty())
+		if err != nil {
+			return nil, fmt.Errorf("header %d: %w", i, err)
+		}
+		work[i] = HeaderWork{
+			Hash:    header.Hash(),
+			PowHash: powHash,
+			Rank:    rank,
+		}
+	}
+	return work, nil
+}
+
+// CalcRank verifies that powHash satisfies difficulty and returns its NiPoPoW
+// superchain rank above the header's base target.
+func CalcRank(powHash common.Hash, difficulty *big.Int) (uint64, error) {
+	if difficulty == nil || difficulty.Sign() <= 0 {
+		return 0, ErrInvalidDifficulty
+	}
+	target := new(big.Int).Div(common.Big2e256, difficulty)
+	if target.Sign() <= 0 {
+		return 0, ErrInvalidDifficulty
+	}
+
+	pow := new(big.Int).SetBytes(powHash.Bytes())
+	if pow.Sign() == 0 {
+		return 256, nil
+	}
+	if pow.Cmp(target) > 0 {
+		return 0, ErrInvalidPoW
+	}
+
+	ratio := new(big.Int).Div(target, pow)
+	return uint64(ratio.BitLen() - 1), nil
+}

--- a/core/nipopow/pow_test.go
+++ b/core/nipopow/pow_test.go
@@ -1,0 +1,103 @@
+package nipopow
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/core/types"
+)
+
+type fakePrimePoWVerifier map[common.Hash]common.Hash
+
+func (v fakePrimePoWVerifier) ComputePowHash(header *types.WorkObjectHeader) (common.Hash, error) {
+	if powHash, ok := v[header.Hash()]; ok {
+		return powHash, nil
+	}
+	return common.Hash{}, errors.New("missing pow hash")
+}
+
+func hashFromBig(t *testing.T, n *big.Int) common.Hash {
+	t.Helper()
+	if n.Sign() < 0 || n.BitLen() > 256 {
+		t.Fatalf("cannot encode %s as 256-bit hash", n.String())
+	}
+	return common.BytesToHash(n.Bytes())
+}
+
+func powHashForRank(t *testing.T, difficulty *big.Int, rank uint) common.Hash {
+	t.Helper()
+	target := new(big.Int).Div(common.Big2e256, difficulty)
+	powHash := new(big.Int).Rsh(target, rank)
+	return hashFromBig(t, powHash)
+}
+
+func powHashAboveTarget(t *testing.T, difficulty *big.Int) common.Hash {
+	t.Helper()
+	target := new(big.Int).Div(common.Big2e256, difficulty)
+	return hashFromBig(t, new(big.Int).Add(target, common.Big1))
+}
+
+func TestVerifyPrimeProofWorkComputesRankFromPowHash(t *testing.T) {
+	difficulty := big.NewInt(2)
+	anchor := testPrimeBlockWithDifficulty(t, 1, nil, nil, difficulty)
+	tip := testPrimeBlockWithDifficulty(t, 2, anchor, nil, difficulty)
+
+	anchorPow := powHashForRank(t, difficulty, 0)
+	tipPow := powHashForRank(t, difficulty, 2)
+	proof := &Proof{
+		Anchor:  anchor.Hash(),
+		M:       1,
+		Headers: []*types.WorkObject{anchor, tip},
+	}
+
+	work, err := VerifyPrimeProofWork(proof, fakePrimePoWVerifier{
+		anchor.Hash(): anchorPow,
+		tip.Hash():    tipPow,
+	})
+	if err != nil {
+		t.Fatalf("expected proof work to verify: %v", err)
+	}
+	if len(work) != 2 {
+		t.Fatalf("expected work for 2 headers, got %d", len(work))
+	}
+	if work[0].Hash != anchor.Hash() || work[0].PowHash != anchorPow || work[0].Rank != 0 {
+		t.Fatalf("unexpected anchor work: %+v", work[0])
+	}
+	if work[1].Hash != tip.Hash() || work[1].PowHash != tipPow || work[1].Rank != 2 {
+		t.Fatalf("unexpected tip work: %+v", work[1])
+	}
+}
+
+func TestVerifyPrimeProofWithPoWRejectsPowHashAboveTarget(t *testing.T) {
+	difficulty := big.NewInt(2)
+	anchor := testPrimeBlockWithDifficulty(t, 1, nil, nil, difficulty)
+	proof := &Proof{
+		Anchor:  anchor.Hash(),
+		M:       1,
+		Headers: []*types.WorkObject{anchor},
+	}
+
+	err := VerifyPrimeProofWithPoW(proof, fakePrimePoWVerifier{
+		anchor.Hash(): powHashAboveTarget(t, difficulty),
+	})
+	if !errors.Is(err, ErrInvalidPoW) {
+		t.Fatalf("expected invalid PoW error, got %v", err)
+	}
+}
+
+func TestVerifyPrimeProofWithPoWRequiresVerifier(t *testing.T) {
+	difficulty := big.NewInt(2)
+	anchor := testPrimeBlockWithDifficulty(t, 1, nil, nil, difficulty)
+	proof := &Proof{
+		Anchor:  anchor.Hash(),
+		M:       1,
+		Headers: []*types.WorkObject{anchor},
+	}
+
+	err := VerifyPrimeProofWithPoW(proof, nil)
+	if !errors.Is(err, ErrNilPoWVerifier) {
+		t.Fatalf("expected nil verifier error, got %v", err)
+	}
+}

--- a/core/nipopow/proof.go
+++ b/core/nipopow/proof.go
@@ -1,0 +1,161 @@
+// Package nipopow contains read-only NiPoPoW proof primitives.
+//
+// The initial implementation is intentionally non-consensus: it verifies the
+// compact proof structure against WorkObject headers/bodies without changing
+// block validation rules.
+package nipopow
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/core/types"
+	"github.com/dominant-strategies/go-quai/trie"
+)
+
+var (
+	ErrNilProof              = errors.New("nil nipopow proof")
+	ErrNoHeaders             = errors.New("nipopow proof has no headers")
+	ErrInvalidM              = errors.New("nipopow proof has invalid m")
+	ErrInsufficientSuffix    = errors.New("nipopow proof has fewer headers than m")
+	ErrAnchorMismatch        = errors.New("nipopow proof anchor mismatch")
+	ErrNilHeader             = errors.New("nipopow proof contains nil header")
+	ErrInterlinkRootMismatch = errors.New("nipopow proof interlink root mismatch")
+	ErrDisconnectedHeaders   = errors.New("nipopow proof headers are disconnected")
+	ErrNonLinearSuffix       = errors.New("nipopow proof suffix is not linear")
+)
+
+// Proof is a compact Prime-chain NiPoPoW proof.
+//
+// Headers are ordered oldest-to-newest. Adjacent headers may either be connected
+// linearly by parent hash and height, or compactly by an interlink committed to
+// by the newer header's InterlinkRootHash. The final M headers form the suffix
+// and must be linearly connected.
+type Proof struct {
+	Anchor  common.Hash         `json:"anchor"`
+	M       uint64              `json:"m"`
+	Headers []*types.WorkObject `json:"headers"`
+}
+
+// Tip returns the newest header hash in the proof, or the zero hash if the
+// proof is nil or empty.
+func (p *Proof) Tip() common.Hash {
+	if p == nil || len(p.Headers) == 0 || p.Headers[len(p.Headers)-1] == nil {
+		return common.Hash{}
+	}
+	return p.Headers[len(p.Headers)-1].Hash()
+}
+
+// VerifyPrimeProof validates the read-only structural invariants of a Prime
+// NiPoPoW proof.
+//
+// This structural primitive verifies header/body/interlink connectivity without
+// consensus-engine access. Use VerifyPrimeProofWithPoW when the caller can
+// supply ComputePowHash and needs seal/rank validation too.
+func VerifyPrimeProof(proof *Proof) error {
+	if proof == nil {
+		return ErrNilProof
+	}
+	if proof.M == 0 {
+		return ErrInvalidM
+	}
+	if len(proof.Headers) == 0 {
+		return ErrNoHeaders
+	}
+	if uint64(len(proof.Headers)) < proof.M {
+		return ErrInsufficientSuffix
+	}
+
+	for i, header := range proof.Headers {
+		if err := verifyUsableHeader(header); err != nil {
+			return fmt.Errorf("header %d: %w", i, err)
+		}
+		if err := verifyInterlinkRoot(header); err != nil {
+			return fmt.Errorf("header %d: %w", i, err)
+		}
+		if i == 0 {
+			if proof.Anchor != (common.Hash{}) && proof.Anchor != header.Hash() {
+				return fmt.Errorf("%w: expected %s got %s", ErrAnchorMismatch, proof.Anchor.Hex(), header.Hash().Hex())
+			}
+			continue
+		}
+		if !connectedByParentOrInterlink(proof.Headers[i-1], header) {
+			return fmt.Errorf("%w: %s -> %s", ErrDisconnectedHeaders, proof.Headers[i-1].Hash().Hex(), header.Hash().Hex())
+		}
+	}
+
+	if err := verifyLinearSuffix(proof.Headers, int(proof.M)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func verifyUsableHeader(header *types.WorkObject) error {
+	if header == nil || header.WorkObjectHeader() == nil || header.Body() == nil || header.Header() == nil {
+		return ErrNilHeader
+	}
+	if header.WorkObjectHeader().HeaderHash() != header.Header().Hash() {
+		return fmt.Errorf("%w: expected %s got %s", ErrHeaderHashMismatch, header.Header().Hash().Hex(), header.WorkObjectHeader().HeaderHash().Hex())
+	}
+	if header.Number(common.PRIME_CTX) == nil {
+		return fmt.Errorf("%w: missing prime number", ErrNilHeader)
+	}
+	return nil
+}
+
+func verifyInterlinkRoot(header *types.WorkObject) error {
+	expected := types.DeriveSha(header.InterlinkHashes(), trie.NewStackTrie(nil))
+	if header.InterlinkRootHash() != expected {
+		return fmt.Errorf("%w: expected %s got %s", ErrInterlinkRootMismatch, expected.Hex(), header.InterlinkRootHash().Hex())
+	}
+	return nil
+}
+
+func connectedByParentOrInterlink(prev, current *types.WorkObject) bool {
+	return isLinearChild(prev, current) || isForwardInterlinkJump(prev, current)
+}
+
+func isForwardInterlinkJump(prev, current *types.WorkObject) bool {
+	if prev == nil || current == nil || prev.Number(common.PRIME_CTX) == nil || current.Number(common.PRIME_CTX) == nil {
+		return false
+	}
+	if current.Number(common.PRIME_CTX).Uint64() <= prev.Number(common.PRIME_CTX).Uint64() {
+		return false
+	}
+	return interlinksContain(current.InterlinkHashes(), prev.Hash())
+}
+
+func verifyLinearSuffix(headers []*types.WorkObject, m int) error {
+	if m <= 1 {
+		return nil
+	}
+	start := len(headers) - m
+	for i := start + 1; i < len(headers); i++ {
+		if !isLinearChild(headers[i-1], headers[i]) {
+			return fmt.Errorf("%w: %s -> %s", ErrNonLinearSuffix, headers[i-1].Hash().Hex(), headers[i].Hash().Hex())
+		}
+	}
+	return nil
+}
+
+func isLinearChild(parent, child *types.WorkObject) bool {
+	if parent == nil || child == nil || parent.Number(common.PRIME_CTX) == nil || child.Number(common.PRIME_CTX) == nil {
+		return false
+	}
+	if child.ParentHash(common.PRIME_CTX) != parent.Hash() {
+		return false
+	}
+	parentNumber := parent.Number(common.PRIME_CTX)
+	childNumber := child.Number(common.PRIME_CTX)
+	return childNumber.Uint64() == parentNumber.Uint64()+1
+}
+
+func interlinksContain(interlinks common.Hashes, hash common.Hash) bool {
+	for _, interlink := range interlinks {
+		if interlink == hash {
+			return true
+		}
+	}
+	return false
+}

--- a/core/nipopow/proof_test.go
+++ b/core/nipopow/proof_test.go
@@ -1,0 +1,141 @@
+package nipopow
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/core/types"
+	"github.com/dominant-strategies/go-quai/trie"
+)
+
+func testPrimeBlock(t *testing.T, number uint64, parent *types.WorkObject, interlinks common.Hashes) *types.WorkObject {
+	return testPrimeBlockWithDifficulty(t, number, parent, interlinks, big.NewInt(1))
+}
+
+func testPrimeBlockWithDifficulty(t *testing.T, number uint64, parent *types.WorkObject, interlinks common.Hashes, difficulty *big.Int) *types.WorkObject {
+	t.Helper()
+
+	wo := types.EmptyWorkObject(common.PRIME_CTX)
+	wo.WorkObjectHeader().SetNumber(new(big.Int).SetUint64(number))
+	wo.WorkObjectHeader().SetDifficulty(new(big.Int).Set(difficulty))
+	wo.WorkObjectHeader().SetPrimeTerminusNumber(new(big.Int).SetUint64(number))
+	wo.WorkObjectHeader().SetTime(number)
+
+	header := wo.Header()
+	header.SetNumber(new(big.Int).SetUint64(number), common.PRIME_CTX)
+	header.SetParentDeltaEntropy(big.NewInt(1), common.PRIME_CTX)
+	header.SetExpansionNumber(0)
+	if parent != nil {
+		header.SetParentHash(parent.Hash(), common.PRIME_CTX)
+		wo.WorkObjectHeader().SetParentHash(parent.Hash())
+	}
+	setTestInterlinks(t, wo, interlinks)
+	return wo
+}
+
+func setTestInterlinks(t *testing.T, wo *types.WorkObject, interlinks common.Hashes) {
+	t.Helper()
+	wo.Body().SetInterlinkHashes(interlinks)
+	wo.Header().SetInterlinkRootHash(types.DeriveSha(interlinks, trie.NewStackTrie(nil)))
+	wo.WorkObjectHeader().SetHeaderHash(wo.Header().Hash())
+}
+
+func TestVerifyPrimeProofAcceptsLinearSuffixAndInterlinkJump(t *testing.T) {
+	anchor := testPrimeBlock(t, 1, nil, nil)
+	jump := testPrimeBlock(t, 4, anchor, common.Hashes{anchor.Hash()})
+	suffix1 := testPrimeBlock(t, 5, jump, common.Hashes{anchor.Hash(), jump.Hash()})
+	suffix2 := testPrimeBlock(t, 6, suffix1, common.Hashes{jump.Hash()})
+
+	proof := &Proof{
+		Anchor:  anchor.Hash(),
+		M:       2,
+		Headers: []*types.WorkObject{anchor, jump, suffix1, suffix2},
+	}
+
+	if err := VerifyPrimeProof(proof); err != nil {
+		t.Fatalf("expected proof to verify: %v", err)
+	}
+}
+
+func TestVerifyPrimeProofRejectsMismatchedInterlinkRoot(t *testing.T) {
+	anchor := testPrimeBlock(t, 1, nil, nil)
+	jump := testPrimeBlock(t, 4, anchor, common.Hashes{anchor.Hash()})
+	jump.Header().SetInterlinkRootHash(common.HexToHash("0x01"))
+	jump.WorkObjectHeader().SetHeaderHash(jump.Header().Hash())
+
+	proof := &Proof{
+		Anchor:  anchor.Hash(),
+		M:       1,
+		Headers: []*types.WorkObject{anchor, jump},
+	}
+
+	if err := VerifyPrimeProof(proof); err == nil {
+		t.Fatal("expected proof with mismatched interlink root to fail")
+	}
+}
+
+func TestVerifyPrimeProofRejectsHeaderHashMismatch(t *testing.T) {
+	anchor := testPrimeBlock(t, 1, nil, nil)
+	jump := testPrimeBlock(t, 4, anchor, common.Hashes{anchor.Hash()})
+	jump.Header().SetExtra([]byte("tampered without updating work object header hash"))
+
+	proof := &Proof{
+		Anchor:  anchor.Hash(),
+		M:       1,
+		Headers: []*types.WorkObject{anchor, jump},
+	}
+
+	if err := VerifyPrimeProof(proof); err == nil {
+		t.Fatal("expected proof with mismatched body header hash to fail")
+	}
+}
+
+func TestVerifyPrimeProofRejectsDisconnectedHeaders(t *testing.T) {
+	anchor := testPrimeBlock(t, 1, nil, nil)
+	unrelatedParent := testPrimeBlock(t, 2, nil, nil)
+	disconnected := testPrimeBlock(t, 5, unrelatedParent, nil)
+
+	proof := &Proof{
+		Anchor:  anchor.Hash(),
+		M:       1,
+		Headers: []*types.WorkObject{anchor, disconnected},
+	}
+
+	if err := VerifyPrimeProof(proof); err == nil {
+		t.Fatal("expected disconnected proof to fail")
+	}
+}
+
+func TestVerifyPrimeProofRequiresLinearSuffix(t *testing.T) {
+	anchor := testPrimeBlock(t, 1, nil, nil)
+	jump := testPrimeBlock(t, 4, anchor, common.Hashes{anchor.Hash()})
+	nonlinearSuffix := testPrimeBlock(t, 8, jump, common.Hashes{jump.Hash()})
+
+	proof := &Proof{
+		Anchor:  anchor.Hash(),
+		M:       2,
+		Headers: []*types.WorkObject{anchor, jump, nonlinearSuffix},
+	}
+
+	if err := VerifyPrimeProof(proof); err == nil {
+		t.Fatal("expected non-linear suffix to fail")
+	}
+}
+
+func TestVerifyPrimeProofRejectsBackwardInterlinkJump(t *testing.T) {
+	newer := testPrimeBlock(t, 5, nil, nil)
+	older := testPrimeBlock(t, 4, nil, common.Hashes{newer.Hash()})
+
+	proof := &Proof{
+		Anchor:  newer.Hash(),
+		M:       1,
+		Headers: []*types.WorkObject{newer, older},
+	}
+
+	err := VerifyPrimeProof(proof)
+	if !errors.Is(err, ErrDisconnectedHeaders) {
+		t.Fatalf("expected backward jump to be disconnected, got %v", err)
+	}
+}

--- a/core/nipopow/score.go
+++ b/core/nipopow/score.go
@@ -1,0 +1,110 @@
+package nipopow
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/dominant-strategies/go-quai/common"
+)
+
+var ErrIncomparableProofs = errors.New("nipopow proofs are not comparable")
+
+// ProofScore is the verified superchain score for a Prime NiPoPoW proof.
+//
+// SuperchainCounts[level] is the number of proof headers whose verified PoW rank
+// is at least level. Competing proofs are compared from the highest populated
+// level down to level zero; ties are left unresolved instead of using arbitrary
+// tip-hash tie breakers.
+type ProofScore struct {
+	Anchor           common.Hash  `json:"anchor"`
+	Tip              common.Hash  `json:"tip"`
+	M                uint64       `json:"m"`
+	TipNumber        uint64       `json:"tipNumber"`
+	HeaderCount      uint64       `json:"headerCount"`
+	MaxRank          uint64       `json:"maxRank"`
+	SuperchainCounts []uint64     `json:"superchainCounts"`
+	Work             []HeaderWork `json:"work"`
+}
+
+// ScorePrimeProof verifies a Prime NiPoPoW proof and derives its superchain
+// counts from each header's verified PoW rank.
+func ScorePrimeProof(proof *Proof, verifier PrimePoWVerifier) (*ProofScore, error) {
+	work, err := VerifyPrimeProofWork(proof, verifier)
+	if err != nil {
+		return nil, err
+	}
+
+	maxRank := uint64(0)
+	for _, headerWork := range work {
+		if headerWork.Rank > maxRank {
+			maxRank = headerWork.Rank
+		}
+	}
+
+	superchainCounts := make([]uint64, maxRank+1)
+	for _, headerWork := range work {
+		for level := range superchainCounts {
+			if uint64(level) <= headerWork.Rank {
+				superchainCounts[level]++
+			}
+		}
+	}
+
+	tip := proof.Headers[len(proof.Headers)-1]
+	return &ProofScore{
+		Anchor:           proof.Anchor,
+		Tip:              tip.Hash(),
+		M:                proof.M,
+		TipNumber:        tip.Number(common.PRIME_CTX).Uint64(),
+		HeaderCount:      uint64(len(proof.Headers)),
+		MaxRank:          maxRank,
+		SuperchainCounts: superchainCounts,
+		Work:             work,
+	}, nil
+}
+
+// ComparePrimeProofs verifies and compares two Prime NiPoPoW proofs. It returns
+// +1 when left is better, -1 when right is better, and 0 when their score vectors
+// tie. Proofs are comparable only when they use the same anchor and suffix
+// parameter M.
+func ComparePrimeProofs(left, right *Proof, verifier PrimePoWVerifier) (int, *ProofScore, *ProofScore, error) {
+	leftScore, err := ScorePrimeProof(left, verifier)
+	if err != nil {
+		return 0, nil, nil, fmt.Errorf("left proof: %w", err)
+	}
+	rightScore, err := ScorePrimeProof(right, verifier)
+	if err != nil {
+		return 0, leftScore, nil, fmt.Errorf("right proof: %w", err)
+	}
+	if leftScore.Anchor != rightScore.Anchor || leftScore.M != rightScore.M {
+		return 0, leftScore, rightScore, fmt.Errorf("%w: anchor/m mismatch", ErrIncomparableProofs)
+	}
+	return CompareProofScores(leftScore, rightScore), leftScore, rightScore, nil
+}
+
+// CompareProofScores compares verified proof score vectors. It returns +1 when
+// left is better, -1 when right is better, and 0 for an unresolved tie.
+func CompareProofScores(left, right *ProofScore) int {
+	maxLen := len(left.SuperchainCounts)
+	if len(right.SuperchainCounts) > maxLen {
+		maxLen = len(right.SuperchainCounts)
+	}
+	for level := maxLen - 1; level >= 0; level-- {
+		leftCount := countAtLevel(left.SuperchainCounts, level)
+		rightCount := countAtLevel(right.SuperchainCounts, level)
+		if leftCount > rightCount {
+			return 1
+		}
+		if leftCount < rightCount {
+			return -1
+		}
+	}
+	return 0
+}
+
+func countAtLevel(counts []uint64, level int) uint64 {
+	if level < 0 || level >= len(counts) {
+		return 0
+	}
+	return counts[level]
+}

--- a/core/nipopow/score_test.go
+++ b/core/nipopow/score_test.go
@@ -1,0 +1,89 @@
+package nipopow
+
+import (
+	"errors"
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/dominant-strategies/go-quai/core/types"
+)
+
+func testForkPrimeBlock(t *testing.T, number uint64, parent *types.WorkObject, tag string) *types.WorkObject {
+	t.Helper()
+	wo := testPrimeBlock(t, number, parent, nil)
+	wo.Header().SetExtra([]byte(tag))
+	setTestInterlinks(t, wo, nil)
+	return wo
+}
+
+func TestScorePrimeProofBuildsSuperchainCounts(t *testing.T) {
+	difficulty := big.NewInt(2)
+	anchor := testPrimeBlockWithDifficulty(t, 1, nil, nil, difficulty)
+	mid := testPrimeBlockWithDifficulty(t, 2, anchor, nil, difficulty)
+	tip := testPrimeBlockWithDifficulty(t, 3, mid, nil, difficulty)
+	proof := &Proof{
+		Anchor:  anchor.Hash(),
+		M:       1,
+		Headers: []*types.WorkObject{anchor, mid, tip},
+	}
+
+	score, err := ScorePrimeProof(proof, fakePrimePoWVerifier{
+		anchor.Hash(): powHashForRank(t, difficulty, 0),
+		mid.Hash():    powHashForRank(t, difficulty, 2),
+		tip.Hash():    powHashForRank(t, difficulty, 1),
+	})
+	if err != nil {
+		t.Fatalf("expected proof to score: %v", err)
+	}
+	if score.Tip != tip.Hash() || score.TipNumber != 3 || score.MaxRank != 2 {
+		t.Fatalf("unexpected score metadata: %+v", score)
+	}
+	wantCounts := []uint64{3, 2, 1}
+	if !reflect.DeepEqual(score.SuperchainCounts, wantCounts) {
+		t.Fatalf("unexpected superchain counts: want %v got %v", wantCounts, score.SuperchainCounts)
+	}
+}
+
+func TestComparePrimeProofsPrefersHigherSuperchainCount(t *testing.T) {
+	difficulty := big.NewInt(2)
+	anchor := testPrimeBlockWithDifficulty(t, 1, nil, nil, difficulty)
+
+	a2 := testForkPrimeBlock(t, 2, anchor, "a2")
+	a3 := testForkPrimeBlock(t, 3, a2, "a3")
+	proofA := &Proof{Anchor: anchor.Hash(), M: 1, Headers: []*types.WorkObject{anchor, a2, a3}}
+
+	b2 := testForkPrimeBlock(t, 2, anchor, "b2")
+	b3 := testForkPrimeBlock(t, 3, b2, "b3")
+	proofB := &Proof{Anchor: anchor.Hash(), M: 1, Headers: []*types.WorkObject{anchor, b2, b3}}
+
+	cmp, scoreA, scoreB, err := ComparePrimeProofs(proofA, proofB, fakePrimePoWVerifier{
+		anchor.Hash(): powHashForRank(t, difficulty, 0),
+		a2.Hash():     powHashForRank(t, difficulty, 2),
+		a3.Hash():     powHashForRank(t, difficulty, 0),
+		b2.Hash():     powHashForRank(t, difficulty, 1),
+		b3.Hash():     powHashForRank(t, difficulty, 1),
+	})
+	if err != nil {
+		t.Fatalf("expected proofs to compare: %v", err)
+	}
+	if cmp <= 0 {
+		t.Fatalf("expected proof A to win, cmp=%d scoreA=%+v scoreB=%+v", cmp, scoreA, scoreB)
+	}
+}
+
+func TestComparePrimeProofsRejectsDifferentAnchors(t *testing.T) {
+	difficulty := big.NewInt(2)
+	anchorA := testPrimeBlockWithDifficulty(t, 1, nil, nil, difficulty)
+	anchorB := testForkPrimeBlock(t, 1, nil, "anchorB")
+	proofA := &Proof{Anchor: anchorA.Hash(), M: 1, Headers: []*types.WorkObject{anchorA}}
+	proofB := &Proof{Anchor: anchorB.Hash(), M: 1, Headers: []*types.WorkObject{anchorB}}
+
+	_, _, _, err := ComparePrimeProofs(proofA, proofB, fakePrimePoWVerifier{
+		anchorA.Hash(): powHashForRank(t, difficulty, 0),
+		anchorB.Hash(): powHashForRank(t, difficulty, 0),
+	})
+	if !errors.Is(err, ErrIncomparableProofs) {
+		t.Fatalf("expected incomparable proof error, got %v", err)
+	}
+}

--- a/core/nipopow/validate.go
+++ b/core/nipopow/validate.go
@@ -1,0 +1,168 @@
+package nipopow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/dominant-strategies/go-quai/common"
+)
+
+var (
+	ErrNilValidationSource = errors.New("nil nipopow validation source")
+	ErrNoValidationRanges  = errors.New("no nipopow validation ranges configured")
+)
+
+// PrimeValidationSource supplies canonical Prime hashes and hydrated proof
+// headers for real-chain validation runs.
+type PrimeValidationSource interface {
+	PrimeProofSource
+	GetCanonicalHash(number uint64) common.Hash
+}
+
+// ValidationRange identifies one canonical Prime range to build and verify.
+type ValidationRange struct {
+	Name         string `json:"name"`
+	AnchorNumber uint64 `json:"anchorNumber"`
+	TipNumber    uint64 `json:"tipNumber"`
+}
+
+// ValidationOptions configures a batch of Prime proof validation ranges.
+type ValidationOptions struct {
+	M      uint64            `json:"m"`
+	Ranges []ValidationRange `json:"ranges"`
+	Limits BuildLimits       `json:"limits"`
+}
+
+// ValidationReport is the structured output of a real-chain validation run.
+type ValidationReport struct {
+	M       uint64             `json:"m"`
+	Limits  BuildLimits        `json:"limits"`
+	Results []ValidationResult `json:"results"`
+}
+
+// Failed reports whether any validation range failed.
+func (r *ValidationReport) Failed() bool {
+	if r == nil {
+		return true
+	}
+	for _, result := range r.Results {
+		if !result.OK {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidationResult contains the proof metrics and status for one range.
+type ValidationResult struct {
+	Name         string        `json:"name"`
+	AnchorNumber uint64        `json:"anchorNumber"`
+	TipNumber    uint64        `json:"tipNumber"`
+	ChainLength  uint64        `json:"chainLength"`
+	Anchor       common.Hash   `json:"anchor"`
+	Tip          common.Hash   `json:"tip"`
+	ProofHeaders uint64        `json:"proofHeaders"`
+	ProofBytes   uint64        `json:"proofBytes"`
+	Elapsed      time.Duration `json:"elapsed"`
+	OK           bool          `json:"ok"`
+	Error        string        `json:"error,omitempty"`
+}
+
+// ValidatePrimeProofRanges builds and verifies Prime NiPoPoW proofs for the
+// configured canonical ranges. Range-level failures are recorded in the report
+// so a real-chain validation run can continue across many samples; only invalid
+// harness configuration is returned as a top-level error.
+func ValidatePrimeProofRanges(ctx context.Context, source PrimeValidationSource, opts ValidationOptions) (*ValidationReport, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if source == nil {
+		return nil, ErrNilValidationSource
+	}
+	if opts.M == 0 {
+		return nil, ErrInvalidM
+	}
+	if len(opts.Ranges) == 0 {
+		return nil, ErrNoValidationRanges
+	}
+
+	limits := opts.Limits.withDefaults()
+	report := &ValidationReport{
+		M:       opts.M,
+		Limits:  limits,
+		Results: make([]ValidationResult, 0, len(opts.Ranges)),
+	}
+	for _, validationRange := range opts.Ranges {
+		report.Results = append(report.Results, validatePrimeProofRange(ctx, source, opts.M, limits, validationRange))
+	}
+	return report, nil
+}
+
+func validatePrimeProofRange(ctx context.Context, source PrimeValidationSource, m uint64, limits BuildLimits, validationRange ValidationRange) ValidationResult {
+	result := ValidationResult{
+		Name:         validationRange.name(),
+		AnchorNumber: validationRange.AnchorNumber,
+		TipNumber:    validationRange.TipNumber,
+	}
+	if validationRange.TipNumber < validationRange.AnchorNumber {
+		result.Error = fmt.Sprintf("tip number %d is before anchor number %d", validationRange.TipNumber, validationRange.AnchorNumber)
+		return result
+	}
+	result.ChainLength = validationRange.TipNumber - validationRange.AnchorNumber + 1
+
+	anchor := source.GetCanonicalHash(validationRange.AnchorNumber)
+	if anchor == (common.Hash{}) {
+		result.Error = fmt.Sprintf("canonical anchor hash not found for number %d", validationRange.AnchorNumber)
+		return result
+	}
+	tip := source.GetCanonicalHash(validationRange.TipNumber)
+	if tip == (common.Hash{}) {
+		result.Error = fmt.Sprintf("canonical tip hash not found for number %d", validationRange.TipNumber)
+		return result
+	}
+	result.Anchor = anchor
+	result.Tip = tip
+
+	started := time.Now()
+	proof, err := BuildPrimeProofWithContext(ctx, source, anchor, tip, m, limits)
+	result.Elapsed = time.Since(started)
+	if err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	if err := VerifyPrimeProof(proof); err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	result.ProofHeaders = uint64(len(proof.Headers))
+	result.ProofBytes = estimateProofBytes(proof)
+	result.OK = true
+	return result
+}
+
+func estimateProofBytes(proof *Proof) uint64 {
+	if proof == nil {
+		return 0
+	}
+	size := uint64(common.HashLength + 8) // anchor + m
+	for _, header := range proof.Headers {
+		if header == nil {
+			continue
+		}
+		headerSize := uint64(header.Size())
+		if headerSize == 0 {
+			headerSize = uint64(2*common.HashLength + 8 + common.HashLength*len(header.InterlinkHashes()))
+		}
+		size += headerSize
+	}
+	return size
+}
+
+func (r ValidationRange) name() string {
+	if r.Name != "" {
+		return r.Name
+	}
+	return fmt.Sprintf("%d-%d", r.AnchorNumber, r.TipNumber)
+}

--- a/core/nipopow/validate_test.go
+++ b/core/nipopow/validate_test.go
@@ -1,0 +1,171 @@
+package nipopow
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/core/types"
+)
+
+type validationTestSource struct {
+	fakePrimeProofSource
+	canonical map[uint64]common.Hash
+}
+
+func newValidationTestSource(headers ...*types.WorkObject) *validationTestSource {
+	source := &validationTestSource{
+		fakePrimeProofSource: sourceFromHeaders(headers...),
+		canonical:            make(map[uint64]common.Hash),
+	}
+	for _, header := range headers {
+		number := header.NumberU64(common.PRIME_CTX)
+		source.canonical[number] = header.Hash()
+	}
+	return source
+}
+
+func (s *validationTestSource) GetCanonicalHash(number uint64) common.Hash {
+	return s.canonical[number]
+}
+
+func TestValidatePrimeProofRangesReportsSuccessfulRange(t *testing.T) {
+	b1 := testPrimeBlock(t, 1, nil, nil)
+	b2 := testPrimeBlock(t, 2, b1, nil)
+	b3 := testPrimeBlock(t, 3, b2, nil)
+	b4 := testPrimeBlock(t, 4, b3, common.Hashes{b1.Hash()})
+	b5 := testPrimeBlock(t, 5, b4, nil)
+	b6 := testPrimeBlock(t, 6, b5, nil)
+	source := newValidationTestSource(b1, b2, b3, b4, b5, b6)
+
+	report, err := ValidatePrimeProofRanges(context.Background(), source, ValidationOptions{
+		M: 2,
+		Ranges: []ValidationRange{{
+			Name:         "interlink-jump",
+			AnchorNumber: 1,
+			TipNumber:    6,
+		}},
+		Limits: BuildLimits{MaxChainLength: 16, MaxProofHeaders: 16, MaxM: 16},
+	})
+	if err != nil {
+		t.Fatalf("expected validation report: %v", err)
+	}
+	if report.Failed() {
+		t.Fatalf("expected report to pass: %+v", report.Results)
+	}
+	if report.M != 2 || len(report.Results) != 1 {
+		t.Fatalf("unexpected report shape: %+v", report)
+	}
+
+	result := report.Results[0]
+	if !result.OK || result.Error != "" {
+		t.Fatalf("expected successful result: %+v", result)
+	}
+	if result.Name != "interlink-jump" {
+		t.Fatalf("unexpected result name: %q", result.Name)
+	}
+	if result.Anchor != b1.Hash() || result.Tip != b6.Hash() {
+		t.Fatalf("unexpected endpoints: anchor=%s tip=%s", result.Anchor, result.Tip)
+	}
+	if result.AnchorNumber != 1 || result.TipNumber != 6 || result.ChainLength != 6 {
+		t.Fatalf("unexpected range metrics: %+v", result)
+	}
+	if result.ProofHeaders != 4 {
+		t.Fatalf("expected compressed proof to contain 4 headers, got %d", result.ProofHeaders)
+	}
+	if result.ProofBytes == 0 {
+		t.Fatal("expected non-zero encoded proof size")
+	}
+}
+
+func TestValidatePrimeProofRangesContinuesAfterRangeFailure(t *testing.T) {
+	b1 := testPrimeBlock(t, 1, nil, nil)
+	b2 := testPrimeBlock(t, 2, b1, nil)
+	source := newValidationTestSource(b1, b2)
+	delete(source.canonical, 1)
+
+	report, err := ValidatePrimeProofRanges(context.Background(), source, ValidationOptions{
+		M:      1,
+		Ranges: []ValidationRange{{Name: "missing-anchor", AnchorNumber: 1, TipNumber: 2}},
+		Limits: BuildLimits{MaxChainLength: 4, MaxProofHeaders: 4, MaxM: 4},
+	})
+	if err != nil {
+		t.Fatalf("expected per-range failure report, got top-level error: %v", err)
+	}
+	if !report.Failed() || len(report.Results) != 1 {
+		t.Fatalf("expected failed report: %+v", report)
+	}
+	result := report.Results[0]
+	if result.OK {
+		t.Fatalf("expected result failure: %+v", result)
+	}
+	if !strings.Contains(result.Error, "canonical anchor hash not found") {
+		t.Fatalf("unexpected error: %q", result.Error)
+	}
+}
+
+func TestValidatePrimeProofRangesReportsReversedRangeFailure(t *testing.T) {
+	b1 := testPrimeBlock(t, 1, nil, nil)
+	b2 := testPrimeBlock(t, 2, b1, nil)
+	source := newValidationTestSource(b1, b2)
+
+	report, err := ValidatePrimeProofRanges(context.Background(), source, ValidationOptions{
+		M:      1,
+		Ranges: []ValidationRange{{Name: "reversed", AnchorNumber: 2, TipNumber: 1}},
+		Limits: BuildLimits{MaxChainLength: 4, MaxProofHeaders: 4, MaxM: 4},
+	})
+	if err != nil {
+		t.Fatalf("expected per-range failure report, got top-level error: %v", err)
+	}
+	if !report.Failed() || len(report.Results) != 1 {
+		t.Fatalf("expected failed report: %+v", report)
+	}
+	if got := report.Results[0].Error; !strings.Contains(got, "before anchor") {
+		t.Fatalf("unexpected reversed-range error: %q", got)
+	}
+}
+
+func TestValidatePrimeProofRangesReportsLimitFailureAndDefaultName(t *testing.T) {
+	b1 := testPrimeBlock(t, 1, nil, nil)
+	b2 := testPrimeBlock(t, 2, b1, nil)
+	source := newValidationTestSource(b1, b2)
+
+	report, err := ValidatePrimeProofRanges(context.Background(), source, ValidationOptions{
+		M:      2,
+		Ranges: []ValidationRange{{AnchorNumber: 1, TipNumber: 2}},
+		Limits: BuildLimits{MaxChainLength: 4, MaxProofHeaders: 4, MaxM: 1},
+	})
+	if err != nil {
+		t.Fatalf("expected per-range failure report, got top-level error: %v", err)
+	}
+	if !report.Failed() || len(report.Results) != 1 {
+		t.Fatalf("expected failed report: %+v", report)
+	}
+	result := report.Results[0]
+	if result.Name != "1-2" {
+		t.Fatalf("unexpected default result name: %q", result.Name)
+	}
+	if !strings.Contains(result.Error, "exceeds max") {
+		t.Fatalf("unexpected limit error: %q", result.Error)
+	}
+}
+
+func TestValidatePrimeProofRangesRejectsInvalidConfig(t *testing.T) {
+	source := newValidationTestSource(testPrimeBlock(t, 1, nil, nil))
+	_, err := ValidatePrimeProofRanges(context.Background(), source, ValidationOptions{M: 0})
+	if err == nil {
+		t.Fatal("expected invalid m to return a top-level error")
+	}
+
+	_, err = ValidatePrimeProofRanges(context.Background(), nil, ValidationOptions{M: 1})
+	if err == nil {
+		t.Fatal("expected nil source to return a top-level error")
+	}
+
+	_, err = ValidatePrimeProofRanges(context.Background(), source, ValidationOptions{M: 1})
+	if !errors.Is(err, ErrNoValidationRanges) {
+		t.Fatalf("expected missing ranges error, got %v", err)
+	}
+}

--- a/doc/nipopow.md
+++ b/doc/nipopow.md
@@ -172,6 +172,22 @@ if report.Failed() {
 
 `ValidatePrimeProofRanges` records one result per range and continues after range-level failures. Each result includes anchor/tip numbers, anchor/tip hashes, uncompressed chain length, compressed proof header count, estimated encoded proof bytes, elapsed build/verify time, and any error. The harness uses the same read-only `PrimeProofSource` path as public proof generation, so a successful run proves that persisted canonical headers and interlinks can build and verify Prime proofs without mutating storage.
 
+A command-line real-chain validator is available for offline or snapshot DBs:
+
+```bash
+go run ./cmd/nipopow-prime-validate \
+  --db /path/to/prime/go-quai/chaindata \
+  --m 16 \
+  --lengths 16,64,256,1024 \
+  --max-chain 1024 \
+  --max-headers 1024 \
+  --timeout 3m
+```
+
+The command opens the DB with `ReadOnly: true`, auto-attaches `<db>/ancient` when present, and emits a JSON report with head/genesis metadata, selected ranges, per-range proof metrics, and errors. Use `--ranges name=anchor:tip,name2=anchor:tip` for explicit reviewer samples and `--out report.json` to write the JSON to disk.
+
+Do not point this command directly at a running production LevelDB/freezer store if it is locked. For live nodes, use an offline copy or a same-filesystem hardlink snapshot with independent mutable metadata/lock files (`LOCK`, `ancient/FLOCK`, `CURRENT`, `LOG`, `MANIFEST-*`, `*.log`), run the validator against the snapshot, then remove the snapshot promptly so hardlinked SST files do not pin old compaction data.
+
 ### Level 3: adversarial validation
 
 Before treating the proof system as security-critical, add fuzz/property tests and adversarial cases:

--- a/doc/nipopow.md
+++ b/doc/nipopow.md
@@ -203,6 +203,36 @@ Before treating the proof system as security-critical, add fuzz/property tests a
 - oversized requested ranges
 - invalid `m`
 
+The package includes an adversarial validation harness for verifier hardening:
+
+```go
+report, err := nipopow.ValidatePrimeProofAdversarialCases(validProof, []nipopow.AdversarialCase{
+    {
+        Name:          "bad-interlink-root",
+        ExpectedError: nipopow.ErrInterlinkRootMismatch,
+        Mutate: func(proof *nipopow.Proof) error {
+            proof.Headers[1].Body().SetInterlinkHashes(common.Hashes{})
+            return nil
+        },
+    },
+})
+if err != nil {
+    return err
+}
+if report.Failed() {
+    // The baseline failed or a mutated proof verified / failed for the wrong reason.
+}
+```
+
+Adversarial gate command examples:
+
+```bash
+go test ./core/nipopow -run 'Adversarial|FuzzVerifyPrimeProofRejectsUnsafeMutations' -count=1
+go test ./core/nipopow -run '^$' -fuzz FuzzVerifyPrimeProofRejectsUnsafeMutations -fuzztime=5s
+```
+
+Current coverage includes anchor mismatch, nil headers, swapped WorkObject body/header binding, bad interlink roots, disconnected prefixes, non-linear suffixes, no-op mutations that should fail the gate, invalid harness config, and seeded fuzz mutations for invalid `m`, empty headers, anchor mismatch, nil headers, body/header tampering, bad interlinks, disconnected prefixes, and non-linear suffixes.
+
 ### Level 4: mining-template readiness
 
 Mining-template use requires the later stages:

--- a/doc/nipopow.md
+++ b/doc/nipopow.md
@@ -150,6 +150,28 @@ Record:
 - verification result
 - failure mode for malformed requests
 
+The package includes a reusable validation harness for this stage:
+
+```go
+report, err := nipopow.ValidatePrimeProofRanges(ctx, headerChain, nipopow.ValidationOptions{
+    M: 15,
+    Ranges: []nipopow.ValidationRange{
+        {Name: "recent-short", AnchorNumber: recentAnchor, TipNumber: recentTip},
+        {Name: "older-short", AnchorNumber: olderAnchor, TipNumber: olderTip},
+        {Name: "limit-boundary", AnchorNumber: boundaryAnchor, TipNumber: boundaryTip},
+    },
+    Limits: nipopow.DefaultBuildLimits,
+})
+if err != nil {
+    return err
+}
+if report.Failed() {
+    // At least one range failed; inspect report.Results for the exact cause.
+}
+```
+
+`ValidatePrimeProofRanges` records one result per range and continues after range-level failures. Each result includes anchor/tip numbers, anchor/tip hashes, uncompressed chain length, compressed proof header count, estimated encoded proof bytes, elapsed build/verify time, and any error. The harness uses the same read-only `PrimeProofSource` path as public proof generation, so a successful run proves that persisted canonical headers and interlinks can build and verify Prime proofs without mutating storage.
+
 ### Level 3: adversarial validation
 
 Before treating the proof system as security-critical, add fuzz/property tests and adversarial cases:

--- a/doc/nipopow.md
+++ b/doc/nipopow.md
@@ -1,0 +1,259 @@
+# NiPoPoW Proofs for Trust-Reduced Mining Templates
+
+## Status
+
+This document describes the staged NiPoPoW work for `go-quai`.
+
+Current stage: Prime-chain proof foundation.
+
+The current implementation is intentionally read-only and non-consensus. It does not change block validation rules, fork choice, mining behavior, or persisted chain state. Its purpose is to add the Prime-chain proof primitives needed before Zone mining templates can be verified by external pools without trusting the node that produced the template.
+
+## Problem
+
+Mining pools currently need to trust or whitelist nodes that provide block templates. A pool receiving a Zone block template from an untrusted node needs compact evidence that the template is anchored into the canonical Quai hierarchy and backed by sufficient Prime-chain work.
+
+The desired verification shape is:
+
+```text
+Zone block template/header
+  -> committed/linked by Zone/Region manifest context
+Region context
+  -> committed/linked by Region/Prime manifest context
+Prime context
+  -> proven by compact Prime NiPoPoW proof
+Sufficient Prime-chain work according to the verifier policy
+```
+
+The first implementation stage only provides the bottom layer:
+
+```text
+Prime context
+  -> compact Prime NiPoPoW proof
+```
+
+The Zone/Region wrapper and mining-template integration are later stages.
+
+## Goals
+
+- Add a compact Prime-chain proof representation.
+- Build Prime proofs from already-persisted canonical chain data.
+- Verify proof structure, header/body binding, interlink roots, linear suffixes, and interlink jumps.
+- Verify proof-of-work/rank when the caller supplies the consensus PoW hash function.
+- Bound public proof generation with context cancellation and explicit limits.
+- Keep the implementation read-only and non-consensus.
+- Provide a clean foundation for later Zone -> Region -> Prime template proofs.
+
+## Non-goals for the current stage
+
+- No consensus-rule changes.
+- No fork-choice changes.
+- No block-template behavior changes.
+- No DB writes or recalculation of persisted interlinks.
+- No claim that Zone templates are trustlessly verifiable yet.
+- No public verifier RPC that could be mistaken for a canonical truth oracle.
+
+## Current code layout
+
+- `core/nipopow/proof.go`
+  - `Proof`
+  - `VerifyPrimeProof`
+  - structural checks for header connectivity and interlink commitments
+
+- `core/nipopow/build.go`
+  - `PrimeProofSource`
+  - `BuildPrimeProof`
+  - `BuildPrimeProofWithContext`
+  - bounded canonical-chain walking and proof compression
+
+- `core/nipopow/pow.go`
+  - `PrimePoWVerifier`
+  - `VerifyPrimeProofWithPoW`
+  - `VerifyPrimeProofWork`
+  - `CalcRank`
+
+- `core/nipopow/score.go`
+  - `ScorePrimeProof`
+  - `ComparePrimeProofs`
+  - `CompareProofScores`
+
+- `core/headerchain_nipopow.go`
+  - read-only bridge from canonical chain storage into the proof builder
+
+- `core/core_nipopow.go`
+  - Core-level proof access
+
+- `internal/quaiapi/backend.go`
+  - backend interface extension
+
+- `quai/api_backend.go`
+  - concrete backend bridge
+
+- `internal/quaiapi/quai_api.go`
+  - bounded Prime-only `quai_getNiPoPoWProof` RPC access
+
+## Safety model
+
+The Prime proof path is designed as read-only infrastructure.
+
+Important safety properties:
+
+1. The proof builder reads persisted chain data only.
+2. It does not call interlink calculation paths that can mutate storage.
+3. Genesis is handled explicitly so the builder does not attempt to read a nonexistent parent.
+4. Public proof construction is bounded by:
+   - maximum chain walk length
+   - maximum proof header count
+   - maximum `m`
+   - context cancellation
+5. The structural verifier checks:
+   - non-nil proof and headers
+   - valid `m`
+   - sufficient suffix length
+   - anchor consistency
+   - WorkObject header/body binding
+   - interlink root consistency
+   - forward-only interlink jumps
+   - linear final suffix
+6. PoW verification is separated from structural verification because it requires access to the consensus PoW hash function.
+7. Generic public proof verification is intentionally not exposed as an RPC endpoint. A public verifier that accepts arbitrary proofs without canonical-chain context can be misused as a misleading truth oracle.
+
+## Verification levels
+
+### Level 1: package and integration tests
+
+The first stage should pass:
+
+```bash
+go test ./core/nipopow ./core ./internal/quaiapi ./quai -count=1
+go test ./... -run TestNonExistentCompileOnly -count=0
+go vet ./core/nipopow ./internal/quaiapi ./quai
+go build ./cmd/go-quai
+```
+
+### Level 2: real-chain validation
+
+Before relying on this for mining or public production behavior, run the proof builder against real or snapshot chain data:
+
+- recent Prime blocks
+- older Prime blocks
+- short ranges
+- long ranges near the configured limit
+- genesis / early-chain edge cases
+- recent tips
+- malformed/tampered proof inputs
+
+Record:
+
+- proof generation time
+- proof size
+- memory behavior
+- verification result
+- failure mode for malformed requests
+
+### Level 3: adversarial validation
+
+Before treating the proof system as security-critical, add fuzz/property tests and adversarial cases:
+
+- tampered headers
+- swapped WorkObject bodies
+- bad interlink roots
+- backward/no-progress interlink jumps
+- disconnected suffixes
+- stale tips
+- competing proofs with different score vectors
+- anchors not in the tip ancestry
+- oversized requested ranges
+- invalid `m`
+
+### Level 4: mining-template readiness
+
+Mining-template use requires the later stages:
+
+1. Zone -> Region manifest wrapper.
+2. Region -> Prime manifest wrapper.
+3. Combined proof object.
+4. Pool/client verifier.
+5. Optional proof delivery through `quai_getBlockTemplate`.
+6. Shadow-mode deployment before pools depend on the result economically.
+
+## Recommended upstream PR sequence
+
+Even if the implementation is completed internally before review, the upstream GitHub changes should remain split into small, reviewable PRs.
+
+### PR 1: Prime NiPoPoW core
+
+Scope:
+
+- `core/nipopow`
+- read-only HeaderChain/Core integration
+- bounded Prime proof RPC, if accepted as an experimental proof-fetch endpoint
+- tests
+- this documentation
+
+This PR should be mergeable on its own and should not claim to solve trustless mining templates yet.
+
+Suggested title:
+
+```text
+feat(core): add read-only Prime NiPoPoW proof engine
+```
+
+### PR 2: Zone/Region/Prime manifest wrapper
+
+Scope:
+
+- prove Zone context is committed into Region context
+- prove Region context is committed into Prime context
+- combine wrapper proof with Prime NiPoPoW proof
+- verifier for the combined hierarchical proof
+
+Suggested title:
+
+```text
+feat(core): add hierarchical NiPoPoW manifest wrapper
+```
+
+### PR 3: Mining-template and pool integration
+
+Scope:
+
+- optional proof field in `quai_getBlockTemplate`
+- config/feature flag
+- request limits and timeout behavior
+- pool/client verifier documentation or minimal library/example
+- shadow-mode guidance
+
+Suggested title:
+
+```text
+feat(miner): expose optional NiPoPoW proof with block templates
+```
+
+## Why not one large PR?
+
+A single PR containing Prime proof logic, manifest wrappers, block-template changes, and pool verifier code would be harder to review and riskier to merge. Splitting the work keeps each layer independently testable:
+
+1. Prime proof correctness.
+2. Hierarchical anchoring correctness.
+3. Mining-template integration correctness.
+
+The implementation can still be developed end-to-end internally before opening the final upstream PRs. The split is for reviewability, risk control, and easier rollback.
+
+## Mainnet-readiness bar
+
+Before this should influence mainnet mining decisions:
+
+- all package and integration tests pass
+- real-chain validation completed
+- adversarial/fuzz validation completed
+- proof generation remains bounded under bad inputs
+- no DB writes from proof paths
+- no default consensus or mining behavior change
+- feature flag or opt-in API behavior
+- pool/client verifier tested independently from the prover
+- shadow-mode operation before economic reliance
+- rollback path documented
+
+## Short version
+
+The current implementation is the Prime-chain foundation. It is designed to be safe, read-only, and independently testable. The full trust-reduced mining-template flow requires two additional layers: a Zone/Region/Prime manifest wrapper and an opt-in block-template/pool verifier integration.

--- a/internal/quaiapi/backend.go
+++ b/internal/quaiapi/backend.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dominant-strategies/go-quai/consensus"
 	"github.com/dominant-strategies/go-quai/core"
 	"github.com/dominant-strategies/go-quai/core/bloombits"
+	"github.com/dominant-strategies/go-quai/core/nipopow"
 	"github.com/dominant-strategies/go-quai/core/state"
 	"github.com/dominant-strategies/go-quai/core/types"
 	"github.com/dominant-strategies/go-quai/core/vm"
@@ -139,6 +140,7 @@ type Backend interface {
 	ForfeitureAddresses() map[common.AddressBytes]bool
 	GetTerminiByHash(hash common.Hash) *types.Termini
 	GetHeaderByHash(hash common.Hash) *types.WorkObject
+	GetNiPoPoWProof(ctx context.Context, anchor common.Hash, tip common.Hash, m uint64) (*nipopow.Proof, error)
 	IsGenesisHash(hash common.Hash) bool
 	GetQuaiHeaderForDonorHash(donorHash common.Hash) *types.WorkObjectHeader
 	GetBlockForWorkShareHash(workshareHash common.Hash) *types.WorkObject

--- a/internal/quaiapi/quai_api.go
+++ b/internal/quaiapi/quai_api.go
@@ -35,6 +35,7 @@ import (
 	quaimath "github.com/dominant-strategies/go-quai/common/math"
 	"github.com/dominant-strategies/go-quai/consensus/misc"
 	"github.com/dominant-strategies/go-quai/core"
+	"github.com/dominant-strategies/go-quai/core/nipopow"
 	"github.com/dominant-strategies/go-quai/core/rawdb"
 	"github.com/dominant-strategies/go-quai/core/types"
 	"github.com/dominant-strategies/go-quai/core/vm"
@@ -108,6 +109,17 @@ func (api *PublicBlockChainQuaiAPI) ChainId() (*hexutil.Big, error) {
 // NodeLocation is the access call to the location of the node.
 func (api *PublicBlockChainQuaiAPI) NodeLocation() []hexutil.Uint64 {
 	return api.b.NodeLocation().RPCMarshal()
+}
+
+// GetNiPoPoWProof returns a read-only Prime-chain NiPoPoW proof from anchor to tip.
+func (api *PublicBlockChainQuaiAPI) GetNiPoPoWProof(ctx context.Context, anchor common.Hash, tip common.Hash, m hexutil.Uint64) (*nipopow.Proof, error) {
+	if api.b.NodeCtx() != common.PRIME_CTX {
+		return nil, errors.New("getNiPoPoWProof call can only be made in prime chain")
+	}
+	if tip == (common.Hash{}) {
+		tip = api.b.CurrentHeader().Hash()
+	}
+	return api.b.GetNiPoPoWProof(ctx, anchor, tip, uint64(m))
 }
 
 // BlockNumber returns the block number of the chain head.

--- a/quai/api_backend.go
+++ b/quai/api_backend.go
@@ -28,6 +28,7 @@ import (
 	"github.com/dominant-strategies/go-quai/consensus"
 	"github.com/dominant-strategies/go-quai/core"
 	"github.com/dominant-strategies/go-quai/core/bloombits"
+	"github.com/dominant-strategies/go-quai/core/nipopow"
 	"github.com/dominant-strategies/go-quai/core/rawdb"
 	"github.com/dominant-strategies/go-quai/core/state"
 	"github.com/dominant-strategies/go-quai/core/types"
@@ -810,6 +811,10 @@ func (b *QuaiAPIBackend) GetBlockByHash(hash common.Hash) *types.WorkObject {
 
 func (b *QuaiAPIBackend) GetHeaderByHash(hash common.Hash) *types.WorkObject {
 	return b.quai.core.GetHeaderByHash(hash)
+}
+
+func (b *QuaiAPIBackend) GetNiPoPoWProof(ctx context.Context, anchor common.Hash, tip common.Hash, m uint64) (*nipopow.Proof, error) {
+	return b.quai.core.GetNiPoPoWProof(ctx, anchor, tip, m)
 }
 
 func (b *QuaiAPIBackend) GetHeaderByNumber(number uint64) *types.WorkObject {


### PR DESCRIPTION
## Summary

- Adds read-only Prime NiPoPoW proof primitives and verifier support.
- Adds bounded proof construction from canonical chain data.
- Adds validation/adversarial harnesses and documentation for the first proof layer.

## Safety

- Read-only path only: no consensus, fork-choice, mining, or DB mutation behavior changes.
- Public proof generation remains bounded by explicit limits and context cancellation.
- This PR intentionally does not claim trust-reduced mining templates yet.

## Test plan

- [x] `/snap/bin/go test ./core/nipopow ./core ./internal/quaiapi ./quai -count=1`
- [x] `/snap/bin/go vet ./core/nipopow ./internal/quaiapi ./quai`
- [x] `/snap/bin/go build ./cmd/go-quai`

## Stack

This is PR 1 of the NiPoPoW stack.

- PR 1 upstream: https://github.com/dominant-strategies/go-quai/pull/2724
- PR 2 draft stack branch: https://github.com/Clonners/go-quai/pull/1
- PR 3 draft stack branch: https://github.com/Clonners/go-quai/pull/2

Because I do not have permission to push stack-base branches to `dominant-strategies/go-quai`, PR 2 and PR 3 are staged as draft PRs in the fork for clean diff review against their stacked bases.
