### PR TITLE
Fix unpinned-action in docker-publish.yml

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,16 +35,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -68,7 +68,7 @@ jobs:
           echo "tags=${tags}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
> 🤖 An AI-generated pull request from [codeopsai](https://codeopsai.com). We open PRs only when we find a concrete, citable issue worth fixing. Not useful? Comment **"no thanks"** and we won't open more.

<details>
<summary>About codeopsai</summary>

codeopsai analyzes public GitHub Actions workflows for security and reliability issues and opens fixes for maintainer review. Every PR carries citations to the relevant standard (CWE, GitHub docs) and a structural verification trail; if our evidence bar isn't met, we don't open the PR.

**Mistake, or unwelcome?** Comment here or open an issue at [github.com/codeopsai/feedback](https://github.com/codeopsai/feedback). We read every one and adjust.
</details>

## Why these matter

**Why pin to a SHA** (`unpinned-action`)

Each unpinned action reference can be force-moved to attacker-controlled code by the action's owner or anyone who compromises their account — exactly what happened in the tj-actions/changed-files attack (CVE-2025-30066, Mar 2025). Pinning to a 40-character commit SHA freezes the exact reviewed code.

Reference: CWE-829 · [GitHub/OWASP guidance](https://docs.github.com/en/actions/reference/security/secure-use) · Real-world precedent: tj-actions/changed-files supply-chain attack (CVE-2025-30066, Mar 2025)

### `.github/workflows/docker-publish.yml`

- 🟠 MED `docker/setup-qemu-action` (job `docker`)
- 🟠 MED `docker/setup-buildx-action` (job `docker`)
- 🟠 MED `docker/login-action` (job `docker`)
- 🟠 MED `docker/build-push-action` (job `docker`)
- ⚪ LOW `actions/checkout` (job `docker`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,16 +35,16 @@
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -68,7 +68,7 @@
           echo "tags=${tags}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: .
           file: ./Dockerfile
```

</details>


---

_Have other repositories you'd like analysed? Request a scan at [codeopsai.com](https://codeopsai.com)._

---

_AI-generated. Review the diff before merging._
