### PR TITLE
Fix unpinned-action in antithesis.yml

### DIFF
--- a/.github/workflows/antithesis.yml
+++ b/.github/workflows/antithesis.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Read version and generate commit hash
         id: versioning
@@ -28,10 +28,10 @@ jobs:
           gcloud auth configure-docker us-central1-docker.pkg.dev
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -42,7 +42,7 @@ jobs:
           cache-to: type=inline
 
       - name: Run Antithesis Test
-        uses: antithesishq/antithesis-trigger-action@v0.6
+        uses: antithesishq/antithesis-trigger-action@aaaebf2f004854ac2fb72a951118d5a5eda21aa3
         with:
           notebook_name: dominant
           tenant: dominantstrategies


### PR DESCRIPTION
> 🤖 An AI-generated pull request from [codeopsai](https://codeopsai.com). We open PRs only when we find a concrete, citable issue worth fixing. Not useful? Comment **"no thanks"** and we won't open more.

<details>
<summary>About codeopsai</summary>

codeopsai analyzes public GitHub Actions workflows for security and reliability issues and opens fixes for maintainer review. Every PR carries citations to the relevant standard (CWE, GitHub docs) and a structural verification trail; if our evidence bar isn't met, we don't open the PR.

**Mistake, or unwelcome?** Comment here or open an issue at [github.com/codeopsai/feedback](https://github.com/codeopsai/feedback). We read every one and adjust.
</details>

## Why these matter

**Why pin to a SHA** (`unpinned-action`)

Each unpinned action reference can be force-moved to attacker-controlled code by the action's owner or anyone who compromises their account — exactly what happened in the tj-actions/changed-files attack (CVE-2025-30066, Mar 2025). Pinning to a 40-character commit SHA freezes the exact reviewed code.

Reference: CWE-829 · [GitHub/OWASP guidance](https://docs.github.com/en/actions/reference/security/secure-use) · Real-world precedent: tj-actions/changed-files supply-chain attack (CVE-2025-30066, Mar 2025)

### `.github/workflows/antithesis.yml`

- 🟠 MED `docker/setup-buildx-action` (job `nightly-run`)
- 🟠 MED `docker/build-push-action` (job `nightly-run`)
- 🟠 MED `antithesishq/antithesis-trigger-action` (job `nightly-run`)
- ⚪ LOW `actions/checkout` (job `nightly-run`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/antithesis.yml
+++ b/.github/workflows/antithesis.yml
@@ -10,7 +10,7 @@
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Read version and generate commit hash
         id: versioning
@@ -28,10 +28,10 @@
           gcloud auth configure-docker us-central1-docker.pkg.dev
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -42,7 +42,7 @@
           cache-to: type=inline
 
       - name: Run Antithesis Test
-        uses: antithesishq/antithesis-trigger-action@v0.6
+        uses: antithesishq/antithesis-trigger-action@aaaebf2f004854ac2fb72a951118d5a5eda21aa3
         with:
           notebook_name: dominant
           tenant: dominantstrategies
```

</details>


---

_Have other repositories you'd like analysed? Request a scan at [codeopsai.com](https://codeopsai.com)._

---

_AI-generated. Review the diff before merging._
