### PR TITLE
cmd: fix pending header worker limiter

### DIFF
--- a/cmd/utils/hierarchical_coordinator.go
+++ b/cmd/utils/hierarchical_coordinator.go
@@ -90,7 +90,9 @@ type HierarchicalCoordinator struct {
 
 	bestEntropy *big.Int
 
-	oneMu                      sync.Mutex
+	oneMu sync.Mutex
+
+	generateHeaderWorkersMu    sync.Mutex
 	generateHeaderWorkersCount int
 
 	pendingHeaderBackupCh chan struct{}
@@ -182,6 +184,25 @@ func removeFromSlice(keyToRemove string, pendingHeaders *PendingHeaders) {
 			pendingHeaders.order = append(pendingHeaders.order[:i], pendingHeaders.order[i+1:]...)
 		}
 	}
+}
+
+func (hc *HierarchicalCoordinator) tryAcquireGenerateHeaderWorker() bool {
+	hc.generateHeaderWorkersMu.Lock()
+	defer hc.generateHeaderWorkersMu.Unlock()
+	if hc.generateHeaderWorkersCount >= c_maxHeaderWorkers {
+		return false
+	}
+	hc.generateHeaderWorkersCount++
+	return true
+}
+
+func (hc *HierarchicalCoordinator) releaseGenerateHeaderWorker() {
+	hc.generateHeaderWorkersMu.Lock()
+	defer hc.generateHeaderWorkersMu.Unlock()
+	if hc.generateHeaderWorkersCount == 0 {
+		return
+	}
+	hc.generateHeaderWorkersCount--
 }
 
 func (ns *NodeSet) Extendable(wo *types.WorkObject, order int) bool {
@@ -1074,8 +1095,7 @@ func (hc *HierarchicalCoordinator) BuildPendingHeaders(wo *types.WorkObject, ord
 	}
 
 	bestNode, exists := hc.pendingHeaders.collection.Peek(hc.bestEntropy.String())
-	if exists && hc.generateHeaderWorkersCount <= c_maxHeaderWorkers {
-		hc.generateHeaderWorkersCount++
+	if exists && hc.tryAcquireGenerateHeaderWorker() {
 		go hc.ComputePendingHeaders(bestNode)
 	} else {
 		log.Global.Info("Reached the maxHeaderWorkers, skipping GeneratePending")
@@ -1096,6 +1116,7 @@ func (hc *HierarchicalCoordinator) ComputePendingHeaders(nodeSet NodeSet) {
 			}).Fatal("Go-Quai Panicked")
 		}
 	}()
+	defer hc.releaseGenerateHeaderWorker()
 	numRegions, numZones := common.GetHierarchySizeForExpansionNumber(hc.currentExpansionNumber)
 	var wg sync.WaitGroup
 	primeLocation := common.Location{}.Name()
@@ -1109,7 +1130,6 @@ func (hc *HierarchicalCoordinator) ComputePendingHeaders(nodeSet NodeSet) {
 		}
 	}
 	wg.Wait()
-	hc.generateHeaderWorkersCount--
 }
 
 func circularShift(arr []Node) []Node {

--- a/cmd/utils/hierarchical_coordinator_worker_test.go
+++ b/cmd/utils/hierarchical_coordinator_worker_test.go
@@ -1,0 +1,31 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateHeaderWorkerLimiterAllowsOnlyConfiguredWorkers(t *testing.T) {
+	hc := &HierarchicalCoordinator{}
+
+	require.True(t, hc.tryAcquireGenerateHeaderWorker())
+	require.Equal(t, 1, hc.generateHeaderWorkersCount)
+
+	require.False(t, hc.tryAcquireGenerateHeaderWorker())
+	require.Equal(t, 1, hc.generateHeaderWorkersCount)
+
+	hc.releaseGenerateHeaderWorker()
+	require.Equal(t, 0, hc.generateHeaderWorkersCount)
+
+	require.True(t, hc.tryAcquireGenerateHeaderWorker())
+	require.Equal(t, 1, hc.generateHeaderWorkersCount)
+}
+
+func TestReleaseGenerateHeaderWorkerDoesNotUnderflow(t *testing.T) {
+	hc := &HierarchicalCoordinator{}
+
+	hc.releaseGenerateHeaderWorker()
+
+	require.Equal(t, 0, hc.generateHeaderWorkersCount)
+}


### PR DESCRIPTION
## Summary
- Fix the pending-header worker limiter so `c_maxHeaderWorkers` is enforced as the actual maximum.
- Protect the worker counter with a dedicated mutex instead of updating it from multiple goroutines without synchronization.
- Add focused tests for limiter acquisition and release behavior.

## Details
The previous guard used `<= c_maxHeaderWorkers`, which allowed one more worker than configured. With `c_maxHeaderWorkers = 1`, this admitted two concurrent pending-header workers before reporting saturation.

This change centralizes acquire/release handling and prevents the counter from underflowing on release.

## Test Plan
- [x] `go test ./cmd/utils -run 'TestGenerateHeaderWorkerLimiter|TestReleaseGenerateHeaderWorker' -count=1`
- [x] `go test -race ./cmd/utils -run 'TestGenerateHeaderWorkerLimiter|TestReleaseGenerateHeaderWorker' -count=1`
- [x] `go test ./cmd/utils -count=1`
- [x] `go build ./cmd/go-quai`

## Scope
This PR only fixes the pending-header worker limiter accounting. It does not change consensus rules, block validity, fork choice, RPC behavior, or network protocol.