### PR TITLE
Qi privacy usability

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -130,6 +130,8 @@ var TXPoolFlags = []Flag{
 	TxPoolLocalsFlag,
 	TxPoolNoLocalsFlag,
 	TxPoolSyncTxWithReturnFlag,
+	TxPoolDandelionFlag,
+	TxPoolStemProbabilityFlag,
 	TxPoolJournalFlag,
 	TxPoolRejournalFlag,
 	TxPoolPriceLimitFlag,
@@ -385,6 +387,18 @@ var (
 		Name:  c_TXPoolPrefix + "sync-tx-with-return",
 		Value: true,
 		Usage: "Shares the tx with the sharing client with syncronous return (also bypasses local pool, only use it with combination of sharing clients)" + generateEnvDoc(c_TXPoolPrefix+"sync-tx-with-return"),
+	}
+
+	TxPoolDandelionFlag = Flag{
+		Name:  c_TXPoolPrefix + "dandelion",
+		Value: true,
+		Usage: "Enable Dandelion-style stem/fluff relay for locally submitted Qi transactions (stems through sharing clients when configured)" + generateEnvDoc(c_TXPoolPrefix+"dandelion"),
+	}
+
+	TxPoolStemProbabilityFlag = Flag{
+		Name:  c_TXPoolPrefix + "stem-probability",
+		Value: 90,
+		Usage: "Percent chance [0,100] that a stem Qi transaction is relayed onward rather than fluffed" + generateEnvDoc(c_TXPoolPrefix+"stem-probability"),
 	}
 
 	TxPoolJournalFlag = Flag{
@@ -1184,6 +1198,8 @@ func setTxPool(cfg *core.TxPoolConfig, nodeLocation common.Location) {
 		cfg.NoLocals = viper.GetBool(TxPoolNoLocalsFlag.Name)
 	}
 	cfg.SyncTxWithReturn = viper.GetBool(TxPoolSyncTxWithReturnFlag.Name)
+	cfg.Dandelion = viper.GetBool(TxPoolDandelionFlag.Name)
+	cfg.StemProbability = viper.GetUint64(TxPoolStemProbabilityFlag.Name)
 	if viper.IsSet(TxPoolJournalFlag.Name) {
 		cfg.Journal = viper.GetString(TxPoolJournalFlag.Name)
 	}

--- a/core/chain_indexer.go
+++ b/core/chain_indexer.go
@@ -32,6 +32,7 @@ import (
 	"github.com/dominant-strategies/go-quai/core/state"
 	"github.com/dominant-strategies/go-quai/core/types"
 	"github.com/dominant-strategies/go-quai/crypto"
+	"github.com/dominant-strategies/go-quai/crypto/gcs"
 	"github.com/dominant-strategies/go-quai/ethdb"
 	"github.com/dominant-strategies/go-quai/event"
 	"github.com/dominant-strategies/go-quai/log"
@@ -432,6 +433,7 @@ func (c *ChainIndexer) indexerLoop(currentHeader *types.WorkObject, qiIndexerCh 
 							continue
 						}
 						c.addOutpointsToIndexer(nodeCtx, config, block)
+						c.buildBlockFilter(nodeCtx, block)
 					}
 				}
 
@@ -442,6 +444,7 @@ func (c *ChainIndexer) indexerLoop(currentHeader *types.WorkObject, qiIndexerCh 
 				time3 = time.Since(start)
 				if c.indexAddressUtxos {
 					c.addOutpointsToIndexer(nodeCtx, config, block)
+					c.buildBlockFilter(nodeCtx, block)
 				}
 				time4 = time.Since(start)
 				c.newHead(block.NumberU64(nodeCtx), false)
@@ -465,6 +468,55 @@ func (c *ChainIndexer) indexerLoop(currentHeader *types.WorkObject, qiIndexerCh 
 			}).Info("Times in indexerLoop")
 		}
 
+	}
+}
+
+// buildBlockFilter builds and stores a BIP-158-style compact filter over the
+// addresses touched by a block's UTXO set changes: addresses of created
+// UTXOs (tx outputs, coinbase rewards and ETX-minted outputs) and addresses
+// of spent UTXOs. Wallets download filters, match their own addresses
+// locally and fetch only matching blocks, so they never reveal the addresses
+// they scan for to the serving node. The SipHash key is the first 16 bytes
+// of the block hash.
+func (c *ChainIndexer) buildBlockFilter(nodeCtx int, block *types.WorkObject) {
+	if nodeCtx != common.ZONE_CTX {
+		return
+	}
+	blockHash := block.Hash()
+	items := make([][]byte, 0)
+	createdKeys, err := rawdb.ReadCreatedUTXOKeys(c.chainDb, blockHash)
+	if err == nil {
+		for _, key := range createdKeys {
+			if len(key) == rawdb.UtxoKeyWithDenominationLength {
+				key = key[:rawdb.UtxoKeyLength] // strip the denomination byte
+			}
+			txHash, index, err := rawdb.ReverseUtxoKey(key)
+			if err != nil {
+				continue
+			}
+			if utxo := rawdb.GetUTXO(c.chainDb, txHash, index); utxo != nil {
+				items = append(items, utxo.Address)
+			}
+		}
+	}
+	spent, err := rawdb.ReadSpentUTXOs(c.chainDb, blockHash)
+	if err == nil {
+		for _, spentUtxo := range spent {
+			items = append(items, spentUtxo.Address)
+		}
+	}
+	if len(items) == 0 {
+		return
+	}
+	var key [16]byte
+	copy(key[:], blockHash.Bytes()[:16])
+	filter, err := gcs.BuildFilter(key, items)
+	if err != nil {
+		c.logger.WithField("err", err).Error("ChainIndexer: Failed to build block filter")
+		return
+	}
+	if err := rawdb.WriteBlockFilter(c.chainDb, blockHash, filter); err != nil {
+		c.logger.WithField("err", err).Error("ChainIndexer: Failed to write block filter")
 	}
 }
 

--- a/core/core.go
+++ b/core/core.go
@@ -1851,6 +1851,10 @@ func (c *Core) SendTxToSharingClients(tx *types.Transaction) error {
 	return c.sl.txPool.SendTxToSharingClients(tx)
 }
 
+func (c *Core) QiTxPoolStatus(txHash common.Hash) *QiTxPoolStatus {
+	return c.sl.txPool.QiTxStatus(txHash)
+}
+
 func (c *Core) GetRollingFeeInfo() (min, max, avg *big.Int) {
 	return c.Processor().GetRollingFeeInfo()
 }

--- a/core/core.go
+++ b/core/core.go
@@ -1855,6 +1855,12 @@ func (c *Core) QiTxPoolStatus(txHash common.Hash) *QiTxPoolStatus {
 	return c.sl.txPool.QiTxStatus(txHash)
 }
 
+// GetBlockFilter returns the stored compact (GCS) block filter for the given
+// block hash, or nil if no filter was built for it.
+func (c *Core) GetBlockFilter(blockHash common.Hash) []byte {
+	return rawdb.ReadBlockFilter(c.sl.sliceDb, blockHash)
+}
+
 func (c *Core) GetRollingFeeInfo() (min, max, avg *big.Int) {
 	return c.Processor().GetRollingFeeInfo()
 }

--- a/core/core.go
+++ b/core/core.go
@@ -1855,6 +1855,10 @@ func (c *Core) QiTxPoolStatus(txHash common.Hash) *QiTxPoolStatus {
 	return c.sl.txPool.QiTxStatus(txHash)
 }
 
+func (c *Core) ReceiveStemTransaction(tx *types.Transaction) error {
+	return c.sl.txPool.ReceiveStemQiTx(tx)
+}
+
 // GetBlockFilter returns the stored compact (GCS) block filter for the given
 // block hash, or nil if no filter was built for it.
 func (c *Core) GetBlockFilter(blockHash common.Hash) []byte {

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -1727,6 +1727,28 @@ func DeleteCreatedUTXOKeys(db ethdb.KeyValueWriter, blockHash common.Hash) {
 	}
 }
 
+// WriteBlockFilter stores the compact (GCS) block filter for a block.
+func WriteBlockFilter(db ethdb.KeyValueWriter, blockHash common.Hash, filter []byte) error {
+	return db.Put(blockFilterKey(blockHash), filter)
+}
+
+// ReadBlockFilter retrieves the compact (GCS) block filter for a block, or
+// nil if none was stored.
+func ReadBlockFilter(db ethdb.Reader, blockHash common.Hash) []byte {
+	data, _ := db.Get(blockFilterKey(blockHash))
+	if len(data) == 0 {
+		return nil
+	}
+	return data
+}
+
+// DeleteBlockFilter removes the compact (GCS) block filter for a block.
+func DeleteBlockFilter(db ethdb.KeyValueWriter, blockHash common.Hash) {
+	if err := db.Delete(blockFilterKey(blockHash)); err != nil {
+		db.Logger().WithField("err", err).Fatal("Failed to delete block filter")
+	}
+}
+
 func WriteCreatedCoinbaseLockupKeys(db ethdb.KeyValueWriter, blockHash common.Hash, keys [][]byte) error {
 	protoKeys := &types.ProtoKeys{Keys: make([][]byte, 0, len(keys))}
 	protoKeys.Keys = append(protoKeys.Keys, keys...)

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -105,6 +105,7 @@ var (
 	manifestPrefix                  = []byte("ma")    // manifestPrefix + hash -> Manifest at block
 	interlinkPrefix                 = []byte("il")    // interlinkPrefix + hash -> Interlink at block
 	bloomPrefix                     = []byte("bl")    // bloomPrefix + hash -> bloom at block
+	blockFilterPrefix               = []byte("bf")    // blockFilterPrefix + hash -> compact (GCS) block filter over UTXO addresses touched at block
 
 	txLookupPrefix        = []byte("l") // txLookupPrefix + hash -> transaction/receipt lookup metadata
 	BloomBitsPrefix       = []byte("B") // bloomBitsPrefix + bit (uint16 big endian) + section (uint64 big endian) + hash -> bloom bits
@@ -376,6 +377,10 @@ func trimmedUTXOsKey(blockHash common.Hash) []byte {
 
 func createdUTXOsKey(blockHash common.Hash) []byte {
 	return append(createdUTXOsPrefix, blockHash[:]...)
+}
+
+func blockFilterKey(blockHash common.Hash) []byte {
+	return append(blockFilterPrefix, blockHash[:]...)
 }
 
 func multiSetKey(hash common.Hash) []byte {

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -2203,6 +2203,24 @@ func ProcessQiTx(tx *types.Transaction, chain ChainContext, checkSig bool, isFir
 	return txFeeInQit, etxs, receipt, nil, stepTimings
 }
 
+// QiTxOutputDenominations counts a Qi tx's outputs per denomination the same
+// way block processing does: conversion and wrapping outputs are excluded
+// because they are aggregated into an ETX instead of minting local UTXOs.
+// The result is suitable as the outputs argument of CheckDenominations.
+func QiTxOutputDenominations(tx *types.Transaction, location common.Location) map[uint]uint64 {
+	outputs := make(map[uint]uint64)
+	for _, txOut := range tx.TxOut() {
+		outputs[uint(txOut.Denomination)]++
+		toAddr := common.BytesToAddress(txOut.Address, location)
+		if toAddr.Location().Equal(location) && toAddr.IsInQuaiLedgerScope() &&
+			(len(tx.Data()) == params.MaxQiTxDataLength || len(tx.Data()) == common.AddressLength) {
+			// Conversion or wrapping output, aggregated into an ETX
+			outputs[uint(txOut.Denomination)]--
+		}
+	}
+	return outputs
+}
+
 // Go through all denominations largest to smallest, check if the input exists as the output, if not, convert it to the respective number of bills for the next smallest denomination, then repeat the check. Subtract the 'carry' when the outputs match the carry for that denomination.
 func CheckDenominations(inputs, outputs map[uint]uint64) error {
 	carries := make(map[uint]uint64)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -17,6 +17,7 @@
 package core
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
@@ -1586,8 +1587,11 @@ func ValidateQiTxInputs(tx *types.Transaction, chain ChainContext, db ethdb.Read
 	if tx.ChainId().Cmp(signer.ChainID()) != 0 {
 		return nil, fmt.Errorf("tx %032x has wrong chain ID", tx.Hash())
 	}
-	if len(tx.Data()) != 0 && (len(tx.Data()) != params.MaxQiTxDataLength && len(tx.Data()) != common.AddressLength) {
+	if !qiTxDataLengthValid(tx, currentHeader) {
 		return nil, fmt.Errorf("tx %v emits UTXO with data %d not equal to either address length or MaxQiTxDataLength %d", tx.Hash().Hex(), len(tx.Data()), params.MaxQiTxDataLength)
+	}
+	if err := validateQiTxLockTime(tx, currentHeader, location); err != nil {
+		return nil, err
 	}
 
 	// Wrap Qi Transaction
@@ -1660,6 +1664,51 @@ func qiWrappingSkipsLocalUTXO(header *types.WorkObject) bool {
 
 func qiUserLocksEnabled(header *types.WorkObject) bool {
 	return header.PrimeTerminusNumber().Uint64() >= params.QiUserLockForkBlock
+}
+
+// QiTxLockTime returns the absolute transaction-level locktime carried in a
+// Qi transaction's Data field, if any. A locktime is encoded as exactly
+// QiTxLockTimeDataLength bytes, big endian.
+func QiTxLockTime(tx *types.Transaction) (uint64, bool) {
+	data := tx.Data()
+	if len(data) != params.QiTxLockTimeDataLength {
+		return 0, false
+	}
+	return binary.BigEndian.Uint64(data), true
+}
+
+// qiTxDataLengthValid reports whether a Qi transaction's Data field has one of
+// the recognized lengths: empty, an address (wrapping), a conversion payload,
+// or - once the fork activates - a transaction-level locktime.
+func qiTxDataLengthValid(tx *types.Transaction, currentHeader *types.WorkObject) bool {
+	switch len(tx.Data()) {
+	case 0, common.AddressLength, params.MaxQiTxDataLength:
+		return true
+	case params.QiTxLockTimeDataLength:
+		return qiUserLocksEnabled(currentHeader)
+	default:
+		return false
+	}
+}
+
+// validateQiTxLockTime rejects a transaction that carries an absolute
+// locktime the chain has not reached yet. Unlike a UTXO Lock, which delays
+// spending an output that already exists, this delays the transaction itself,
+// so two parties can pre-sign competing spends of one output that mature at
+// different heights - the ordering payment channels are built on.
+func validateQiTxLockTime(tx *types.Transaction, currentHeader *types.WorkObject, location common.Location) error {
+	lockTime, ok := QiTxLockTime(tx)
+	if !ok {
+		return nil
+	}
+	if !qiUserLocksEnabled(currentHeader) {
+		return fmt.Errorf("tx %032x carries a locktime before the fork activates", tx.Hash())
+	}
+	current := currentHeader.Number(location.Context())
+	if current.Cmp(new(big.Int).SetUint64(lockTime)) < 0 {
+		return fmt.Errorf("tx %032x is not valid until height %d, current height %s", tx.Hash(), lockTime, current.String())
+	}
+	return nil
 }
 
 // validateQiTxOutLock enforces the rules for user-set locks on Qi outputs.
@@ -1894,8 +1943,11 @@ func ProcessQiTx(tx *types.Transaction, chain ChainContext, checkSig bool, isFir
 		return nil, nil, nil, errors.New("one of the parameters is nil"), nil
 	}
 
-	if len(tx.Data()) != 0 && (len(tx.Data()) != params.MaxQiTxDataLength && len(tx.Data()) != common.AddressLength) {
+	if !qiTxDataLengthValid(tx, currentHeader) {
 		return nil, nil, nil, fmt.Errorf("tx %v emits UTXO with data %d not equal to either address length or MaxQiTxDataLength %d", tx.Hash().Hex(), len(tx.Data()), params.MaxQiTxDataLength), nil
+	}
+	if err := validateQiTxLockTime(tx, currentHeader, location); err != nil {
+		return nil, nil, nil, err, nil
 	}
 
 	// Wrap Qi Transaction

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -1642,8 +1642,8 @@ func ValidateQiTxInputs(tx *types.Transaction, chain ChainContext, db ethdb.Read
 				types.MaxDenomination)
 			return nil, errors.New(str)
 		}
-		if txOut.Lock != nil && txOut.Lock.Sign() != 0 {
-			return nil, errors.New("QiTx output has non-zero lock")
+		if err := validateQiTxOutLock(&txOut, currentHeader, location); err != nil {
+			return nil, err
 		}
 		outputs[uint(txOut.Denomination)]++
 		if common.IsConversionOutput(txOut.Address, location) { // Qi->Quai conversion
@@ -1656,6 +1656,40 @@ func ValidateQiTxInputs(tx *types.Transaction, chain ChainContext, db ethdb.Read
 
 func qiWrappingSkipsLocalUTXO(header *types.WorkObject) bool {
 	return header.PrimeTerminusNumber().Uint64() >= params.QiWrappingChangeBlock
+}
+
+func qiUserLocksEnabled(header *types.WorkObject) bool {
+	return header.PrimeTerminusNumber().Uint64() >= params.QiUserLockForkBlock
+}
+
+// validateQiTxOutLock enforces the rules for user-set locks on Qi outputs.
+// Before QiUserLockForkBlock any non-zero lock is invalid. After activation a
+// locked output must be a local Qi-ledger UTXO (not a conversion, wrapping or
+// cross-chain output), must use a denomination above the trimmable range so a
+// locked output can never sit out the trimmer, and may not lock further out
+// than MaxQiUserLockDuration blocks from the current height.
+func validateQiTxOutLock(txOut *types.TxOut, currentHeader *types.WorkObject, location common.Location) error {
+	if txOut.Lock == nil || txOut.Lock.Sign() == 0 {
+		return nil
+	}
+	if !qiUserLocksEnabled(currentHeader) {
+		return errors.New("QiTx output has non-zero lock")
+	}
+	if txOut.Lock.Sign() < 0 {
+		return errors.New("QiTx output lock is negative")
+	}
+	if txOut.Denomination <= types.MaxTrimDenomination {
+		return fmt.Errorf("QiTx output lock requires denomination greater than %d, have %d", types.MaxTrimDenomination, txOut.Denomination)
+	}
+	toAddr := common.BytesToAddress(txOut.Address, location)
+	if !toAddr.Location().Equal(location) || !toAddr.IsInQiLedgerScope() {
+		return errors.New("QiTx output lock is only allowed on local Qi ledger outputs")
+	}
+	maxLock := new(big.Int).Add(currentHeader.Number(location.Context()), new(big.Int).SetUint64(params.MaxQiUserLockDuration))
+	if txOut.Lock.Cmp(maxLock) > 0 {
+		return fmt.Errorf("QiTx output lock %s exceeds maximum allowed unlock height %s", txOut.Lock.String(), maxLock.String())
+	}
+	return nil
 }
 
 func ValidateQiTxOutputsAndSignature(tx *types.Transaction, chain ChainContext, totalQitIn *big.Int, currentHeader *types.WorkObject, signer types.Signer, location common.Location, chainId big.Int, qiScalingFactor float64, etxRLimit, etxPLimit uint64) (*big.Int, error) {
@@ -1691,8 +1725,8 @@ func ValidateQiTxOutputsAndSignature(tx *types.Transaction, chain ChainContext, 
 		if txOutIdx > types.MaxOutputIndex {
 			return nil, fmt.Errorf("tx [%v] exceeds max output index of %d", tx.Hash().Hex(), types.MaxOutputIndex)
 		}
-		if txOut.Lock != nil && txOut.Lock.Sign() != 0 {
-			return nil, errors.New("QiTx output has non-zero lock")
+		if err := validateQiTxOutLock(&txOut, currentHeader, location); err != nil {
+			return nil, err
 		}
 		if txOut.Denomination > types.MaxDenomination {
 			str := fmt.Sprintf("transaction output value of %v is "+
@@ -1972,8 +2006,8 @@ func ProcessQiTx(tx *types.Transaction, chain ChainContext, checkSig bool, isFir
 				types.MaxDenomination)
 			return nil, nil, nil, errors.New(str), nil
 		}
-		if txOut.Lock != nil && txOut.Lock.Sign() != 0 {
-			return nil, nil, nil, errors.New("QiTx output has non-zero lock"), nil
+		if err := validateQiTxOutLock(&txOut, currentHeader, location); err != nil {
+			return nil, nil, nil, err, nil
 		}
 		totalQitOut.Add(totalQitOut, types.Denominations[txOut.Denomination])
 

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -18,6 +18,8 @@ package core
 
 import (
 	"context"
+	crand "crypto/rand"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
@@ -200,6 +202,9 @@ type TxPoolConfig struct {
 	ReorgFrequency  time.Duration // Frequency of reorgs outside of new head events
 
 	SharingClientsEndpoints []string // List of end points of the nodes to share the incoming local transactions with
+
+	Dandelion       bool   // Enable Dandelion-style stem/fluff relay for locally submitted Qi transactions
+	StemProbability uint64 // Percent chance [0,100] that a stem Qi tx is relayed onward rather than fluffed
 }
 
 // DefaultTxPoolConfig contains the default configurations for the transaction
@@ -222,6 +227,9 @@ var DefaultTxPoolConfig = TxPoolConfig{
 	QiTxLifetime:    30 * time.Minute,
 	Lifetime:        5 * time.Minute,
 	ReorgFrequency:  1 * time.Second,
+
+	Dandelion:       true,
+	StemProbability: 90,
 }
 
 // sanitize checks the provided user configurations and changes anything that's
@@ -290,6 +298,13 @@ func (config *TxPoolConfig) sanitize(logger *log.Logger) TxPoolConfig {
 			"updated":  DefaultTxPoolConfig.QiTxLifetime,
 		}).Warn("Sanitizing invalid txpool Qi transaction lifetime")
 		conf.QiTxLifetime = DefaultTxPoolConfig.QiTxLifetime
+	}
+	if conf.StemProbability > 100 {
+		logger.WithFields(log.Fields{
+			"provided": conf.StemProbability,
+			"updated":  DefaultTxPoolConfig.StemProbability,
+		}).Warn("Sanitizing invalid txpool stem probability")
+		conf.StemProbability = DefaultTxPoolConfig.StemProbability
 	}
 	if conf.Lifetime < 1 {
 		logger.WithFields(log.Fields{
@@ -370,6 +385,9 @@ type TxPool struct {
 
 	poolSharingClients []*quaiclient.Client
 	poolSharingTxCh    chan *types.Transaction
+
+	stemMu  sync.Mutex               // Protects stemTxs
+	stemTxs map[common.Hash]struct{} // Qi txs currently under a Dandelion stem embargo
 }
 
 type txpoolResetRequest struct {
@@ -447,6 +465,7 @@ func NewTxPool(config TxPoolConfig, chainconfig *params.ChainConfig, chain block
 
 	pool.qiOutpoints = make(map[types.OutPoint]common.Hash)
 	pool.qiConsolidation = make(map[common.Hash]struct{})
+	pool.stemTxs = make(map[common.Hash]struct{})
 	qiPool, _ := lru.NewWithEvict[common.Hash, *types.TxWithMinerFee](int(config.QiPoolSize), pool.onQiTxDropped)
 	pool.qiPool = qiPool
 
@@ -1764,9 +1783,143 @@ func (pool *TxPool) queueTxEvent(tx *types.Transaction) {
 	}
 }
 
+// stemEmbargo bounds for Dandelion stem relays: an embargo timer fires
+// between stemEmbargoMin and stemEmbargoMin+stemEmbargoJitter after a stem
+// hop, fluffing the tx if it has not become public by then, so a stem peer
+// cannot black-hole it.
+const (
+	stemEmbargoMin    = 10 * time.Second
+	stemEmbargoJitter = 20 * time.Second
+)
+
+// randIntn returns a uniform random int in [0, n) using crypto/rand. Stem
+// routing decisions are an anonymity mechanism, so they must not be
+// predictable; on entropy failure it falls back to 0.
+func randIntn(n int) int {
+	if n <= 1 {
+		return 0
+	}
+	var buf [8]byte
+	if _, err := crand.Read(buf[:]); err != nil {
+		return 0
+	}
+	return int(binary.LittleEndian.Uint64(buf[:]) % uint64(n))
+}
+
+// randomSharingClient returns a uniformly random connected sharing client,
+// or nil if none is available.
+func (pool *TxPool) randomSharingClient() *quaiclient.Client {
+	pool.sharingClientMu.RLock()
+	defer pool.sharingClientMu.RUnlock()
+	candidates := make([]*quaiclient.Client, 0, len(pool.poolSharingClients))
+	for _, client := range pool.poolSharingClients {
+		if client != nil {
+			candidates = append(candidates, client)
+		}
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+	return candidates[randIntn(len(candidates))]
+}
+
+// stemOrFluffQiTx implements Dandelion-style relay for Qi transactions. With
+// probability StemProbability the tx is forwarded to one randomly chosen
+// sharing client (the stem) and held under an embargo timer; otherwise, or
+// when no sharing client is available, it is fluffed: added to the local
+// pool and queued for public workshare broadcast. origin indicates the tx
+// was submitted to this node over RPC rather than relayed by a stem peer.
+func (pool *TxPool) stemOrFluffQiTx(tx *types.Transaction, origin bool) error {
+	client := pool.randomSharingClient()
+	if client == nil || uint64(randIntn(100)) >= pool.config.StemProbability {
+		return pool.fluffQiTx(tx)
+	}
+	pool.stemMu.Lock()
+	if _, exists := pool.stemTxs[tx.Hash()]; exists {
+		pool.stemMu.Unlock()
+		return nil // already stemming this tx
+	}
+	pool.stemTxs[tx.Hash()] = struct{}{}
+	pool.stemMu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), txSharingPoolTimeout)
+	defer cancel()
+	if err := client.SendStemTransaction(ctx, tx); err != nil {
+		pool.logger.WithField("err", err).Warn("Stem relay failed, fluffing Qi tx")
+		pool.stemMu.Lock()
+		delete(pool.stemTxs, tx.Hash())
+		pool.stemMu.Unlock()
+		return pool.fluffQiTx(tx)
+	}
+	embargo := stemEmbargoMin + time.Duration(randIntn(int(stemEmbargoJitter)))
+	time.AfterFunc(embargo, func() {
+		defer func() {
+			if r := recover(); r != nil {
+				pool.logger.WithFields(log.Fields{
+					"error":      r,
+					"stacktrace": string(debug.Stack()),
+				}).Error("Go-Quai Panicked")
+			}
+		}()
+		pool.stemMu.Lock()
+		delete(pool.stemTxs, tx.Hash())
+		pool.stemMu.Unlock()
+		if origin && pool.Has(tx.Hash()) {
+			// The tx came back to us through public propagation, so the stem
+			// phase completed elsewhere; nothing to do.
+			return
+		}
+		if err := pool.fluffQiTx(tx); err != nil {
+			pool.logger.WithFields(log.Fields{
+				"err": err,
+				"tx":  tx.Hash().String(),
+			}).Debug("Failed to fluff Qi tx after stem embargo")
+		}
+	})
+	return nil
+}
+
+// fluffQiTx makes a Qi tx public: it enters the local pool (if not already
+// there) and is queued for this node's broadcast set, from where it
+// propagates via workshare gossip.
+func (pool *TxPool) fluffQiTx(tx *types.Transaction) error {
+	if pool.qiPool.Contains(tx.Hash()) {
+		// Already pooled, e.g. added while relaying the stem; flip it to
+		// local so it is broadcast publicly.
+		tx.SetLocal(true)
+		pool.queueTxEvent(tx)
+		return nil
+	}
+	return pool.AddLocal(tx)
+}
+
+// ReceiveStemQiTx handles a Qi tx relayed to this node by a Dandelion stem
+// peer: the tx joins the pool without being marked local (minable, but not
+// broadcast by this node yet) and the stem continues, either onward to one
+// of our own sharing clients or by fluffing here.
+func (pool *TxPool) ReceiveStemQiTx(tx *types.Transaction) error {
+	if tx.Type() != types.QiTxType {
+		return errors.New("stem relay only accepts Qi transactions")
+	}
+	if !pool.config.Dandelion {
+		return pool.AddLocal(tx)
+	}
+	errs := pool.AddRemotes([]*types.Transaction{tx})
+	if errs[0] != nil && !errors.Is(errs[0], ErrAlreadyKnown) {
+		return errs[0]
+	}
+	return pool.stemOrFluffQiTx(tx, false)
+}
+
 // SendTxToSharingClients sends the tx into the pool sharing tx ch and
 // if its full logs it
 func (pool *TxPool) SendTxToSharingClients(tx *types.Transaction) error {
+	// Dandelion stem/fluff for locally submitted Qi transactions: relay
+	// through a single randomly chosen sharing client before public
+	// broadcast, so the first hop cannot tie the tx to its origin.
+	if pool.config.Dandelion && tx.Type() == types.QiTxType {
+		return pool.stemOrFluffQiTx(tx, true)
+	}
 	// If there are no tx pool sharing clients just submit to the local pool
 	if !pool.config.SyncTxWithReturn || len(pool.config.SharingClientsEndpoints) == 0 {
 		err := pool.AddLocal(tx)

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -331,22 +331,25 @@ type TxPool struct {
 	pendingNonces      *txNoncer // Pending state tracking virtual nonces
 	currentMaxGas      uint64    // Current gas limit for transaction caps
 
-	locals         *accountSet                                     // Set of local transaction to exempt from eviction rules
-	journal        *txJournal                                      // Journal of local transaction to back up to disk
-	qiPool         *lru.Cache[common.Hash, *types.TxWithMinerFee]  // Qi pool to store Qi transactions
-	qiTxFees       *lru.Cache[[16]byte, *big.Int]                  // Recent Qi transaction fees (hash is truncated to 16 bytes to save space)
-	pending        map[common.InternalAddress]*txList              // All currently processable transactions
-	queue          map[common.InternalAddress]*txList              // Queued but non-processable transactions
-	beats          map[common.InternalAddress]time.Time            // Last heartbeat from each known account
-	all            *txLookup                                       // All transactions to allow lookups
-	priced         *txPricedList                                   // All transactions sorted by price
-	senders        *lru.Cache[common.Hash, common.InternalAddress] // Tx hash to sender lookup cache (async populated)
-	sendersCh      chan newSender                                  // Channel for async senders cache goroutine
-	feesCh         chan newFee                                     // Channel for async Qi fees cache goroutine
-	invalidQiTxsCh chan []*common.Hash                             // Channel for async invalid Qi transactions
-	SendersMu      sync.RWMutex                                    // Mutex for priority access of senders cache
-	localTxsCount  int                                             // count of txs in last 1 min. Purely for logging purpose
-	remoteTxsCount int                                             // count of txs in last 1 min. Purely for logging purpose
+	locals          *accountSet                                     // Set of local transaction to exempt from eviction rules
+	journal         *txJournal                                      // Journal of local transaction to back up to disk
+	qiPool          *lru.Cache[common.Hash, *types.TxWithMinerFee]  // Qi pool to store Qi transactions
+	qiMu            sync.RWMutex                                    // Protects qiOutpoints and qiConsolidation
+	qiOutpoints     map[types.OutPoint]common.Hash                  // Outpoint -> hash of the pooled Qi tx spending it
+	qiConsolidation map[common.Hash]struct{}                        // Qi txs that combine denominations upward; only minable in a block's first Qi slot
+	qiTxFees        *lru.Cache[[16]byte, *big.Int]                  // Recent Qi transaction fees (hash is truncated to 16 bytes to save space)
+	pending         map[common.InternalAddress]*txList              // All currently processable transactions
+	queue           map[common.InternalAddress]*txList              // Queued but non-processable transactions
+	beats           map[common.InternalAddress]time.Time            // Last heartbeat from each known account
+	all             *txLookup                                       // All transactions to allow lookups
+	priced          *txPricedList                                   // All transactions sorted by price
+	senders         *lru.Cache[common.Hash, common.InternalAddress] // Tx hash to sender lookup cache (async populated)
+	sendersCh       chan newSender                                  // Channel for async senders cache goroutine
+	feesCh          chan newFee                                     // Channel for async Qi fees cache goroutine
+	invalidQiTxsCh  chan []*common.Hash                             // Channel for async invalid Qi transactions
+	SendersMu       sync.RWMutex                                    // Mutex for priority access of senders cache
+	localTxsCount   int                                             // count of txs in last 1 min. Purely for logging purpose
+	remoteTxsCount  int                                             // count of txs in last 1 min. Purely for logging purpose
 
 	broadcastSetCache *lru.Cache[common.Hash, types.Transactions]
 	broadcastSetMu    sync.RWMutex
@@ -442,7 +445,9 @@ func NewTxPool(config TxPoolConfig, chainconfig *params.ChainConfig, chain block
 		poolSharingTxCh:    make(chan *types.Transaction, 100),
 	}
 
-	qiPool, _ := lru.New[common.Hash, *types.TxWithMinerFee](int(config.QiPoolSize))
+	pool.qiOutpoints = make(map[types.OutPoint]common.Hash)
+	pool.qiConsolidation = make(map[common.Hash]struct{})
+	qiPool, _ := lru.NewWithEvict[common.Hash, *types.TxWithMinerFee](int(config.QiPoolSize), pool.onQiTxDropped)
 	pool.qiPool = qiPool
 
 	senders, _ := lru.New[common.Hash, common.InternalAddress](int(config.MaxSenders))
@@ -726,10 +731,42 @@ func (pool *TxPool) ContentFrom(addr common.InternalAddress) (types.Transactions
 	return pending, queued
 }
 
+// QiPoolPending returns the pooled Qi transactions that are minable anywhere
+// in a block. Consolidation (denomination-combining) txs are excluded; they
+// are only valid in a block's first Qi slot and are returned by
+// QiConsolidationPending instead.
 func (pool *TxPool) QiPoolPending() []*types.TxWithMinerFee {
 	pool.mu.RLock()
 	defer pool.mu.RUnlock()
-	return pool.qiPool.Values()
+	values := pool.qiPool.Values()
+	pool.qiMu.RLock()
+	defer pool.qiMu.RUnlock()
+	pending := make([]*types.TxWithMinerFee, 0, len(values))
+	for _, tx := range values {
+		if _, ok := pool.qiConsolidation[tx.Tx().Hash()]; !ok {
+			pending = append(pending, tx)
+		}
+	}
+	return pending
+}
+
+// QiConsolidationPending returns the pooled Qi transactions that combine
+// smaller denominations into larger ones. They are only minable in the first
+// Qi slot of a block, which is exempt from CheckDenominations, so block
+// builders auction that slot to the highest-fee consolidation tx.
+func (pool *TxPool) QiConsolidationPending() []*types.TxWithMinerFee {
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
+	values := pool.qiPool.Values()
+	pool.qiMu.RLock()
+	defer pool.qiMu.RUnlock()
+	pending := make([]*types.TxWithMinerFee, 0, len(pool.qiConsolidation))
+	for _, tx := range values {
+		if _, ok := pool.qiConsolidation[tx.Tx().Hash()]; ok {
+			pending = append(pending, tx)
+		}
+	}
+	return pending
 }
 
 func (pool *TxPool) GetTxsFromBroadcastSet(hash common.Hash) (types.Transactions, error) {
@@ -1308,6 +1345,17 @@ func (pool *TxPool) addQiTxs(txs types.Transactions) []error {
 			errs = append(errs, err)
 			continue
 		}
+		// Resolve outpoint conflicts explicitly: first-seen wins unless the
+		// newcomer pays at least PriceBump percent more fee than every pooled
+		// tx it conflicts with, in which case those txs are dropped.
+		if err := pool.resolveQiConflicts(tx, txFee); err != nil {
+			pool.logger.WithFields(logrus.Fields{
+				"tx":  tx.Hash().String(),
+				"err": err,
+			}).Debug("Conflicting Qi transaction")
+			errs = append(errs, err)
+			continue
+		}
 		txWithMinerFee, err := types.NewTxWithMinerFee(tx, txFee, time.Now())
 		if err != nil {
 			errs = append(errs, err)
@@ -1319,6 +1367,7 @@ func (pool *TxPool) addQiTxs(txs types.Transactions) []error {
 
 		txHash := txWithFee.Tx().Hash()
 		pool.qiPool.Add(txHash, txWithFee)
+		pool.registerQiTx(txWithFee.Tx(), pool.isQiConsolidationTx(txWithFee.Tx()))
 		pool.queueTxEvent(txWithFee.Tx())
 		select {
 		case pool.sendersCh <- newSender{txHash, common.InternalAddress{}}: // There is no "sender" for Qi transactions, but the sig is good
@@ -1385,12 +1434,20 @@ func (pool *TxPool) addQiTxsWithoutValidationLocked(txs types.Transactions) {
 				pool.logger.Error("feesCh is full, skipping until there is room")
 			}
 		}
+		if err := pool.resolveQiConflicts(tx, fee); err != nil {
+			pool.logger.WithFields(logrus.Fields{
+				"tx":  tx.Hash().String(),
+				"err": err,
+			}).Debug("Conflicting Qi transaction, skipping re-inject")
+			continue
+		}
 		txWithMinerFee, err := types.NewTxWithMinerFee(tx, fee, time.Now())
 		if err != nil {
 			pool.logger.Error("Error creating txWithMinerFee: " + err.Error())
 			continue
 		}
 		pool.qiPool.Add(tx.Hash(), txWithMinerFee)
+		pool.registerQiTx(tx, pool.isQiConsolidationTx(tx))
 		select {
 		case pool.sendersCh <- newSender{tx.Hash(), common.InternalAddress{}}: // There is no "sender" for Qi transactions, but the sig is good
 		default:
@@ -1402,6 +1459,113 @@ func (pool *TxPool) addQiTxsWithoutValidationLocked(txs types.Transactions) {
 		}).Debug("Added qi tx to pool")
 		qiTxGauge.Add(1)
 	}
+}
+
+// onQiTxDropped is invoked by the Qi pool LRU whenever an entry leaves the
+// pool (explicit removal, expiry or capacity eviction). It keeps the outpoint
+// index and the consolidation set in sync with the pool contents.
+// The LRU invokes this callback under its own lock, so qiPool methods must
+// never be called while holding qiMu or the lock order would invert.
+func (pool *TxPool) onQiTxDropped(hash common.Hash, tx *types.TxWithMinerFee) {
+	pool.qiMu.Lock()
+	defer pool.qiMu.Unlock()
+	for _, txIn := range tx.Tx().TxIn() {
+		if h, ok := pool.qiOutpoints[txIn.PreviousOutPoint]; ok && h == hash {
+			delete(pool.qiOutpoints, txIn.PreviousOutPoint)
+		}
+	}
+	delete(pool.qiConsolidation, hash)
+}
+
+// registerQiTx records the outpoints spent by a tx that was just added to the
+// Qi pool, and whether it is a consolidation (first-slot-only) tx.
+func (pool *TxPool) registerQiTx(tx *types.Transaction, consolidation bool) {
+	pool.qiMu.Lock()
+	defer pool.qiMu.Unlock()
+	for _, txIn := range tx.TxIn() {
+		pool.qiOutpoints[txIn.PreviousOutPoint] = tx.Hash()
+	}
+	if consolidation {
+		pool.qiConsolidation[tx.Hash()] = struct{}{}
+	} else {
+		delete(pool.qiConsolidation, tx.Hash())
+	}
+}
+
+// resolveQiConflicts enforces an explicit replacement policy for Qi txs that
+// spend an outpoint already spent by a pooled tx: the newcomer is rejected
+// unless its fee is at least PriceBump percent higher than the combined fee
+// of every pooled tx it conflicts with, in which case the conflicting txs are
+// dropped. Stale index entries pointing at txs no longer in the pool are
+// ignored.
+func (pool *TxPool) resolveQiConflicts(tx *types.Transaction, txFee *big.Int) error {
+	conflicts := make(map[common.Hash]struct{})
+	pool.qiMu.RLock()
+	for _, txIn := range tx.TxIn() {
+		if h, ok := pool.qiOutpoints[txIn.PreviousOutPoint]; ok && h != tx.Hash() {
+			conflicts[h] = struct{}{}
+		}
+	}
+	pool.qiMu.RUnlock()
+	if len(conflicts) == 0 {
+		return nil
+	}
+	oldFees := new(big.Int)
+	conflictingTxs := make([]common.Hash, 0, len(conflicts))
+	for h := range conflicts {
+		if old, ok := pool.qiPool.Peek(h); ok {
+			oldFees.Add(oldFees, old.MinerFee())
+			conflictingTxs = append(conflictingTxs, h)
+		}
+	}
+	if len(conflictingTxs) == 0 {
+		return nil
+	}
+	threshold := new(big.Int).Mul(oldFees, big.NewInt(int64(100+pool.config.PriceBump)))
+	threshold.Div(threshold, big.NewInt(100))
+	if txFee.Cmp(threshold) < 0 {
+		return fmt.Errorf("qi tx %s spends outpoints of %d pooled tx(s) and does not pay %d%% more fee to replace them", tx.Hash().String(), len(conflictingTxs), pool.config.PriceBump)
+	}
+	for _, h := range conflictingTxs {
+		pool.qiPool.Remove(h) // eviction callback cleans the outpoint index
+	}
+	qiTxGauge.Sub(float64(len(conflictingTxs)))
+	return nil
+}
+
+// isQiConsolidationTx reports whether a Qi tx combines smaller denominations
+// into larger ones. Such txs fail CheckDenominations and are only minable in
+// the first Qi slot of a block, which is exempt from that rule.
+func (pool *TxPool) isQiConsolidationTx(tx *types.Transaction) bool {
+	inputs := make(map[uint]uint64)
+	for _, txIn := range tx.TxIn() {
+		utxo := rawdb.GetUTXO(pool.db, txIn.PreviousOutPoint.TxHash, txIn.PreviousOutPoint.Index)
+		if utxo == nil {
+			return false
+		}
+		inputs[uint(utxo.Denomination)]++
+	}
+	return CheckDenominations(inputs, QiTxOutputDenominations(tx, pool.chainconfig.Location)) != nil
+}
+
+// QiTxPoolStatus describes the pool state of a Qi transaction.
+type QiTxPoolStatus struct {
+	Pending       bool     `json:"pending"`
+	FirstSlotOnly bool     `json:"firstSlotOnly"`
+	Fee           *big.Int `json:"fee"`
+}
+
+// QiTxStatus returns the pool status of a Qi transaction.
+func (pool *TxPool) QiTxStatus(hash common.Hash) *QiTxPoolStatus {
+	status := &QiTxPoolStatus{}
+	if tx, ok := pool.qiPool.Peek(hash); ok {
+		status.Pending = true
+		status.Fee = tx.MinerFee()
+		pool.qiMu.RLock()
+		_, status.FirstSlotOnly = pool.qiConsolidation[hash]
+		pool.qiMu.RUnlock()
+	}
+	return status
 }
 
 func (pool *TxPool) RemoveQiTxs(txs []*common.Hash) {
@@ -1465,6 +1629,13 @@ func (pool *TxPool) Status(hashes []common.Hash) []TxStatus {
 		if tx == nil {
 			continue
 		}
+		if tx.Type() == types.QiTxType {
+			// Qi txs have no sender; presence in the Qi pool means pending
+			if pool.qiPool.Contains(hash) {
+				status[i] = TxStatusPending
+			}
+			continue
+		}
 		from, err := types.Sender(pool.signer, tx) // already validated
 		if err != nil {
 			pool.logger.WithField("err", err).Error("Error calculating sender in txpool Status")
@@ -1502,7 +1673,7 @@ func (pool *TxPool) Get(hash common.Hash) *types.Transaction {
 // Has returns an indicator whether txpool has a transaction cached with the
 // given hash.
 func (pool *TxPool) Has(hash common.Hash) bool {
-	return pool.all.Get(hash) != nil
+	return pool.all.Get(hash) != nil || pool.qiPool.Contains(hash)
 }
 
 // removeTx removes a single transaction from the queue, moving all subsequent

--- a/core/worker.go
+++ b/core/worker.go
@@ -2878,8 +2878,8 @@ func (w *worker) processQiTx(tx *types.Transaction, env *environment, primeTermi
 				types.MaxDenomination)
 			return errors.New(str)
 		}
-		if txOut.Lock != nil && txOut.Lock.Sign() != 0 {
-			return errors.New("QiTx output has non-zero lock")
+		if err := validateQiTxOutLock(&txOut, env.wo, location); err != nil {
+			return err
 		}
 		outputs[uint(txOut.Denomination)] += 1
 		totalQitOut.Add(totalQitOut, types.Denominations[txOut.Denomination])

--- a/core/worker.go
+++ b/core/worker.go
@@ -1573,7 +1573,7 @@ func (w *worker) commitTransaction(env *environment, parent *types.WorkObject, t
 
 var qiTxErrs uint64
 
-func (w *worker) commitTransactions(env *environment, primeTerminus *types.WorkObject, parent *types.WorkObject, txs *types.TransactionsByPriceAndNonce) error {
+func (w *worker) commitTransactions(env *environment, primeTerminus *types.WorkObject, parent *types.WorkObject, txs *types.TransactionsByPriceAndNonce, consolidationTxs []*types.TxWithMinerFee) error {
 	qiTxsToRemove := make([]*common.Hash, 0)
 	gasLimit := env.wo.GasLimit()
 	if env.gasPool == nil {
@@ -1622,6 +1622,39 @@ func (w *worker) commitTransactions(env *environment, primeTerminus *types.WorkO
 		}
 	}
 	firstQiTx := true
+	// Consolidation auction: the first Qi tx in a block is exempt from the
+	// denomination-combining rule, so award that slot to the highest-fee
+	// consolidation transaction that fits.
+	for _, cTx := range consolidationTxs {
+		if env.gasPool.Gas() < params.TxGas {
+			break
+		}
+		tx := cTx.Tx()
+		if types.CalculateBlockQiTxGas(tx, env.qiGasScalingFactor, w.hc.NodeLocation()) > gasLimit {
+			hash := tx.Hash()
+			qiTxsToRemove = append(qiTxsToRemove, &hash)
+			continue
+		}
+		if err := w.processQiTx(tx, env, primeTerminus, parent, true); err != nil {
+			if strings.Contains(err.Error(), "emits too many") || strings.Contains(err.Error(), "uses too much gas") || errors.Is(err, types.ErrGasLimitReached) {
+				// The block is too full for this consolidation tx; leave it pooled
+				break
+			}
+			if strings.Contains(err.Error(), "double spends") {
+				// Conflicts with a tx already committed in this block; try the next candidate
+				continue
+			}
+			hash := tx.Hash()
+			w.logger.WithFields(log.Fields{
+				"err": err,
+				"tx":  hash.Hex(),
+			}).Debug("Error processing consolidation QiTx")
+			qiTxsToRemove = append(qiTxsToRemove, &hash)
+			continue
+		}
+		firstQiTx = false
+		break // the first-slot auction is settled
+	}
 	for {
 		// If we don't have enough gas for any further transactions then we're done
 		if env.gasPool.Gas() < params.TxGas {
@@ -2498,7 +2531,7 @@ func (w *worker) fillTransactions(env *environment, primeTerminus *types.WorkObj
 	}).Info("ETXs and fill")
 	if !fill {
 		if etxs {
-			return w.commitTransactions(env, primeTerminus, block, &types.TransactionsByPriceAndNonce{})
+			return w.commitTransactions(env, primeTerminus, block, &types.TransactionsByPriceAndNonce{}, nil)
 		}
 		return nil
 	}
@@ -2532,9 +2565,30 @@ func (w *worker) fillTransactions(env *environment, primeTerminus *types.WorkObj
 		pendingQiTxsWithQuaiFee = append(pendingQiTxsWithQuaiFee, qiTx)
 	}
 
-	if len(pending) > 0 || len(pendingQiTxsWithQuaiFee) > 0 || etxs {
+	// Consolidation auction candidates: denomination-combining txs compete
+	// for the single first-Qi-tx slot, highest fee first.
+	consolidationTxs := make([]*types.TxWithMinerFee, 0)
+	for _, tx := range w.txPool.QiConsolidationPending() {
+		qiFeeInQuai := misc.QiToQuai(env.wo, exchangeRate, env.wo.Difficulty(), tx.MinerFee())
+		minerFeeInQuai := new(big.Int).Div(qiFeeInQuai, big.NewInt(int64(types.CalculateBlockQiTxGas(tx.Tx(), env.qiGasScalingFactor, w.hc.NodeLocation()))))
+		if minerFeeInQuai.Cmp(block.BaseFee()) < 0 {
+			w.logger.Debugf("consolidation qi tx has less fee than min base fee: have %s, want %s", minerFeeInQuai, block.BaseFee())
+			continue
+		}
+		qiTx, err := types.NewTxWithMinerFee(tx.Tx(), minerFeeInQuai, time.Now())
+		if err != nil {
+			w.logger.WithField("err", err).Error("Error creating new tx with miner Fee for consolidation Qi TX", tx.Tx().Hash())
+			continue
+		}
+		consolidationTxs = append(consolidationTxs, qiTx)
+	}
+	sort.SliceStable(consolidationTxs, func(i, j int) bool {
+		return consolidationTxs[i].MinerFee().Cmp(consolidationTxs[j].MinerFee()) > 0
+	})
+
+	if len(pending) > 0 || len(pendingQiTxsWithQuaiFee) > 0 || len(consolidationTxs) > 0 || etxs {
 		txs := types.NewTransactionsByPriceAndNonce(env.signer, pendingQiTxsWithQuaiFee, pending)
-		return w.commitTransactions(env, primeTerminus, block, txs)
+		return w.commitTransactions(env, primeTerminus, block, txs, consolidationTxs)
 	}
 	return nil
 }

--- a/core/worker.go
+++ b/core/worker.go
@@ -2856,8 +2856,11 @@ func (w *worker) processQiTx(tx *types.Transaction, env *environment, primeTermi
 	if tx.ChainId().Cmp(w.chainConfig.ChainID) != 0 {
 		return fmt.Errorf("tx %032x has wrong chain ID", tx.Hash())
 	}
-	if len(tx.Data()) != 0 && (len(tx.Data()) != params.MaxQiTxDataLength && len(tx.Data()) != common.AddressLength) {
+	if !qiTxDataLengthValid(tx, env.wo) {
 		return fmt.Errorf("tx %v emits UTXO with data %d not equal to either address length or MaxQiTxDataLength %d", tx.Hash().Hex(), len(tx.Data()), params.MaxQiTxDataLength)
+	}
+	if err := validateQiTxLockTime(tx, env.wo, location); err != nil {
+		return err
 	}
 	// Wrap Qi Transaction
 	if len(tx.Data()) == common.AddressLength && !common.BytesToAddress(tx.Data()[:], parent.Location()).IsInQuaiLedgerScope() {

--- a/crypto/adaptor/adaptor.go
+++ b/crypto/adaptor/adaptor.go
@@ -1,0 +1,419 @@
+// Package adaptor implements Schnorr adaptor signatures over secp256k1, for
+// both single keys and MuSig2 aggregate keys.
+//
+// An adaptor signature is a signature that is "missing" a secret scalar. Given
+// an adaptor point T = t*G, a signer can produce a value that is not yet a
+// valid signature, but which anyone can:
+//
+//   - verify is well formed and will become valid once t is supplied,
+//   - complete into a valid signature given t (Adapt), and
+//   - use, together with the completed signature, to recover t (Extract).
+//
+// That last property is what makes payments atomic: publishing the completed
+// signature on chain necessarily reveals t to the counterparty, who can then
+// complete their own adaptor signature one hop upstream. This is the basis of
+// point timelocked contracts (PTLCs), the scriptless replacement for HTLCs.
+//
+// The signatures produced here are ordinary BIP-340 Schnorr signatures, and
+// the MuSig2 variant aggregates keys exactly as consensus does
+// (musig2.AggregateKeys(keys, false)), so completed signatures verify against
+// the same aggregate key a Qi UTXO is addressed to.
+//
+// # Construction
+//
+// The signer commits to the shifted nonce point R' = R + T, where R is the
+// nonce point it actually knows the discrete log of. The challenge is
+// computed over R' as usual, so the resulting scalar is short by exactly t.
+// BIP-340 signatures carry only x(R'), so verification lifts it to the
+// even-Y representative; when R' has an odd Y coordinate the signer negates
+// its nonce and completion subtracts t rather than adding it. The Negated
+// field records which case applies.
+//
+// # Security
+//
+// Nonces must be uniformly random and never reused across signing sessions;
+// reuse leaks the private key. The MuSig2 API takes nonces from the caller
+// (as MuSig2 requires an interactive nonce exchange) and callers must
+// generate them with musig2.GenNonces and use each secret nonce exactly once.
+package adaptor
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+)
+
+// Signature is an adaptor signature: a scalar S that becomes a valid BIP-340
+// signature over the nonce point R once the discrete log of the adaptor point
+// is added (or subtracted, when Negated is set).
+type Signature struct {
+	// R is the shifted nonce point R' = R + T that the completed signature
+	// will commit to.
+	R *btcec.PublicKey
+
+	// S is the adaptor scalar: the signature scalar less the adaptor secret.
+	S *btcec.ModNScalar
+
+	// Negated reports whether R had an odd Y coordinate, in which case
+	// completion subtracts the adaptor secret instead of adding it.
+	Negated bool
+}
+
+var (
+	ErrNilArgument     = errors.New("adaptor: nil argument")
+	ErrInvalidAdaptor  = errors.New("adaptor: adaptor signature is invalid")
+	ErrSecretMismatch  = errors.New("adaptor: secret does not match the adaptor point")
+	ErrNoPartialSigs   = errors.New("adaptor: no partial signatures provided")
+	ErrPointAtInfinity = errors.New("adaptor: computed point is at infinity")
+)
+
+// NewSecret generates a random adaptor secret t and its point T = t*G.
+func NewSecret() (*btcec.ModNScalar, *btcec.PublicKey, error) {
+	key, err := btcec.NewPrivateKey()
+	if err != nil {
+		return nil, nil, err
+	}
+	secret := new(btcec.ModNScalar)
+	secret.Set(&key.Key)
+	return secret, key.PubKey(), nil
+}
+
+// PointFromSecret returns T = t*G for an adaptor secret t.
+func PointFromSecret(secret *btcec.ModNScalar) (*btcec.PublicKey, error) {
+	if secret == nil {
+		return nil, ErrNilArgument
+	}
+	if secret.IsZero() {
+		return nil, ErrPointAtInfinity
+	}
+	var point btcec.JacobianPoint
+	btcec.ScalarBaseMultNonConst(secret, &point)
+	point.ToAffine()
+	return btcec.NewPublicKey(&point.X, &point.Y), nil
+}
+
+// challenge computes the BIP-340 challenge e = H(x(R) || x(Q) || m).
+func challenge(nonce, pubKey *btcec.PublicKey, msg [32]byte) *btcec.ModNScalar {
+	var buf bytes.Buffer
+	buf.Write(schnorr.SerializePubKey(nonce))
+	buf.Write(schnorr.SerializePubKey(pubKey))
+	buf.Write(msg[:])
+	hash := chainhash.TaggedHash(musig2.ChallengeHashTag, buf.Bytes())
+	e := new(btcec.ModNScalar)
+	e.SetByteSlice(hash[:])
+	return e
+}
+
+// isOdd reports whether a public key has an odd Y coordinate.
+func isOdd(key *btcec.PublicKey) bool {
+	return key.SerializeCompressed()[0] == secp256k1PubKeyFormatCompressedOdd
+}
+
+// secp256k1PubKeyFormatCompressedOdd is the compressed-point prefix for an
+// odd Y coordinate.
+const secp256k1PubKeyFormatCompressedOdd = 0x03
+
+// AddPoints returns a + b. It is exported because PTLC route construction
+// blinds adaptor points per hop by adding an offset point.
+func AddPoints(a, b *btcec.PublicKey) (*btcec.PublicKey, error) {
+	return addPoints(a, b)
+}
+
+// addPoints returns a + b.
+func addPoints(a, b *btcec.PublicKey) (*btcec.PublicKey, error) {
+	var aJ, bJ, sum btcec.JacobianPoint
+	a.AsJacobian(&aJ)
+	b.AsJacobian(&bJ)
+	btcec.AddNonConst(&aJ, &bJ, &sum)
+	if (sum.X.IsZero() && sum.Y.IsZero()) || sum.Z.IsZero() {
+		return nil, ErrPointAtInfinity
+	}
+	sum.ToAffine()
+	return btcec.NewPublicKey(&sum.X, &sum.Y), nil
+}
+
+// negatePoint returns -p.
+func negatePoint(p *btcec.PublicKey) *btcec.PublicKey {
+	var pJ btcec.JacobianPoint
+	p.AsJacobian(&pJ)
+	pJ.ToAffine()
+	pJ.Y.Negate(1)
+	pJ.Y.Normalize()
+	return btcec.NewPublicKey(&pJ.X, &pJ.Y)
+}
+
+// evenY returns the even-Y representative of a point, which is what BIP-340
+// verification lifts an x-only coordinate to.
+func evenY(p *btcec.PublicKey) *btcec.PublicKey {
+	if isOdd(p) {
+		return negatePoint(p)
+	}
+	return p
+}
+
+// PreSign produces an adaptor signature over msg with a single private key,
+// locked to the adaptor point T.
+func PreSign(privKey *btcec.PrivateKey, msg [32]byte, T *btcec.PublicKey) (*Signature, error) {
+	if privKey == nil || T == nil {
+		return nil, ErrNilArgument
+	}
+	// A fresh random nonce per call. Never make this deterministic in a
+	// multi-party setting; see the package security note.
+	nonceKey, err := btcec.NewPrivateKey()
+	if err != nil {
+		return nil, err
+	}
+	k := new(btcec.ModNScalar)
+	k.Set(&nonceKey.Key)
+
+	shiftedNonce, err := addPoints(nonceKey.PubKey(), T)
+	if err != nil {
+		return nil, err
+	}
+
+	// BIP-340 verification lifts x(R') to even Y, so when R' is odd the
+	// signer negates its nonce and completion subtracts the secret.
+	negated := isOdd(shiftedNonce)
+	if negated {
+		k.Negate()
+	}
+
+	pubKey := privKey.PubKey()
+	d := new(btcec.ModNScalar)
+	d.Set(&privKey.Key)
+	if isOdd(pubKey) {
+		d.Negate()
+	}
+
+	e := challenge(shiftedNonce, pubKey, msg)
+	s := new(btcec.ModNScalar)
+	s.Add(k).Add(e.Mul(d))
+
+	sig := &Signature{R: shiftedNonce, S: s, Negated: negated}
+	if !sig.Verify(pubKey, msg, T) {
+		return nil, ErrInvalidAdaptor
+	}
+	return sig, nil
+}
+
+// Verify checks that the adaptor signature is well formed for the given
+// public key, message and adaptor point: that completing it with the discrete
+// log of T would yield a valid BIP-340 signature. It does not require, and
+// tells the verifier nothing about, the adaptor secret.
+//
+// For a MuSig2 adaptor signature, pubKey is the aggregate key.
+func (sig *Signature) Verify(pubKey *btcec.PublicKey, msg [32]byte, T *btcec.PublicKey) bool {
+	if sig == nil || sig.R == nil || sig.S == nil || pubKey == nil || T == nil {
+		return false
+	}
+	// The completed signature satisfies s*G = R_even + e*Q_even, with
+	// s = S + t (or S - t when negated), so the adaptor scalar satisfies
+	//   S*G + T = R_even + e*Q_even   (not negated)
+	//   S*G - T = R_even + e*Q_even   (negated)
+	var sG btcec.JacobianPoint
+	btcec.ScalarBaseMultNonConst(sig.S, &sG)
+	sG.ToAffine()
+	if sG.X.IsZero() && sG.Y.IsZero() {
+		return false
+	}
+	left, err := addPoints(btcec.NewPublicKey(&sG.X, &sG.Y), adaptorTerm(T, sig.Negated))
+	if err != nil {
+		return false
+	}
+
+	e := challenge(sig.R, pubKey, msg)
+	var qJ, eQ btcec.JacobianPoint
+	evenY(pubKey).AsJacobian(&qJ)
+	btcec.ScalarMultNonConst(e, &qJ, &eQ)
+	eQ.ToAffine()
+	if eQ.Z.IsZero() {
+		return false
+	}
+	right, err := addPoints(evenY(sig.R), btcec.NewPublicKey(&eQ.X, &eQ.Y))
+	if err != nil {
+		return false
+	}
+	return left.IsEqual(right)
+}
+
+// adaptorTerm returns T or -T depending on the nonce parity.
+func adaptorTerm(T *btcec.PublicKey, negated bool) *btcec.PublicKey {
+	if negated {
+		return negatePoint(T)
+	}
+	return T
+}
+
+// Adapt completes the adaptor signature with the adaptor secret, producing a
+// standard BIP-340 Schnorr signature.
+func (sig *Signature) Adapt(secret *btcec.ModNScalar) (*schnorr.Signature, error) {
+	if sig == nil || sig.S == nil || sig.R == nil || secret == nil {
+		return nil, ErrNilArgument
+	}
+	s := new(btcec.ModNScalar)
+	s.Set(sig.S)
+	if sig.Negated {
+		var negated btcec.ModNScalar
+		negated.Set(secret)
+		negated.Negate()
+		s.Add(&negated)
+	} else {
+		s.Add(secret)
+	}
+	var rX btcec.FieldVal
+	rX.SetByteSlice(schnorr.SerializePubKey(sig.R))
+	return schnorr.NewSignature(&rX, s), nil
+}
+
+// Extract recovers the adaptor secret from a completed signature, given the
+// adaptor signature it was completed from. This is what lets a routing node
+// learn the payment secret from an on-chain (or off-chain) settlement and
+// claim the corresponding payment one hop upstream.
+func (sig *Signature) Extract(final *schnorr.Signature) (*btcec.ModNScalar, error) {
+	if sig == nil || sig.S == nil || final == nil {
+		return nil, ErrNilArgument
+	}
+	serialized := final.Serialize()
+	if len(serialized) != 64 {
+		return nil, fmt.Errorf("adaptor: unexpected signature length %d", len(serialized))
+	}
+	finalS := new(btcec.ModNScalar)
+	if overflow := finalS.SetByteSlice(serialized[32:]); overflow {
+		return nil, errors.New("adaptor: signature scalar overflows the group order")
+	}
+
+	// final = S + t  =>  t = final - S       (not negated)
+	// final = S - t  =>  t = S - final       (negated)
+	secret := new(btcec.ModNScalar)
+	if sig.Negated {
+		secret.Set(sig.S)
+		var negated btcec.ModNScalar
+		negated.Set(finalS)
+		negated.Negate()
+		secret.Add(&negated)
+	} else {
+		secret.Set(finalS)
+		var negated btcec.ModNScalar
+		negated.Set(sig.S)
+		negated.Negate()
+		secret.Add(&negated)
+	}
+	if secret.IsZero() {
+		return nil, ErrSecretMismatch
+	}
+	return secret, nil
+}
+
+// VerifySecret checks that a secret is the discrete log of an adaptor point.
+func VerifySecret(secret *btcec.ModNScalar, T *btcec.PublicKey) bool {
+	point, err := PointFromSecret(secret)
+	if err != nil {
+		return false
+	}
+	return point.IsEqual(T)
+}
+
+// TweakCombinedNonce shifts an aggregated MuSig2 public nonce by the adaptor
+// point, by adding T to the first of its two nonce points. Every signer in
+// the session must sign against this tweaked nonce; the resulting combined
+// signature is then short by exactly the adaptor secret.
+func TweakCombinedNonce(combinedNonce [musig2.PubNonceSize]byte, T *btcec.PublicKey) ([musig2.PubNonceSize]byte, error) {
+	var out [musig2.PubNonceSize]byte
+	if T == nil {
+		return out, ErrNilArgument
+	}
+	const pointSize = musig2.PubNonceSize / 2
+	first, err := btcec.ParsePubKey(combinedNonce[:pointSize])
+	if err != nil {
+		return out, err
+	}
+	shifted, err := addPoints(first, T)
+	if err != nil {
+		return out, err
+	}
+	copy(out[:pointSize], shifted.SerializeCompressed())
+	copy(out[pointSize:], combinedNonce[pointSize:])
+	return out, nil
+}
+
+// PreSignPartial produces one signer's partial signature in a MuSig2 adaptor
+// signing session. combinedNonce is the untweaked aggregate of all signers'
+// public nonces; this function applies the adaptor tweak itself so that every
+// signer derives the same shifted nonce.
+//
+// Keys are aggregated unsorted, matching Qi consensus verification.
+func PreSignPartial(secNonce [musig2.SecNonceSize]byte, privKey *btcec.PrivateKey,
+	combinedNonce [musig2.PubNonceSize]byte, pubKeys []*btcec.PublicKey,
+	msg [32]byte, T *btcec.PublicKey) (*musig2.PartialSignature, error) {
+
+	if privKey == nil || T == nil {
+		return nil, ErrNilArgument
+	}
+	tweaked, err := TweakCombinedNonce(combinedNonce, T)
+	if err != nil {
+		return nil, err
+	}
+	return musig2.Sign(secNonce, privKey, tweaked, pubKeys, msg)
+}
+
+// CombinePartials aggregates partial adaptor signatures into a single adaptor
+// signature over the MuSig2 aggregate key. It verifies the result before
+// returning, so a malformed or malicious partial signature is caught here
+// rather than at settlement time.
+func CombinePartials(partialSigs []*musig2.PartialSignature, pubKeys []*btcec.PublicKey,
+	msg [32]byte, T *btcec.PublicKey) (*Signature, error) {
+
+	if len(partialSigs) == 0 {
+		return nil, ErrNoPartialSigs
+	}
+	if T == nil {
+		return nil, ErrNilArgument
+	}
+	shiftedNonce := partialSigs[0].R
+	if shiftedNonce == nil {
+		return nil, ErrNilArgument
+	}
+	s := new(btcec.ModNScalar)
+	for _, partial := range partialSigs {
+		if partial == nil || partial.S == nil {
+			return nil, ErrNilArgument
+		}
+		if partial.R == nil || !partial.R.IsEqual(shiftedNonce) {
+			return nil, errors.New("adaptor: partial signatures disagree on the nonce point")
+		}
+		s.Add(partial.S)
+	}
+
+	aggKey, err := AggregateKeys(pubKeys)
+	if err != nil {
+		return nil, err
+	}
+	sig := &Signature{R: shiftedNonce, S: s, Negated: isOdd(shiftedNonce)}
+	if !sig.Verify(aggKey, msg, T) {
+		return nil, ErrInvalidAdaptor
+	}
+	return sig, nil
+}
+
+// AggregateKeys returns the MuSig2 aggregate public key for a set of signers,
+// aggregated exactly as Qi consensus does (unsorted, untweaked). A Qi address
+// derived from this key is spendable by a signature from the full signer set
+// and is indistinguishable on chain from an ordinary single-key address.
+func AggregateKeys(pubKeys []*btcec.PublicKey) (*btcec.PublicKey, error) {
+	if len(pubKeys) == 0 {
+		return nil, ErrNilArgument
+	}
+	if len(pubKeys) == 1 {
+		return pubKeys[0], nil
+	}
+	aggKey, _, _, err := musig2.AggregateKeys(pubKeys, false)
+	if err != nil {
+		return nil, err
+	}
+	return aggKey.FinalKey, nil
+}

--- a/crypto/adaptor/adaptor_test.go
+++ b/crypto/adaptor/adaptor_test.go
@@ -1,0 +1,329 @@
+package adaptor_test
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
+	"github.com/dominant-strategies/go-quai/crypto/adaptor"
+)
+
+func testMsg(seed byte) [32]byte {
+	var msg [32]byte
+	for i := range msg {
+		msg[i] = seed + byte(i)
+	}
+	return msg
+}
+
+func newKey(t *testing.T) *btcec.PrivateKey {
+	t.Helper()
+	key, err := btcec.NewPrivateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return key
+}
+
+// TestSingleKeyRoundTrip covers the full PTLC lifecycle for a single key:
+// pre-sign, verify without the secret, complete, verify as a standard BIP-340
+// signature, and recover the secret from the completed signature.
+func TestSingleKeyRoundTrip(t *testing.T) {
+	// Run repeatedly so both nonce parities are exercised.
+	for i := 0; i < 32; i++ {
+		key := newKey(t)
+		msg := testMsg(byte(i))
+		secret, point, err := adaptor.NewSecret()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		sig, err := adaptor.PreSign(key, msg, point)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !sig.Verify(key.PubKey(), msg, point) {
+			t.Fatal("adaptor signature failed verification")
+		}
+
+		final, err := sig.Adapt(secret)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !final.Verify(msg[:], key.PubKey()) {
+			t.Fatal("completed signature is not a valid BIP-340 signature")
+		}
+
+		recovered, err := sig.Extract(final)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !recovered.Equals(secret) {
+			t.Fatal("extracted secret does not match the original")
+		}
+		if !adaptor.VerifySecret(recovered, point) {
+			t.Fatal("extracted secret is not the discrete log of the adaptor point")
+		}
+	}
+}
+
+func TestSingleKeyRejectsBadInputs(t *testing.T) {
+	key := newKey(t)
+	msg := testMsg(1)
+	secret, point, err := adaptor.NewSecret()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sig, err := adaptor.PreSign(key, msg, point)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wrong adaptor point.
+	_, otherPoint, err := adaptor.NewSecret()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sig.Verify(key.PubKey(), msg, otherPoint) {
+		t.Fatal("verified against the wrong adaptor point")
+	}
+	// Wrong message.
+	if sig.Verify(key.PubKey(), testMsg(2), point) {
+		t.Fatal("verified against the wrong message")
+	}
+	// Wrong public key.
+	if sig.Verify(newKey(t).PubKey(), msg, point) {
+		t.Fatal("verified against the wrong public key")
+	}
+	// Completing with the wrong secret must not yield a valid signature.
+	otherSecret, _, err := adaptor.NewSecret()
+	if err != nil {
+		t.Fatal(err)
+	}
+	bad, err := sig.Adapt(otherSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bad.Verify(msg[:], key.PubKey()) {
+		t.Fatal("completing with the wrong secret produced a valid signature")
+	}
+	// Tampering with the adaptor scalar must break verification.
+	tampered := &adaptor.Signature{R: sig.R, S: new(btcec.ModNScalar).SetInt(7), Negated: sig.Negated}
+	if tampered.Verify(key.PubKey(), msg, point) {
+		t.Fatal("verified a tampered adaptor signature")
+	}
+	_ = secret
+}
+
+// musigSession runs a full two-round MuSig2 adaptor signing session across
+// the given keys and returns the combined adaptor signature.
+func musigSession(t *testing.T, keys []*btcec.PrivateKey, msg [32]byte, point *btcec.PublicKey) (*adaptor.Signature, *btcec.PublicKey) {
+	t.Helper()
+	pubKeys := make([]*btcec.PublicKey, len(keys))
+	nonces := make([]*musig2.Nonces, len(keys))
+	pubNonces := make([][musig2.PubNonceSize]byte, len(keys))
+	for i, key := range keys {
+		pubKeys[i] = key.PubKey()
+		nonce, err := musig2.GenNonces(musig2.WithPublicKey(key.PubKey()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		nonces[i] = nonce
+		pubNonces[i] = nonce.PubNonce
+	}
+	combinedNonce, err := musig2.AggregateNonces(pubNonces)
+	if err != nil {
+		t.Fatal(err)
+	}
+	partials := make([]*musig2.PartialSignature, len(keys))
+	for i, key := range keys {
+		partial, err := adaptor.PreSignPartial(nonces[i].SecNonce, key, combinedNonce, pubKeys, msg, point)
+		if err != nil {
+			t.Fatal(err)
+		}
+		partials[i] = partial
+	}
+	sig, err := adaptor.CombinePartials(partials, pubKeys, msg, point)
+	if err != nil {
+		t.Fatal(err)
+	}
+	aggKey, err := adaptor.AggregateKeys(pubKeys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return sig, aggKey
+}
+
+// TestMuSig2RoundTrip is the construction channels actually use: a 2-of-2
+// adaptor signature that completes into a signature valid under the
+// aggregate key, exactly as Qi consensus verifies it.
+func TestMuSig2RoundTrip(t *testing.T) {
+	for i := 0; i < 16; i++ {
+		keys := []*btcec.PrivateKey{newKey(t), newKey(t)}
+		msg := testMsg(byte(i))
+		secret, point, err := adaptor.NewSecret()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		sig, aggKey := musigSession(t, keys, msg, point)
+		if !sig.Verify(aggKey, msg, point) {
+			t.Fatal("combined adaptor signature failed verification")
+		}
+
+		final, err := sig.Adapt(secret)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !final.Verify(msg[:], aggKey) {
+			t.Fatal("completed MuSig2 signature is not valid under the aggregate key")
+		}
+
+		recovered, err := sig.Extract(final)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !recovered.Equals(secret) {
+			t.Fatal("extracted secret does not match")
+		}
+	}
+}
+
+// TestMuSig2AggregateMatchesConsensus pins the aggregate key to what the
+// consensus code computes, since a Qi UTXO is addressed to its hash.
+func TestMuSig2AggregateMatchesConsensus(t *testing.T) {
+	keys := []*btcec.PrivateKey{newKey(t), newKey(t), newKey(t)}
+	pubKeys := make([]*btcec.PublicKey, len(keys))
+	for i, key := range keys {
+		pubKeys[i] = key.PubKey()
+	}
+	got, err := adaptor.AggregateKeys(pubKeys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Mirrors ValidateQiTxOutputsAndSignature.
+	want, _, _, err := musig2.AggregateKeys(pubKeys, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.IsEqual(want.FinalKey) {
+		t.Fatal("aggregate key does not match consensus key aggregation")
+	}
+}
+
+// TestMuSig2ThreeParty covers aggregate sizes beyond the 2-of-2 channel case.
+func TestMuSig2ThreeParty(t *testing.T) {
+	keys := []*btcec.PrivateKey{newKey(t), newKey(t), newKey(t)}
+	msg := testMsg(9)
+	secret, point, err := adaptor.NewSecret()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sig, aggKey := musigSession(t, keys, msg, point)
+	final, err := sig.Adapt(secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !final.Verify(msg[:], aggKey) {
+		t.Fatal("three-party completed signature invalid")
+	}
+}
+
+// TestAtomicityAcrossHops is the property routing depends on: the same
+// secret completes adaptor signatures held by different, unrelated signers,
+// so settling downstream hands the upstream hop what it needs to settle too.
+func TestAtomicityAcrossHops(t *testing.T) {
+	secret, point, err := adaptor.NewSecret()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Hop 1: A -> B, a 2-of-2 channel. Hop 2: B -> C, a different channel.
+	hop1Keys := []*btcec.PrivateKey{newKey(t), newKey(t)}
+	hop2Keys := []*btcec.PrivateKey{newKey(t), newKey(t)}
+	msg1, msg2 := testMsg(11), testMsg(22)
+
+	sig1, agg1 := musigSession(t, hop1Keys, msg1, point)
+	sig2, agg2 := musigSession(t, hop2Keys, msg2, point)
+
+	// The downstream hop settles first, publishing a completed signature.
+	final2, err := sig2.Adapt(secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !final2.Verify(msg2[:], agg2) {
+		t.Fatal("downstream settlement invalid")
+	}
+
+	// The upstream node observes it and recovers the secret...
+	recovered, err := sig2.Extract(final2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// ...then uses it to settle its own, entirely separate, adaptor signature.
+	final1, err := sig1.Adapt(recovered)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !final1.Verify(msg1[:], agg1) {
+		t.Fatal("upstream settlement with the recovered secret failed: routing is not atomic")
+	}
+}
+
+// TestBlindedPointsStayConsistent checks the decorrelation property: hops use
+// different points, but the offsets compose so settlement still cascades.
+func TestBlindedPointsStayConsistent(t *testing.T) {
+	secret, point, err := adaptor.NewSecret()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Upstream hop is locked to a blinded point T' = T + r*G.
+	blind, blindPoint, err := adaptor.NewSecret()
+	if err != nil {
+		t.Fatal(err)
+	}
+	blinded, err := adaptor.AddPoints(point, blindPoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keys := []*btcec.PrivateKey{newKey(t), newKey(t)}
+	msg := testMsg(33)
+	sig, aggKey := musigSession(t, keys, msg, blinded)
+
+	// Knowing t and r, the blinded secret is t + r.
+	blindedSecret := new(btcec.ModNScalar)
+	blindedSecret.Set(secret).Add(blind)
+	final, err := sig.Adapt(blindedSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !final.Verify(msg[:], aggKey) {
+		t.Fatal("blinded adaptor signature did not complete correctly")
+	}
+}
+
+func TestExtractRejectsGarbage(t *testing.T) {
+	key := newKey(t)
+	msg := testMsg(5)
+	_, point, err := adaptor.NewSecret()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sig, err := adaptor.PreSign(key, msg, point)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sig.Extract(nil); err == nil {
+		t.Fatal("expected error extracting from a nil signature")
+	}
+	// Extracting from an unrelated signature yields a scalar that is not the
+	// adaptor secret; callers must check with VerifySecret.
+	other, err := schnorr.Sign(key, msg[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	bogus, err := sig.Extract(other)
+	if err == nil && adaptor.VerifySecret(bogus, point) {
+		t.Fatal("extracted a valid secret from an unrelated signature")
+	}
+}

--- a/crypto/gcs/gcs.go
+++ b/crypto/gcs/gcs.go
@@ -1,0 +1,268 @@
+// Package gcs implements a Golomb-coded set: a compact probabilistic filter
+// following the construction and parameters of BIP-158 compact block filters.
+//
+// A filter commits to a set of byte strings. A wallet can download the filter
+// for a block, test its own addresses against it locally, and fetch only the
+// blocks that match, so it never reveals which addresses it is scanning for.
+// False positives occur at a rate of roughly 1/M and only cost the wallet an
+// unnecessary block download; false negatives cannot occur.
+package gcs
+
+import (
+	"encoding/binary"
+	"errors"
+	"math/bits"
+	"sort"
+)
+
+const (
+	// DefaultP is the Golomb-Rice coding parameter (BIP-158).
+	DefaultP = 19
+	// DefaultM is the false positive rate parameter, ~1/M (BIP-158).
+	DefaultM = 784931
+
+	// maxItems bounds the number of committed items accepted when decoding a
+	// serialized filter, as a defense against maliciously large inputs.
+	maxItems = 1 << 24
+)
+
+var (
+	ErrEmptyFilter     = errors.New("gcs: empty serialized filter")
+	ErrMalformedFilter = errors.New("gcs: malformed serialized filter")
+)
+
+// BuildFilter constructs a serialized Golomb-coded set over the given items
+// using the provided SipHash key. Duplicate and empty items are ignored. The
+// serialization is a uvarint item count followed by the Golomb-Rice coded
+// bitstream of sorted deltas.
+func BuildFilter(key [16]byte, items [][]byte) ([]byte, error) {
+	// Deduplicate items as byte strings so the committed count always equals
+	// the number of encoded deltas. Colliding mapped values are kept and
+	// encode as zero deltas, which decode correctly.
+	unique := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		if len(item) == 0 {
+			continue
+		}
+		unique[string(item)] = struct{}{}
+	}
+	n := uint64(len(unique))
+	if n > maxItems {
+		return nil, ErrMalformedFilter
+	}
+	if n == 0 {
+		return binary.AppendUvarint(nil, 0), nil
+	}
+	values := make([]uint64, 0, n)
+	for item := range unique {
+		values = append(values, hashToRange(key, []byte(item), n))
+	}
+	sort.Slice(values, func(i, j int) bool { return values[i] < values[j] })
+
+	out := binary.AppendUvarint(nil, n)
+	w := &bitWriter{bytes: out}
+	var last uint64
+	for _, v := range values {
+		delta := v - last
+		last = v
+		// Quotient in unary, then P remainder bits.
+		for q := delta >> DefaultP; q > 0; q-- {
+			w.writeBit(1)
+		}
+		w.writeBit(0)
+		w.writeBits(delta, DefaultP)
+	}
+	return w.bytes, nil
+}
+
+// MatchAny reports whether any of the targets may be committed in the
+// serialized filter. A true result may be a false positive at rate ~1/M; a
+// false result is definitive.
+func MatchAny(key [16]byte, filter []byte, targets [][]byte) (bool, error) {
+	if len(filter) == 0 {
+		return false, ErrEmptyFilter
+	}
+	n, offset := binary.Uvarint(filter)
+	if offset <= 0 {
+		return false, ErrMalformedFilter
+	}
+	if n == 0 || len(targets) == 0 {
+		return false, nil
+	}
+	if n > maxItems {
+		return false, ErrMalformedFilter
+	}
+
+	targetValues := make([]uint64, 0, len(targets))
+	for _, target := range targets {
+		if len(target) == 0 {
+			continue
+		}
+		targetValues = append(targetValues, hashToRange(key, target, n))
+	}
+	sort.Slice(targetValues, func(i, j int) bool { return targetValues[i] < targetValues[j] })
+
+	r := &bitReader{bytes: filter[offset:]}
+	var value uint64
+	ti := 0
+	for i := uint64(0); i < n; i++ {
+		delta, err := r.readDelta()
+		if err != nil {
+			return false, err
+		}
+		value += delta
+		for ti < len(targetValues) && targetValues[ti] < value {
+			ti++
+		}
+		if ti == len(targetValues) {
+			return false, nil
+		}
+		if targetValues[ti] == value {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// N returns the number of items committed in a serialized filter.
+func N(filter []byte) (uint64, error) {
+	if len(filter) == 0 {
+		return 0, ErrEmptyFilter
+	}
+	n, offset := binary.Uvarint(filter)
+	if offset <= 0 {
+		return 0, ErrMalformedFilter
+	}
+	return n, nil
+}
+
+// hashToRange maps an item uniformly into [0, n*M) via SipHash-2-4 and a
+// 128-bit multiply-shift reduction.
+func hashToRange(key [16]byte, item []byte, n uint64) uint64 {
+	k0 := binary.LittleEndian.Uint64(key[0:8])
+	k1 := binary.LittleEndian.Uint64(key[8:16])
+	hi, _ := bits.Mul64(sipHash24(k0, k1, item), n*DefaultM)
+	return hi
+}
+
+type bitWriter struct {
+	bytes []byte
+	nbits uint // number of bits used in the final byte, 0 means byte-aligned
+}
+
+func (w *bitWriter) writeBit(bit uint64) {
+	if w.nbits == 0 {
+		w.bytes = append(w.bytes, 0)
+		w.nbits = 8
+	}
+	w.nbits--
+	if bit != 0 {
+		w.bytes[len(w.bytes)-1] |= 1 << w.nbits
+	}
+}
+
+// writeBits writes the low count bits of v, most significant first.
+func (w *bitWriter) writeBits(v uint64, count uint) {
+	for i := int(count) - 1; i >= 0; i-- {
+		w.writeBit((v >> uint(i)) & 1)
+	}
+}
+
+type bitReader struct {
+	bytes []byte
+	pos   uint // bit position
+}
+
+func (r *bitReader) readBit() (uint64, error) {
+	byteIdx := r.pos >> 3
+	if byteIdx >= uint(len(r.bytes)) {
+		return 0, ErrMalformedFilter
+	}
+	bit := uint64(r.bytes[byteIdx]>>(7-(r.pos&7))) & 1
+	r.pos++
+	return bit, nil
+}
+
+func (r *bitReader) readBits(count uint) (uint64, error) {
+	var v uint64
+	for i := uint(0); i < count; i++ {
+		bit, err := r.readBit()
+		if err != nil {
+			return 0, err
+		}
+		v = v<<1 | bit
+	}
+	return v, nil
+}
+
+// readDelta reads one Golomb-Rice coded value: a unary quotient followed by
+// P remainder bits.
+func (r *bitReader) readDelta() (uint64, error) {
+	var q uint64
+	for {
+		bit, err := r.readBit()
+		if err != nil {
+			return 0, err
+		}
+		if bit == 0 {
+			break
+		}
+		q++
+		if q > 1<<(64-DefaultP) {
+			return 0, ErrMalformedFilter
+		}
+	}
+	rem, err := r.readBits(DefaultP)
+	if err != nil {
+		return 0, err
+	}
+	return q<<DefaultP | rem, nil
+}
+
+// sipHash24 computes SipHash-2-4 of data under the key (k0, k1).
+func sipHash24(k0, k1 uint64, data []byte) uint64 {
+	v0 := k0 ^ 0x736f6d6570736575
+	v1 := k1 ^ 0x646f72616e646f6d
+	v2 := k0 ^ 0x6c7967656e657261
+	v3 := k1 ^ 0x7465646279746573
+
+	b := uint64(len(data)) << 56
+	for ; len(data) >= 8; data = data[8:] {
+		m := binary.LittleEndian.Uint64(data[:8])
+		v3 ^= m
+		v0, v1, v2, v3 = sipRound(v0, v1, v2, v3)
+		v0, v1, v2, v3 = sipRound(v0, v1, v2, v3)
+		v0 ^= m
+	}
+	for i, by := range data {
+		b |= uint64(by) << (8 * uint(i))
+	}
+	v3 ^= b
+	v0, v1, v2, v3 = sipRound(v0, v1, v2, v3)
+	v0, v1, v2, v3 = sipRound(v0, v1, v2, v3)
+	v0 ^= b
+	v2 ^= 0xff
+	v0, v1, v2, v3 = sipRound(v0, v1, v2, v3)
+	v0, v1, v2, v3 = sipRound(v0, v1, v2, v3)
+	v0, v1, v2, v3 = sipRound(v0, v1, v2, v3)
+	v0, v1, v2, v3 = sipRound(v0, v1, v2, v3)
+	return v0 ^ v1 ^ v2 ^ v3
+}
+
+func sipRound(v0, v1, v2, v3 uint64) (uint64, uint64, uint64, uint64) {
+	v0 += v1
+	v1 = bits.RotateLeft64(v1, 13)
+	v1 ^= v0
+	v0 = bits.RotateLeft64(v0, 32)
+	v2 += v3
+	v3 = bits.RotateLeft64(v3, 16)
+	v3 ^= v2
+	v0 += v3
+	v3 = bits.RotateLeft64(v3, 21)
+	v3 ^= v0
+	v2 += v1
+	v1 = bits.RotateLeft64(v1, 17)
+	v1 ^= v2
+	v2 = bits.RotateLeft64(v2, 32)
+	return v0, v1, v2, v3
+}

--- a/crypto/gcs/gcs_test.go
+++ b/crypto/gcs/gcs_test.go
@@ -1,0 +1,161 @@
+package gcs
+
+import (
+	"encoding/binary"
+	"math/rand"
+	"testing"
+)
+
+// Reference vectors for SipHash-2-4 with key 000102...0f from the SipHash
+// paper (little-endian interpretation of the 8-byte outputs).
+func TestSipHash24Vectors(t *testing.T) {
+	var key [16]byte
+	for i := range key {
+		key[i] = byte(i)
+	}
+	k0 := binary.LittleEndian.Uint64(key[0:8])
+	k1 := binary.LittleEndian.Uint64(key[8:16])
+
+	vectors := []struct {
+		inputLen int
+		want     uint64
+	}{
+		{0, 0x726fdb47dd0e0e31},
+		{1, 0x74f839c593dc67fd},
+		{2, 0x0d6c8009d9a94f5a},
+		{3, 0x85676696d7fb7e2d},
+		{8, 0x93f5f5799a932462},
+	}
+	for _, vec := range vectors {
+		input := make([]byte, vec.inputLen)
+		for i := range input {
+			input[i] = byte(i)
+		}
+		if got := sipHash24(k0, k1, input); got != vec.want {
+			t.Errorf("sipHash24(len %d) = %#016x, want %#016x", vec.inputLen, got, vec.want)
+		}
+	}
+}
+
+func randomAddresses(rng *rand.Rand, count int) [][]byte {
+	items := make([][]byte, count)
+	for i := range items {
+		addr := make([]byte, 20)
+		rng.Read(addr)
+		items[i] = addr
+	}
+	return items
+}
+
+func TestBuildAndMatch(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	var key [16]byte
+	rng.Read(key[:])
+
+	members := randomAddresses(rng, 500)
+	filter, err := BuildFilter(key, members)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n, err := N(filter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 500 {
+		t.Fatalf("N = %d, want 500", n)
+	}
+
+	// Every member must match, individually and in batches.
+	for _, member := range members {
+		ok, err := MatchAny(key, filter, [][]byte{member})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ok {
+			t.Fatalf("member %x did not match", member)
+		}
+	}
+	ok, err := MatchAny(key, filter, members)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("batch of members did not match")
+	}
+
+	// Non-members should essentially never match: 2000 queries at ~1/784931
+	// false positive rate.
+	falsePositives := 0
+	for i := 0; i < 2000; i++ {
+		ok, err := MatchAny(key, filter, randomAddresses(rng, 1))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ok {
+			falsePositives++
+		}
+	}
+	if falsePositives > 2 {
+		t.Fatalf("false positive rate too high: %d/2000", falsePositives)
+	}
+}
+
+func TestOrderAndDuplicateIndependence(t *testing.T) {
+	rng := rand.New(rand.NewSource(2))
+	var key [16]byte
+	rng.Read(key[:])
+
+	items := randomAddresses(rng, 100)
+	filter1, err := BuildFilter(key, items)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	shuffled := make([][]byte, len(items))
+	copy(shuffled, items)
+	rng.Shuffle(len(shuffled), func(i, j int) { shuffled[i], shuffled[j] = shuffled[j], shuffled[i] })
+	withDuplicates := append(shuffled, items[:10]...)
+	filter2, err := BuildFilter(key, withDuplicates)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(filter1) != string(filter2) {
+		t.Fatal("filters differ across item order / duplicates")
+	}
+}
+
+func TestEmptyFilter(t *testing.T) {
+	var key [16]byte
+	filter, err := BuildFilter(key, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n, err := N(filter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatalf("N = %d, want 0", n)
+	}
+	ok, err := MatchAny(key, filter, randomAddresses(rand.New(rand.NewSource(3)), 5))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatal("empty filter matched")
+	}
+}
+
+func TestMalformedFilter(t *testing.T) {
+	var key [16]byte
+	targets := [][]byte{{1, 2, 3}}
+	if _, err := MatchAny(key, nil, targets); err == nil {
+		t.Fatal("expected error for empty input")
+	}
+	// Claims 1000 items but has no bitstream.
+	truncated := binary.AppendUvarint(nil, 1000)
+	if _, err := MatchAny(key, truncated, targets); err == nil {
+		t.Fatal("expected error for truncated filter")
+	}
+}

--- a/crypto/sphinx/sphinx.go
+++ b/crypto/sphinx/sphinx.go
@@ -1,0 +1,429 @@
+// Package sphinx implements Sphinx onion packets for routed payments.
+//
+// A sender constructs one fixed-size packet addressed to a route. Each hop
+// decrypts exactly one layer, learning only its own instructions and the
+// identity of the next hop; it cannot tell how far along the route it sits,
+// how many hops remain, or who the sender and final recipient are. Every hop
+// re-emits a packet of the same size, so position cannot be inferred from
+// length either.
+//
+// The construction follows the same design as Lightning's BOLT-4: per-hop
+// shared secrets from ECDH against an ephemeral key that is re-blinded at
+// each hop, ChaCha20 as the stream cipher, HMAC-SHA256 for per-hop
+// integrity, and a deterministic filler so that peeling a layer leaves a
+// packet indistinguishable from a freshly constructed one.
+//
+// # Payment-point routing
+//
+// Each hop's instructions carry a point delta rather than a payment hash.
+// A hop learns the point of its incoming PTLC from the payment itself, and
+// derives the point for its outgoing PTLC by adding the delta. This is what
+// lets every hop of a route be locked to a different point, so two colluding
+// intermediaries cannot tell they are forwarding the same payment - a
+// correlation that Lightning's shared payment hash allows.
+package sphinx
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"golang.org/x/crypto/chacha20"
+)
+
+const (
+	// Version is the packet format version.
+	Version byte = 0
+
+	// MaxHops is the greatest number of hops a route may contain.
+	MaxHops = 20
+
+	// HopDataSize is the fixed size of one hop's instructions.
+	HopDataSize = 81
+
+	// hmacSize is the size of a per-hop HMAC tag.
+	hmacSize = 32
+
+	// frameSize is the space one hop occupies in the routing information:
+	// its instructions plus the HMAC covering the remainder of the onion.
+	frameSize = HopDataSize + hmacSize
+
+	// routingInfoSize is the fixed size of the routing information. It is
+	// independent of the actual hop count, which is what hides route length.
+	routingInfoSize = MaxHops * frameSize
+
+	// PacketSize is the total size of an onion packet on the wire.
+	PacketSize = 1 + 33 + routingInfoSize + hmacSize
+
+	// pubKeySize is the size of a compressed public key.
+	pubKeySize = 33
+)
+
+var (
+	ErrInvalidVersion = errors.New("sphinx: unsupported packet version")
+	ErrBadHMAC        = errors.New("sphinx: HMAC mismatch, packet was tampered with or is not for this node")
+	ErrTooManyHops    = errors.New("sphinx: route exceeds the maximum hop count")
+	ErrEmptyRoute     = errors.New("sphinx: route has no hops")
+	ErrBadPacketSize  = errors.New("sphinx: packet has the wrong size")
+
+	keyTypeRho = []byte("rho")
+	keyTypeMu  = []byte("mu")
+)
+
+// HopData is the instruction set one hop receives.
+type HopData struct {
+	// Amount is the value this hop should forward, in the smallest unit of
+	// the hop's ledger.
+	Amount uint64
+
+	// Deadline is the PTLC deadline this hop should set on its outgoing
+	// payment.
+	Deadline uint64
+
+	// NextHop identifies the node to forward to, as a compressed public
+	// key. It is all zeroes at the final hop.
+	NextHop [pubKeySize]byte
+
+	// PointDelta is the scalar to add to the incoming payment point to
+	// obtain the outgoing one, so that each hop is locked to a distinct
+	// point. It is unused at the final hop.
+	PointDelta [32]byte
+}
+
+// IsFinalHop reports whether this hop is the payment's destination.
+func (h *HopData) IsFinalHop() bool {
+	return h.NextHop == [pubKeySize]byte{}
+}
+
+func (h *HopData) encode() []byte {
+	buf := make([]byte, HopDataSize)
+	binary.BigEndian.PutUint64(buf[0:8], h.Amount)
+	binary.BigEndian.PutUint64(buf[8:16], h.Deadline)
+	copy(buf[16:16+pubKeySize], h.NextHop[:])
+	copy(buf[16+pubKeySize:], h.PointDelta[:])
+	return buf
+}
+
+func decodeHopData(buf []byte) (*HopData, error) {
+	if len(buf) != HopDataSize {
+		return nil, fmt.Errorf("sphinx: hop data is %d bytes, want %d", len(buf), HopDataSize)
+	}
+	hop := &HopData{
+		Amount:   binary.BigEndian.Uint64(buf[0:8]),
+		Deadline: binary.BigEndian.Uint64(buf[8:16]),
+	}
+	copy(hop.NextHop[:], buf[16:16+pubKeySize])
+	copy(hop.PointDelta[:], buf[16+pubKeySize:])
+	return hop, nil
+}
+
+// Packet is a fixed-size onion packet.
+type Packet struct {
+	Version      byte
+	EphemeralKey *btcec.PublicKey
+	RoutingInfo  [routingInfoSize]byte
+	HMAC         [hmacSize]byte
+}
+
+// Serialize renders the packet for the wire. Every packet is exactly
+// PacketSize bytes, whatever the route length.
+func (p *Packet) Serialize() []byte {
+	out := make([]byte, 0, PacketSize)
+	out = append(out, p.Version)
+	out = append(out, p.EphemeralKey.SerializeCompressed()...)
+	out = append(out, p.RoutingInfo[:]...)
+	out = append(out, p.HMAC[:]...)
+	return out
+}
+
+// ParsePacket decodes a packet from the wire.
+func ParsePacket(data []byte) (*Packet, error) {
+	if len(data) != PacketSize {
+		return nil, ErrBadPacketSize
+	}
+	if data[0] != Version {
+		return nil, ErrInvalidVersion
+	}
+	ephemeral, err := btcec.ParsePubKey(data[1 : 1+pubKeySize])
+	if err != nil {
+		return nil, fmt.Errorf("sphinx: bad ephemeral key: %w", err)
+	}
+	p := &Packet{Version: data[0], EphemeralKey: ephemeral}
+	copy(p.RoutingInfo[:], data[1+pubKeySize:1+pubKeySize+routingInfoSize])
+	copy(p.HMAC[:], data[1+pubKeySize+routingInfoSize:])
+	return p, nil
+}
+
+// sharedSecret computes the ECDH shared secret between a private key and a
+// public key, hashed to a uniform 32 bytes.
+func sharedSecret(priv *btcec.ModNScalar, pub *btcec.PublicKey) [32]byte {
+	var pubJ, product btcec.JacobianPoint
+	pub.AsJacobian(&pubJ)
+	btcec.ScalarMultNonConst(priv, &pubJ, &product)
+	product.ToAffine()
+	point := btcec.NewPublicKey(&product.X, &product.Y)
+	return sha256.Sum256(point.SerializeCompressed())
+}
+
+// blindingFactor derives the scalar that re-blinds the ephemeral key between
+// hops, binding it to both the current ephemeral key and the shared secret.
+func blindingFactor(ephemeral *btcec.PublicKey, secret [32]byte) btcec.ModNScalar {
+	h := sha256.New()
+	h.Write(ephemeral.SerializeCompressed())
+	h.Write(secret[:])
+	var digest [32]byte
+	copy(digest[:], h.Sum(nil))
+	var factor btcec.ModNScalar
+	factor.SetBytes(&digest)
+	return factor
+}
+
+// deriveKey derives a purpose-specific key from a shared secret.
+func deriveKey(keyType []byte, secret [32]byte) [32]byte {
+	mac := hmac.New(sha256.New, keyType)
+	mac.Write(secret[:])
+	var key [32]byte
+	copy(key[:], mac.Sum(nil))
+	return key
+}
+
+// stream produces a keystream of the requested length. ChaCha20 is used with
+// a zero nonce because every invocation uses a distinct, single-use key
+// derived from a fresh shared secret.
+func stream(key [32]byte, length int) ([]byte, error) {
+	nonce := make([]byte, chacha20.NonceSize)
+	cipher, err := chacha20.NewUnauthenticatedCipher(key[:], nonce)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]byte, length)
+	cipher.XORKeyStream(out, out)
+	return out, nil
+}
+
+func xorInto(dst, src []byte) {
+	for i := range dst {
+		if i >= len(src) {
+			return
+		}
+		dst[i] ^= src[i]
+	}
+}
+
+// computeSharedSecrets walks the route, deriving each hop's shared secret and
+// re-blinding the ephemeral key as it goes. The returned ephemeral keys are
+// what each hop sees.
+func computeSharedSecrets(sessionKey *btcec.PrivateKey, route []*btcec.PublicKey) ([][32]byte, []*btcec.PublicKey, error) {
+	secrets := make([][32]byte, len(route))
+	ephemerals := make([]*btcec.PublicKey, len(route))
+
+	var privScalar btcec.ModNScalar
+	privScalar.Set(&sessionKey.Key)
+	ephemeral := sessionKey.PubKey()
+
+	for i, hop := range route {
+		if hop == nil {
+			return nil, nil, fmt.Errorf("sphinx: hop %d has no public key", i)
+		}
+		ephemerals[i] = ephemeral
+		secrets[i] = sharedSecret(&privScalar, hop)
+
+		if i == len(route)-1 {
+			break
+		}
+		factor := blindingFactor(ephemeral, secrets[i])
+		privScalar.Mul(&factor)
+		if privScalar.IsZero() {
+			return nil, nil, errors.New("sphinx: degenerate blinding factor")
+		}
+		var ephJ, blinded btcec.JacobianPoint
+		ephemeral.AsJacobian(&ephJ)
+		btcec.ScalarMultNonConst(&factor, &ephJ, &blinded)
+		blinded.ToAffine()
+		ephemeral = btcec.NewPublicKey(&blinded.X, &blinded.Y)
+	}
+	return secrets, ephemerals, nil
+}
+
+// generateFiller produces the deterministic padding that occupies the tail of
+// the routing information. It is what makes a peeled packet indistinguishable
+// from a freshly constructed one: each hop's decryption extends the
+// obfuscated region by exactly one frame, and the filler is precomputed by
+// the sender so the HMACs still line up.
+func generateFiller(secrets [][32]byte) ([]byte, error) {
+	numHops := len(secrets)
+	if numHops < 2 {
+		return nil, nil
+	}
+	filler := make([]byte, 0, (numHops-1)*frameSize)
+	for i := 0; i < numHops-1; i++ {
+		filler = append(filler, make([]byte, frameSize)...)
+		keyStream, err := stream(deriveKey(keyTypeRho, secrets[i]), routingInfoSize+frameSize)
+		if err != nil {
+			return nil, err
+		}
+		xorInto(filler, keyStream[routingInfoSize+frameSize-len(filler):])
+	}
+	return filler, nil
+}
+
+// Construct builds an onion packet for a route. route lists the hops' node
+// public keys in forward order, hops carries each hop's instructions, and
+// assocData is authenticated but not encrypted (bind it to the payment so a
+// packet cannot be replayed against a different one).
+//
+// sessionKey must be freshly generated for every packet.
+func Construct(sessionKey *btcec.PrivateKey, route []*btcec.PublicKey, hops []*HopData, assocData []byte) (*Packet, error) {
+	if len(route) == 0 {
+		return nil, ErrEmptyRoute
+	}
+	if len(route) > MaxHops {
+		return nil, ErrTooManyHops
+	}
+	if len(route) != len(hops) {
+		return nil, fmt.Errorf("sphinx: %d hops in route but %d instruction sets", len(route), len(hops))
+	}
+
+	secrets, ephemerals, err := computeSharedSecrets(sessionKey, route)
+	if err != nil {
+		return nil, err
+	}
+	filler, err := generateFiller(secrets)
+	if err != nil {
+		return nil, err
+	}
+
+	// The initial routing information is a keystream rather than zeroes, so
+	// that unused frames are indistinguishable from real ones.
+	var routingInfo [routingInfoSize]byte
+	padStream, err := stream(deriveKey([]byte("pad"), sha256.Sum256(sessionKey.Serialize())), routingInfoSize)
+	if err != nil {
+		return nil, err
+	}
+	copy(routingInfo[:], padStream)
+
+	var nextHMAC [hmacSize]byte
+	for i := len(route) - 1; i >= 0; i-- {
+		// Shift the existing layers back by one frame and write this hop's
+		// instructions, followed by the HMAC covering everything after it.
+		copy(routingInfo[frameSize:], routingInfo[:routingInfoSize-frameSize])
+		copy(routingInfo[:HopDataSize], hops[i].encode())
+		copy(routingInfo[HopDataSize:frameSize], nextHMAC[:])
+
+		keyStream, err := stream(deriveKey(keyTypeRho, secrets[i]), routingInfoSize)
+		if err != nil {
+			return nil, err
+		}
+		xorInto(routingInfo[:], keyStream)
+
+		// The last hop's layer is where the filler comes to rest.
+		if i == len(route)-1 && len(filler) > 0 {
+			copy(routingInfo[routingInfoSize-len(filler):], filler)
+		}
+
+		mac := hmac.New(sha256.New, keyBytes(deriveKey(keyTypeMu, secrets[i])))
+		mac.Write(routingInfo[:])
+		mac.Write(assocData)
+		copy(nextHMAC[:], mac.Sum(nil))
+	}
+
+	return &Packet{
+		Version:      Version,
+		EphemeralKey: ephemerals[0],
+		RoutingInfo:  routingInfo,
+		HMAC:         nextHMAC,
+	}, nil
+}
+
+func keyBytes(key [32]byte) []byte { return key[:] }
+
+// Peeled is the result of processing one layer of an onion.
+type Peeled struct {
+	// HopData is this hop's instructions.
+	HopData *HopData
+
+	// Next is the packet to forward to the next hop. It is nil when this
+	// node is the final recipient.
+	Next *Packet
+
+	// SharedSecret is this hop's shared secret, which callers may use to
+	// key an error return path.
+	SharedSecret [32]byte
+}
+
+// Peel removes one layer of encryption. It authenticates the packet first, so
+// a packet that was tampered with, replayed against different associated
+// data, or simply not addressed to this node is rejected rather than
+// misinterpreted.
+func Peel(privKey *btcec.PrivateKey, packet *Packet, assocData []byte) (*Peeled, error) {
+	if packet == nil || packet.EphemeralKey == nil {
+		return nil, errors.New("sphinx: nil packet")
+	}
+	if packet.Version != Version {
+		return nil, ErrInvalidVersion
+	}
+	var privScalar btcec.ModNScalar
+	privScalar.Set(&privKey.Key)
+	secret := sharedSecret(&privScalar, packet.EphemeralKey)
+
+	mac := hmac.New(sha256.New, keyBytes(deriveKey(keyTypeMu, secret)))
+	mac.Write(packet.RoutingInfo[:])
+	mac.Write(assocData)
+	if !hmac.Equal(mac.Sum(nil), packet.HMAC[:]) {
+		return nil, ErrBadHMAC
+	}
+
+	// Extend the routing information by one frame before decrypting, so the
+	// keystream reveals both this hop's layer and the filler that replaces
+	// it in the forwarded packet.
+	extended := make([]byte, routingInfoSize+frameSize)
+	copy(extended, packet.RoutingInfo[:])
+	keyStream, err := stream(deriveKey(keyTypeRho, secret), routingInfoSize+frameSize)
+	if err != nil {
+		return nil, err
+	}
+	xorInto(extended, keyStream)
+
+	hopData, err := decodeHopData(extended[:HopDataSize])
+	if err != nil {
+		return nil, err
+	}
+	var nextHMAC [hmacSize]byte
+	copy(nextHMAC[:], extended[HopDataSize:frameSize])
+
+	result := &Peeled{HopData: hopData, SharedSecret: secret}
+	if hopData.IsFinalHop() {
+		// A final hop must carry a zero HMAC; anything else means the packet
+		// was malformed.
+		if !bytes.Equal(nextHMAC[:], make([]byte, hmacSize)) {
+			return nil, errors.New("sphinx: final hop carries a non-zero forward HMAC")
+		}
+		return result, nil
+	}
+
+	nextEphemeral, err := blindEphemeral(packet.EphemeralKey, secret)
+	if err != nil {
+		return nil, err
+	}
+	next := &Packet{Version: Version, EphemeralKey: nextEphemeral, HMAC: nextHMAC}
+	copy(next.RoutingInfo[:], extended[frameSize:])
+	result.Next = next
+	return result, nil
+}
+
+// blindEphemeral advances the ephemeral key for the next hop.
+func blindEphemeral(ephemeral *btcec.PublicKey, secret [32]byte) (*btcec.PublicKey, error) {
+	factor := blindingFactor(ephemeral, secret)
+	if factor.IsZero() {
+		return nil, errors.New("sphinx: degenerate blinding factor")
+	}
+	var ephJ, blinded btcec.JacobianPoint
+	ephemeral.AsJacobian(&ephJ)
+	btcec.ScalarMultNonConst(&factor, &ephJ, &blinded)
+	blinded.ToAffine()
+	return btcec.NewPublicKey(&blinded.X, &blinded.Y), nil
+}

--- a/crypto/sphinx/sphinx_test.go
+++ b/crypto/sphinx/sphinx_test.go
@@ -1,0 +1,252 @@
+package sphinx_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/dominant-strategies/go-quai/crypto/sphinx"
+)
+
+func newKey(t *testing.T) *btcec.PrivateKey {
+	t.Helper()
+	key, err := btcec.NewPrivateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return key
+}
+
+// buildRoute creates n hop keys and the matching instructions, with each hop
+// pointing at its successor and the final hop marked by a zero NextHop.
+func buildRoute(t *testing.T, n int) ([]*btcec.PrivateKey, []*btcec.PublicKey, []*sphinx.HopData) {
+	t.Helper()
+	keys := make([]*btcec.PrivateKey, n)
+	pubs := make([]*btcec.PublicKey, n)
+	for i := range keys {
+		keys[i] = newKey(t)
+		pubs[i] = keys[i].PubKey()
+	}
+	hops := make([]*sphinx.HopData, n)
+	for i := range hops {
+		hop := &sphinx.HopData{
+			Amount:   uint64(1000 * (n - i)),
+			Deadline: uint64(5000 + 144*(n-i)),
+		}
+		if i < n-1 {
+			copy(hop.NextHop[:], pubs[i+1].SerializeCompressed())
+		}
+		for j := range hop.PointDelta {
+			hop.PointDelta[j] = byte(i*7 + j)
+		}
+		hops[i] = hop
+	}
+	return keys, pubs, hops
+}
+
+// TestRouteRoundTrip walks a packet along routes of every supported length,
+// checking each hop recovers exactly its own instructions and that the final
+// hop is recognized as the destination.
+func TestRouteRoundTrip(t *testing.T) {
+	assocData := []byte("payment-point-commitment")
+	for n := 1; n <= sphinx.MaxHops; n++ {
+		keys, pubs, hops := buildRoute(t, n)
+		packet, err := sphinx.Construct(newKey(t), pubs, hops, assocData)
+		if err != nil {
+			t.Fatalf("%d hops: %v", n, err)
+		}
+
+		current := packet
+		for i := 0; i < n; i++ {
+			peeled, err := sphinx.Peel(keys[i], current, assocData)
+			if err != nil {
+				t.Fatalf("%d hops, hop %d: %v", n, i, err)
+			}
+			if peeled.HopData.Amount != hops[i].Amount || peeled.HopData.Deadline != hops[i].Deadline {
+				t.Fatalf("%d hops, hop %d: instructions do not match", n, i)
+			}
+			if peeled.HopData.NextHop != hops[i].NextHop {
+				t.Fatalf("%d hops, hop %d: next hop does not match", n, i)
+			}
+			if peeled.HopData.PointDelta != hops[i].PointDelta {
+				t.Fatalf("%d hops, hop %d: point delta does not match", n, i)
+			}
+
+			isLast := i == n-1
+			if peeled.HopData.IsFinalHop() != isLast {
+				t.Fatalf("%d hops, hop %d: final-hop flag is %v", n, i, peeled.HopData.IsFinalHop())
+			}
+			if isLast {
+				if peeled.Next != nil {
+					t.Fatalf("%d hops: final hop produced a forward packet", n)
+				}
+				break
+			}
+			if peeled.Next == nil {
+				t.Fatalf("%d hops, hop %d: no forward packet", n, i)
+			}
+			current = peeled.Next
+		}
+	}
+}
+
+// TestPacketSizeConstant is the property that hides route length: every
+// packet, at every position along every route, is byte-identical in size.
+func TestPacketSizeConstant(t *testing.T) {
+	assocData := []byte("assoc")
+	for _, n := range []int{1, 2, 5, 12, sphinx.MaxHops} {
+		keys, pubs, hops := buildRoute(t, n)
+		packet, err := sphinx.Construct(newKey(t), pubs, hops, assocData)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := len(packet.Serialize()); got != sphinx.PacketSize {
+			t.Fatalf("%d hops: packet is %d bytes, want %d", n, got, sphinx.PacketSize)
+		}
+		current := packet
+		for i := 0; i < n-1; i++ {
+			peeled, err := sphinx.Peel(keys[i], current, assocData)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := len(peeled.Next.Serialize()); got != sphinx.PacketSize {
+				t.Fatalf("%d hops, after hop %d: packet is %d bytes, want %d", n, i, got, sphinx.PacketSize)
+			}
+			current = peeled.Next
+		}
+	}
+}
+
+func TestSerializationRoundTrip(t *testing.T) {
+	keys, pubs, hops := buildRoute(t, 4)
+	assocData := []byte("assoc")
+	packet, err := sphinx.Construct(newKey(t), pubs, hops, assocData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := sphinx.ParsePacket(packet.Serialize())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(parsed.Serialize(), packet.Serialize()) {
+		t.Fatal("packet did not survive serialization")
+	}
+	// A parsed packet must still peel correctly.
+	if _, err := sphinx.Peel(keys[0], parsed, assocData); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sphinx.ParsePacket(packet.Serialize()[:sphinx.PacketSize-1]); err == nil {
+		t.Fatal("expected a short packet to be rejected")
+	}
+}
+
+// TestWrongNodeCannotPeel checks that a hop that is not the addressee cannot
+// read the layer: authentication fails rather than yielding garbage.
+func TestWrongNodeCannotPeel(t *testing.T) {
+	keys, pubs, hops := buildRoute(t, 3)
+	assocData := []byte("assoc")
+	packet, err := sphinx.Construct(newKey(t), pubs, hops, assocData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The second hop cannot peel the outermost layer.
+	if _, err := sphinx.Peel(keys[1], packet, assocData); err != sphinx.ErrBadHMAC {
+		t.Fatalf("expected an HMAC failure, got %v", err)
+	}
+	// Neither can an unrelated node.
+	if _, err := sphinx.Peel(newKey(t), packet, assocData); err != sphinx.ErrBadHMAC {
+		t.Fatalf("expected an HMAC failure, got %v", err)
+	}
+}
+
+func TestTamperDetection(t *testing.T) {
+	keys, pubs, hops := buildRoute(t, 3)
+	assocData := []byte("assoc")
+	packet, err := sphinx.Construct(newKey(t), pubs, hops, assocData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Flipping a bit anywhere in the routing information must be caught.
+	for _, offset := range []int{0, 100, 1000, len(packet.RoutingInfo) - 1} {
+		tampered := *packet
+		tampered.RoutingInfo[offset] ^= 0x01
+		if _, err := sphinx.Peel(keys[0], &tampered, assocData); err != sphinx.ErrBadHMAC {
+			t.Fatalf("tampering at offset %d was not detected: %v", offset, err)
+		}
+	}
+	// So must replaying the packet against different associated data, which
+	// is what binds an onion to one specific payment.
+	if _, err := sphinx.Peel(keys[0], packet, []byte("different-payment")); err != sphinx.ErrBadHMAC {
+		t.Fatalf("expected associated-data mismatch to be caught, got %v", err)
+	}
+}
+
+// TestHopLearnsNothingExtra checks that a hop's forwarded packet does not
+// contain its own instructions any more: what it passes on is opaque to it.
+func TestHopLearnsNothingExtra(t *testing.T) {
+	keys, pubs, hops := buildRoute(t, 4)
+	assocData := []byte("assoc")
+	packet, err := sphinx.Construct(newKey(t), pubs, hops, assocData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	peeled, err := sphinx.Peel(keys[0], packet, assocData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// No later hop's plaintext instructions should appear in the forwarded
+	// packet: everything downstream is still encrypted.
+	for i := 1; i < len(hops); i++ {
+		encoded := hops[i].NextHop[:]
+		if hops[i].IsFinalHop() {
+			continue
+		}
+		if bytes.Contains(peeled.Next.Serialize(), encoded) {
+			t.Fatalf("hop %d's next-hop identity is readable in the forwarded packet", i)
+		}
+	}
+	// A hop also cannot peel the packet it forwards.
+	if _, err := sphinx.Peel(keys[0], peeled.Next, assocData); err != sphinx.ErrBadHMAC {
+		t.Fatal("a hop was able to peel its own forwarded packet")
+	}
+}
+
+func TestConstructRejectsBadRoutes(t *testing.T) {
+	_, pubs, hops := buildRoute(t, 2)
+	if _, err := sphinx.Construct(newKey(t), nil, nil, nil); err != sphinx.ErrEmptyRoute {
+		t.Fatalf("expected ErrEmptyRoute, got %v", err)
+	}
+	if _, err := sphinx.Construct(newKey(t), pubs, hops[:1], nil); err == nil {
+		t.Fatal("expected a hop-count mismatch to be rejected")
+	}
+	tooMany := make([]*btcec.PublicKey, sphinx.MaxHops+1)
+	tooManyHops := make([]*sphinx.HopData, sphinx.MaxHops+1)
+	for i := range tooMany {
+		tooMany[i] = newKey(t).PubKey()
+		tooManyHops[i] = &sphinx.HopData{}
+	}
+	if _, err := sphinx.Construct(newKey(t), tooMany, tooManyHops, nil); err != sphinx.ErrTooManyHops {
+		t.Fatalf("expected ErrTooManyHops, got %v", err)
+	}
+}
+
+// TestDistinctSessionsDiffer checks that two packets for the same route are
+// unlinkable: a fresh session key must change every byte a hop sees.
+func TestDistinctSessionsDiffer(t *testing.T) {
+	_, pubs, hops := buildRoute(t, 3)
+	assocData := []byte("assoc")
+	first, err := sphinx.Construct(newKey(t), pubs, hops, assocData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := sphinx.Construct(newKey(t), pubs, hops, assocData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(first.Serialize(), second.Serialize()) {
+		t.Fatal("two sessions produced identical packets")
+	}
+	if first.EphemeralKey.IsEqual(second.EphemeralKey) {
+		t.Fatal("two sessions shared an ephemeral key")
+	}
+}

--- a/doc/qi-offchain-layer.md
+++ b/doc/qi-offchain-layer.md
@@ -20,8 +20,9 @@ Concretely this branch adds:
 | Adaptor signatures (single key and MuSig2) | `crypto/adaptor` | implemented, tested |
 | Transaction locktime, output locks | `core`, `params` | implemented, fork gated |
 | Channels, PTLCs, routes, invoices | `qichannel` | implemented, tested |
-| Onion routing, gossip, pathfinding | — | not implemented |
-| Quai-side contract channels | — | not implemented |
+| Onion routing | `crypto/sphinx` | implemented, tested |
+| Quai-side contract channels | `qichannel/contracts` | implemented, compiles; point derivation tested |
+| Gossip, pathfinding, node integration | — | not implemented |
 
 ## Consensus primitives
 
@@ -154,18 +155,57 @@ conversion, which changes supply and is the monetary-policy instrument the
 kQuai controller reads; the two layers are complementary rather than
 competing.
 
+## Onion routing
+
+`crypto/sphinx` implements fixed-size onion packets on the BOLT-4 design:
+per-hop ECDH shared secrets against an ephemeral key re-blinded at each hop,
+ChaCha20 layer encryption, per-hop HMAC-SHA256, and a deterministic filler so
+a peeled packet is indistinguishable from a freshly constructed one. A hop
+learns only its own instructions and its successor — not its position, the
+route length, the sender, or the recipient — and every forwarded packet is
+`PacketSize` bytes regardless of route length.
+
+Hop instructions carry a **point delta** rather than a payment hash: a hop
+derives the point for its outgoing PTLC by offsetting the point of its
+incoming one. This is what makes per-hop decorrelation work end to end, and
+it has no equivalent in a hash-based onion.
+
+## The Quai side
+
+`qichannel/contracts/QiPtlcChannel.sol` is a two-party channel on the EVM
+ledger settling PTLCs against the same payment-point space. It compiles clean
+under solc 0.8.26.
+
+The bridge between ledgers is `pointAddress(uint256 secret)`. The contract
+cannot manipulate curve points affordably, but `ecrecover(h, v, r, s)`
+recovers `r⁻¹·(s·R − h·G)`, so taking `h = 0`, `r = Gx` and
+`s = secret·Gx mod n` makes `R` the generator and collapses the expression to
+`secret·G` — a scalar multiplication for about 3000 gas. The address it
+returns is exactly `keccak256(T.x ‖ T.y)[12:]`, the commitment the payee
+publishes. `qichannel.PointAddress` and `ContractRecoveryArgs` mirror this in
+Go, and the equivalence is tested against the same secp256k1 implementation
+the precompile is backed by, including for blinded points.
+
+Because an EVM adjudicator can replace a stale state during a challenge
+window, Quai-side channels are **perpetual**: no bounded update count, no
+expiry. A route may therefore have time-bounded Qi channels on some hops and
+perpetual Quai channels on others, which is a reasonable division of labour —
+the cash ledger contributes privacy, the EVM ledger contributes durable
+routing liquidity.
+
 ## Not implemented
 
-- **Onion routing.** A Sphinx-style packet format is needed so intermediaries
-  learn only their predecessor and successor. Standard and well specified,
-  but not written here.
 - **Gossip and pathfinding.** Public routing nodes must announce channels by
   pointing at a funding outpoint (verifiable through `quai_getUTXO`), which
   trades that channel's privacy for routability. Unannounced channels remain
   fully private.
-- **Quai-side contract channels**, and the liquidity/fee economics of a
-  routing network (jamming, probing, rebalancing), which are unsolved in
-  Lightning too.
+- **The liquidity and fee economics** of a routing network (jamming, probing,
+  rebalancing), which are unsolved in Lightning too.
 - **Network integration.** Nothing here is wired into the node; the packages
   are libraries. A channel daemon holding state, watching heights and
   publishing at maturity is future work.
+- **On-chain contract execution tests.** The contract compiles and its point
+  derivation is verified in Go, but this repository has no EVM test harness
+  (`core/vm/runtime` is absent), so the channel state machine itself — close,
+  challenge, claim, refund, finalize — has not been executed. That should be
+  covered before the contract handles funds.

--- a/doc/qi-offchain-layer.md
+++ b/doc/qi-offchain-layer.md
@@ -1,0 +1,171 @@
+# Qi off-chain contract and payment layer
+
+This document describes the design of Qi payment channels, PTLCs and routed
+payments, the consensus primitives they need, and the limits of the approach.
+
+## Summary
+
+Qi verifies exactly one aggregate Schnorr signature per transaction over all
+input public keys. That single fact allows a large class of two-party
+contracts to be expressed with no script system at all: participants are
+encoded in a MuSig2 aggregate key, conditions in adaptor signatures, and time
+in locktimes. Every such contract settles on chain as an ordinary-looking
+payment to an ordinary-looking address, so expressiveness costs nothing in
+fungibility or privacy.
+
+Concretely this branch adds:
+
+| Layer | Package | Status |
+| --- | --- | --- |
+| Adaptor signatures (single key and MuSig2) | `crypto/adaptor` | implemented, tested |
+| Transaction locktime, output locks | `core`, `params` | implemented, fork gated |
+| Channels, PTLCs, routes, invoices | `qichannel` | implemented, tested |
+| Onion routing, gossip, pathfinding | — | not implemented |
+| Quai-side contract channels | — | not implemented |
+
+## Consensus primitives
+
+Two fork-gated changes (`params.QiUserLockForkBlock`) provide the timing
+primitives. They are distinct and both are needed.
+
+**Output locks** (`TxOut.Lock`) delay spending a UTXO that already exists.
+This was already stored and enforced at spend time; the change permits users
+to set it. It gives vaults, dead-man switches and delayed-withdrawal
+constructions. Locked outputs are restricted to denominations above
+`MaxTrimDenomination` because the trimmer skips locked entries, so a small
+locked note would otherwise never be trimmed and would bloat the UTXO set
+permanently.
+
+**Transaction locktime** delays *a transaction*. It is encoded as an 8-byte
+big-endian height in the Qi `Data` field, which is already covered by the
+signing digest (so it is not malleable) and already carries typed payloads at
+other lengths (20 bytes = wrapping, 22 = conversion). Encoding it there rather
+than as a new struct field avoids any protobuf, RLP or transaction-hash
+change, and therefore any change to how existing transactions serialize or
+hash.
+
+### Why output locks alone are not enough
+
+It is tempting to think channels only need output locks. They do not, and the
+distinction is easy to miss:
+
+- An output lock says *this coin cannot move until height H*.
+- A locktime says *this transaction cannot confirm until height H*.
+
+Every state of a channel spends the **same funding output**. If timing were a
+property of that output, every state would inherit identical timing, and there
+would be no way to make the newest state confirm before a stale one. The
+security of the whole construction rests on that ordering, so a transaction
+locktime is required. An earlier iteration of this work shipped output locks
+alone and would not, in fact, have supported channels.
+
+## Channel construction
+
+A channel is one funding UTXO paying to `addr(MuSig2Agg(A, B))`. Because the
+aggregate key is determined by the participants' keys, one party grinds its
+key until the aggregate hashes into the zone's Qi scope (`GrindFundingKey`,
+about 512 attempts).
+
+States are ordered by **decrementing locktime**. State `i` settles with a
+transaction whose locktime is:
+
+```
+maturity(i) = OpenHeight + (MaxStates - i) * SettlementDelta
+```
+
+Later states mature earlier. An honest party publishing the newest state
+always beats any stale state its counterparty holds, because the stale state
+is not yet valid.
+
+This yields two budgets that callers must respect, both exposed by the API:
+
+- **Watch window** (`WatchWindow`): `SettlementDelta` blocks, the interval in
+  which a unilateral close of state `i` must be published. After it, state
+  `i-1` also matures and the outcome becomes a race.
+- **Lifetime** (`ExpiryHeight`) and **update budget**
+  (`RemainingUpdates`): `MaxStates` updates over `MaxStates *
+  SettlementDelta` blocks. The channel must be closed or rolled over before
+  expiry.
+
+Cooperative closes carry no locktime and confirm immediately, so a
+well-behaved channel never waits. The defaults are a one-day watch window and
+a one-year lifetime, giving 365 updates; trading window for updates is the
+central tuning decision.
+
+### What is not constructible
+
+**Perpetual (penalty) channels.** Lightning's revocation model punishes a
+cheater by giving the victim an immediate spending path while the cheater's is
+delayed. That asymmetry requires two spending branches from one output with
+different conditions, i.e. a script system. With one output and one lock,
+both parties face identical timing and punishment degenerates into a race.
+Channels here are therefore time bounded by construction.
+
+An `ANYPREVOUT`-style sighash mode would allow eltoo-style perpetual channels
+without penalties, and is the natural follow-on if unbounded channel lifetime
+becomes important.
+
+## PTLCs and routing
+
+A PTLC holds an amount claimable by revealing the discrete log of a payment
+point. The claim transaction carries no locktime and is gated only by an
+adaptor signature; the refund carries the deadline as its locktime. Publishing
+a claim necessarily reveals the secret, which is what lets the upstream hop
+claim in turn — atomicity with no hash preimages and no scripts.
+
+`crypto/adaptor` builds MuSig2 adaptor signatures on top of btcd unmodified.
+btcd computes the aggregate nonce as `R = R₁ + b·R₂` and challenges over
+`x(R)`, so adding the adaptor point to the first nonce point makes every
+signer challenge over the shifted nonce while their secret nonces still sum to
+the unshifted one; the combined signature is then short by exactly the secret.
+Since BIP-340 carries only `x(R)`, verification lifts it to even Y, so when
+the shifted nonce is odd the signer negates its nonce and completion subtracts
+rather than adds. Key aggregation reuses `musig2.AggregateKeys(keys, false)`,
+so completed signatures verify under precisely the key consensus checks.
+
+Routes use a **deadline staircase**: the hop nearest the payee has the
+earliest deadline and each hop upstream gets `DefaultHopDelta` more blocks, so
+an intermediary always has time to claim upstream after being claimed
+downstream. Because channels are time bounded, `Route.FitsChannels` rejects
+routes whose deadlines fall outside any hop's remaining channel lifetime —
+routing capacity decays as channels approach expiry, which is a scheduling
+concern Lightning does not have.
+
+Every hop is locked to a **different blinded point** (`T + rᵢ·G`). Lightning's
+HTLCs reuse one payment hash at every hop, letting colluding intermediaries
+correlate a route end to end and enabling wormhole attacks; PTLCs remove that
+by construction.
+
+## Cross-ledger routing
+
+The routing layer's atomicity primitive is only "reveal a scalar for a
+point", which is not Qi-specific. On Qi it is enforced by adaptor signatures;
+on the Quai EVM ledger the same condition can be enforced by a contract that
+checks `T = t·G`. A single network can therefore carry payments whose hops
+traverse Qi channels and Quai contract-channels interchangeably, with one
+onion protocol and one invoice format — hence the `Ledger` field on
+`Invoice`. Because an EVM adjudicator can implement challenge periods and
+penalties, Quai-side channels can be perpetual even while Qi-side channels are
+time bounded.
+
+This makes atomic Qi↔Quai payments possible off chain. That is a secondary
+market between existing holders and does not interact with protocol
+conversion, which changes supply and is the monetary-policy instrument the
+kQuai controller reads; the two layers are complementary rather than
+competing.
+
+## Not implemented
+
+- **Onion routing.** A Sphinx-style packet format is needed so intermediaries
+  learn only their predecessor and successor. Standard and well specified,
+  but not written here.
+- **Gossip and pathfinding.** Public routing nodes must announce channels by
+  pointing at a funding outpoint (verifiable through `quai_getUTXO`), which
+  trades that channel's privacy for routability. Unannounced channels remain
+  fully private.
+- **Quai-side contract channels**, and the liquidity/fee economics of a
+  routing network (jamming, probing, rebalancing), which are unsolved in
+  Lightning too.
+- **Network integration.** Nothing here is wired into the node; the packages
+  are libraries. A channel daemon holding state, watching heights and
+  publishing at maturity is future work.

--- a/internal/quaiapi/api.go
+++ b/internal/quaiapi/api.go
@@ -134,6 +134,21 @@ func (s *PublicTxPoolAPI) Status() map[string]hexutil.Uint {
 	}
 }
 
+// QiTxStatus returns the pool status of a Qi transaction: whether it is
+// pending, its fee in qits, and whether it is a denomination-consolidation
+// transaction that is only minable in the first Qi slot of a block.
+func (s *PublicTxPoolAPI) QiTxStatus(txHash common.Hash) map[string]interface{} {
+	status := s.b.QiTxPoolStatus(txHash)
+	result := map[string]interface{}{
+		"pending": status.Pending,
+	}
+	if status.Pending {
+		result["fee"] = (*hexutil.Big)(status.Fee)
+		result["firstSlotOnly"] = status.FirstSlotOnly
+	}
+	return result
+}
+
 // Inspect retrieves the content of the transaction pool and flattens it into an
 // easily inspectable list.
 func (s *PublicTxPoolAPI) Inspect() map[string]map[string]map[string]string {

--- a/internal/quaiapi/api.go
+++ b/internal/quaiapi/api.go
@@ -1612,6 +1612,30 @@ func (s *PublicTransactionPoolAPI) ReceiveTxFromPoolSharingClient(ctx context.Co
 	return nil
 }
 
+// ReceiveStemTransaction accepts a Qi transaction relayed by a Dandelion
+// stem peer. The tx joins the pool without being publicly broadcast by this
+// node; the stem either continues to one of this node's sharing clients or
+// the tx is fluffed here.
+func (s *PublicTransactionPoolAPI) ReceiveStemTransaction(ctx context.Context, input hexutil.Bytes) error {
+	if s.b.NodeCtx() != common.ZONE_CTX {
+		return errors.New("stem transactions can only be received in zone chains")
+	}
+	if !s.b.ProcessingState() {
+		return errors.New("stem transactions cannot be received in a node that is not processing state")
+	}
+	tx := new(types.Transaction)
+	protoTransaction := new(types.ProtoTransaction)
+	err := proto.Unmarshal(input, protoTransaction)
+	if err != nil {
+		return err
+	}
+	err = tx.ProtoDecode(protoTransaction, s.b.NodeLocation())
+	if err != nil {
+		return err
+	}
+	return s.b.ReceiveStemTransaction(tx)
+}
+
 // PublicDebugAPI is the collection of Quai APIs exposed over the public
 // debugging endpoint.
 type PublicDebugAPI struct {

--- a/internal/quaiapi/backend.go
+++ b/internal/quaiapi/backend.go
@@ -164,6 +164,7 @@ type Backend interface {
 	TxPoolContentFrom(addr common.Address) (types.Transactions, types.Transactions)
 	GetPoolGasPrice() *big.Int
 	SendTxToSharingClients(tx *types.Transaction) error
+	ReceiveStemTransaction(tx *types.Transaction) error
 	GetRollingFeeInfo() (min, max, avg *big.Int)
 	QiTxPoolStatus(txHash common.Hash) *core.QiTxPoolStatus
 	GetBlockFilter(blockHash common.Hash) []byte

--- a/internal/quaiapi/backend.go
+++ b/internal/quaiapi/backend.go
@@ -165,6 +165,7 @@ type Backend interface {
 	GetPoolGasPrice() *big.Int
 	SendTxToSharingClients(tx *types.Transaction) error
 	GetRollingFeeInfo() (min, max, avg *big.Int)
+	QiTxPoolStatus(txHash common.Hash) *core.QiTxPoolStatus
 
 	// Filter API
 	BloomStatus() (uint64, uint64)

--- a/internal/quaiapi/backend.go
+++ b/internal/quaiapi/backend.go
@@ -166,6 +166,7 @@ type Backend interface {
 	SendTxToSharingClients(tx *types.Transaction) error
 	GetRollingFeeInfo() (min, max, avg *big.Int)
 	QiTxPoolStatus(txHash common.Hash) *core.QiTxPoolStatus
+	GetBlockFilter(blockHash common.Hash) []byte
 
 	// Filter API
 	BloomStatus() (uint64, uint64)

--- a/internal/quaiapi/quai_api.go
+++ b/internal/quaiapi/quai_api.go
@@ -601,6 +601,27 @@ func (s *PublicBlockChainQuaiAPI) GetUTXO(ctx context.Context, txHash common.Has
 	return jsonOutpoint, nil
 }
 
+// GetBlockFilter returns the compact (GCS, BIP-158 parameters) block filter
+// for the given block hash. The filter commits to the addresses of all UTXOs
+// created and spent in the block; wallets match their addresses against it
+// locally and only fetch blocks that match, without revealing addresses to
+// the node. Returns null if no filter is available for the block (no Qi
+// activity, or the node does not index filters). The SipHash key is the
+// first 16 bytes of the block hash.
+func (s *PublicBlockChainQuaiAPI) GetBlockFilter(ctx context.Context, blockHash common.Hash) (map[string]interface{}, error) {
+	if s.b.NodeCtx() != common.ZONE_CTX {
+		return nil, errors.New("getBlockFilter call can only be made in zone chain")
+	}
+	filter := s.b.GetBlockFilter(blockHash)
+	if filter == nil {
+		return nil, nil
+	}
+	return map[string]interface{}{
+		"filter": hexutil.Bytes(filter),
+		"key":    hexutil.Bytes(blockHash.Bytes()[:16]),
+	}, nil
+}
+
 // GetProof returns the Merkle-proof for a given account and optionally some storage keys.
 func (s *PublicBlockChainQuaiAPI) GetProof(ctx context.Context, address common.Address, storageKeys []string, blockNrOrHash rpc.BlockNumberOrHash) (*AccountResult, error) {
 	nodeCtx := s.b.NodeCtx()

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -351,14 +351,24 @@ var (
 
 	ConversionStabilityForkBlock uint64 = 1872600
 
-	// QiUserLockForkBlock is the prime terminus number at which user-settable
-	// locks on Qi transaction outputs activate. Placeholder height, must be
-	// finalized before release.
+	// QiUserLockForkBlock is the prime terminus number at which the Qi
+	// off-chain contract primitives activate: user-settable locks on
+	// transaction outputs, and transaction-level locktimes. Placeholder
+	// height, must be finalized before release.
 	QiUserLockForkBlock uint64 = 2400000
 
 	// MaxQiUserLockDuration is the maximum number of blocks beyond the current
 	// height that a user-set Qi output lock may extend.
 	MaxQiUserLockDuration uint64 = BlocksPerYear
+
+	// QiTxLockTimeDataLength is the length of a Qi transaction Data field that
+	// carries an absolute transaction-level locktime: a big-endian uint64
+	// block height before which the transaction may not be included in a
+	// block. Unlike a UTXO Lock, which delays spending an output that already
+	// exists, a locktime delays the transaction itself, which is what lets two
+	// parties pre-sign competing spends of the same output that become valid
+	// at different heights. That ordering is the basis of payment channels.
+	QiTxLockTimeDataLength = 8
 )
 
 const (

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -350,6 +350,15 @@ var (
 	QiWrappingChangeBlock uint64 = 1570000
 
 	ConversionStabilityForkBlock uint64 = 1872600
+
+	// QiUserLockForkBlock is the prime terminus number at which user-settable
+	// locks on Qi transaction outputs activate. Placeholder height, must be
+	// finalized before release.
+	QiUserLockForkBlock uint64 = 2400000
+
+	// MaxQiUserLockDuration is the maximum number of blocks beyond the current
+	// height that a user-set Qi output lock may extend.
+	MaxQiUserLockDuration uint64 = BlocksPerYear
 )
 
 const (

--- a/qichannel/channel.go
+++ b/qichannel/channel.go
@@ -1,0 +1,461 @@
+// Package qichannel implements payment channels over the Qi UTXO ledger.
+//
+// A channel is a single funding UTXO paying to the hash of a 2-of-2 MuSig2
+// aggregate key. Because consensus verifies one aggregate Schnorr signature
+// over all input public keys, that address is indistinguishable on chain from
+// an ordinary single-key wallet address: opens, updates and closes all look
+// like plain payments.
+//
+// # State ordering
+//
+// Both parties hold a chain of pre-signed settlement transactions, all
+// spending the same funding output, each carrying a transaction-level
+// locktime that decreases as the state index grows. The newest state
+// therefore matures first, so an honest party can always publish it before
+// any stale state its counterparty holds becomes valid. This is the
+// decrementing-timelock construction; it needs no revocation secrets, no
+// penalty transactions and no watchtowers, at the cost of a bounded channel
+// lifetime and a defined window in which a party must act.
+//
+// State i matures at OpenHeight + (MaxStates-i)*SettlementDelta, so:
+//
+//   - the watch window for state i is [maturity(i), maturity(i-1)), one
+//     SettlementDelta wide: a party closing unilaterally must publish within
+//     it, or a stale state also becomes publishable and the outcome is a
+//     race;
+//   - the channel supports MaxStates updates and lives for
+//     MaxStates*SettlementDelta blocks.
+//
+// Cooperative closes carry no locktime and confirm immediately, so a
+// well-behaved channel never waits.
+//
+// # What this does not provide
+//
+// Perpetual (penalty-based) channels are not constructible on Qi: punishing a
+// cheater requires two spending paths from one output with different timing,
+// which needs a script system. Every construction here is time-bounded and
+// must be settled or rolled over before expiry.
+package qichannel
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
+	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/core/types"
+	"github.com/dominant-strategies/go-quai/crypto/adaptor"
+	"github.com/dominant-strategies/go-quai/params"
+	"github.com/dominant-strategies/go-quai/qiwallet"
+)
+
+var (
+	ErrChannelExhausted = errors.New("qichannel: no channel states remain; close or roll over")
+	ErrBalanceMismatch  = errors.New("qichannel: balances do not sum to the channel capacity less fees")
+	ErrNotEnoughKeys    = errors.New("qichannel: a channel needs exactly two participants")
+)
+
+// Params configures the timing and capacity of a channel.
+type Params struct {
+	ChainID  *big.Int
+	Location common.Location
+
+	// SettlementDelta is the number of blocks between successive states'
+	// maturity heights, and therefore the window in which a party must
+	// publish a unilateral close. Larger values are safer for parties that
+	// may be briefly offline; smaller values allow more updates within a
+	// given lifetime.
+	SettlementDelta uint64
+
+	// MaxStates bounds the number of channel updates. The channel's total
+	// lifetime is MaxStates*SettlementDelta blocks from the opening height.
+	MaxStates uint64
+}
+
+// DefaultParams returns a conservative configuration: a one-day window to
+// publish a unilateral close, and a lifetime of about one year.
+func DefaultParams(chainID *big.Int, location common.Location) Params {
+	return Params{
+		ChainID:         chainID,
+		Location:        location,
+		SettlementDelta: params.BlocksPerDay,
+		MaxStates:       365,
+	}
+}
+
+// Validate checks that the parameters describe a usable channel.
+func (p Params) Validate() error {
+	if p.ChainID == nil {
+		return errors.New("qichannel: chain ID is required")
+	}
+	if p.SettlementDelta == 0 {
+		return errors.New("qichannel: settlement delta must be positive")
+	}
+	if p.MaxStates == 0 {
+		return errors.New("qichannel: max states must be positive")
+	}
+	return nil
+}
+
+// Lifetime returns the number of blocks a channel remains usable for.
+func (p Params) Lifetime() uint64 { return p.MaxStates * p.SettlementDelta }
+
+// Channel is one party's view of a payment channel.
+type Channel struct {
+	Params
+
+	// LocalKey is this party's funding key; RemotePub is the counterparty's.
+	LocalKey  *btcec.PrivateKey
+	RemotePub *btcec.PublicKey
+
+	// aggKey is the 2-of-2 MuSig2 aggregate the funding output pays to.
+	aggKey *btcec.PublicKey
+
+	FundingAddress  common.Address
+	FundingOutPoint types.OutPoint
+	// Capacity is the value of the funding UTXO in qits.
+	Capacity *big.Int
+	// OpenHeight anchors the maturity schedule.
+	OpenHeight uint64
+
+	// StateIndex is the number of updates applied; 0 is the initial state.
+	StateIndex uint64
+	// LocalBalance and RemoteBalance are in qits and must sum to Capacity
+	// less the settlement fee and any in-flight PTLC amounts.
+	LocalBalance  *big.Int
+	RemoteBalance *big.Int
+
+	// PTLCs are payments currently in flight through this channel.
+	PTLCs []*PTLC
+}
+
+// FundingKeys returns the participants' public keys in the canonical order
+// used for key aggregation: the aggregate is order sensitive, so both parties
+// must agree. The keys are ordered lexicographically by compressed encoding.
+func FundingKeys(a, b *btcec.PublicKey) []*btcec.PublicKey {
+	aBytes := a.SerializeCompressed()
+	bBytes := b.SerializeCompressed()
+	for i := range aBytes {
+		if aBytes[i] != bBytes[i] {
+			if aBytes[i] < bBytes[i] {
+				return []*btcec.PublicKey{a, b}
+			}
+			return []*btcec.PublicKey{b, a}
+		}
+	}
+	return []*btcec.PublicKey{a, b}
+}
+
+// FundingAddressFor returns the Qi address a 2-of-2 channel between the two
+// keys is funded to, and whether it is usable in the given zone. Because the
+// aggregate key is determined by the participants' keys, one party must grind
+// its key until the aggregate lands in the zone's Qi scope; see
+// GrindFundingKey.
+func FundingAddressFor(a, b *btcec.PublicKey, location common.Location) (common.Address, bool, error) {
+	aggKey, err := adaptor.AggregateKeys(FundingKeys(a, b))
+	if err != nil {
+		return common.Address{}, false, err
+	}
+	addr := qiwallet.QiAddressFromKey(aggKey, location)
+	return addr, qiwallet.InQiScope(addr, location), nil
+}
+
+// GrindFundingKey derives fresh local keys until the 2-of-2 aggregate with
+// the counterparty lands in the zone's Qi address scope, which takes about
+// 512 attempts. Only one party needs to grind.
+func GrindFundingKey(remotePub *btcec.PublicKey, location common.Location) (*btcec.PrivateKey, common.Address, error) {
+	const maxAttempts = 65536
+	for i := 0; i < maxAttempts; i++ {
+		key, err := btcec.NewPrivateKey()
+		if err != nil {
+			return nil, common.Address{}, err
+		}
+		addr, ok, err := FundingAddressFor(key.PubKey(), remotePub, location)
+		if err != nil {
+			return nil, common.Address{}, err
+		}
+		if ok {
+			return key, addr, nil
+		}
+	}
+	return nil, common.Address{}, errors.New("qichannel: no funding key found in scope")
+}
+
+// New builds a channel view for one party. The funding UTXO must already pay
+// to the aggregate address, which callers obtain from GrindFundingKey.
+func New(p Params, localKey *btcec.PrivateKey, remotePub *btcec.PublicKey,
+	funding types.OutPoint, capacity *big.Int, openHeight uint64,
+	localBalance, remoteBalance *big.Int) (*Channel, error) {
+
+	if err := p.Validate(); err != nil {
+		return nil, err
+	}
+	if localKey == nil || remotePub == nil {
+		return nil, ErrNotEnoughKeys
+	}
+	aggKey, err := adaptor.AggregateKeys(FundingKeys(localKey.PubKey(), remotePub))
+	if err != nil {
+		return nil, err
+	}
+	addr := qiwallet.QiAddressFromKey(aggKey, p.Location)
+	if !qiwallet.InQiScope(addr, p.Location) {
+		return nil, fmt.Errorf("qichannel: aggregate address %s is not in Qi scope for %v", addr, p.Location)
+	}
+	return &Channel{
+		Params:          p,
+		LocalKey:        localKey,
+		RemotePub:       remotePub,
+		aggKey:          aggKey,
+		FundingAddress:  addr,
+		FundingOutPoint: funding,
+		Capacity:        new(big.Int).Set(capacity),
+		OpenHeight:      openHeight,
+		LocalBalance:    new(big.Int).Set(localBalance),
+		RemoteBalance:   new(big.Int).Set(remoteBalance),
+	}, nil
+}
+
+// AggregateKey returns the 2-of-2 key the funding output is addressed to.
+func (c *Channel) AggregateKey() *btcec.PublicKey { return c.aggKey }
+
+// MaturityHeight returns the height at which the settlement transaction for
+// a state becomes valid. Later states mature earlier, so the newest state can
+// always be published before any stale one.
+func (c *Channel) MaturityHeight(state uint64) uint64 {
+	if state >= c.MaxStates {
+		state = c.MaxStates - 1
+	}
+	return c.OpenHeight + (c.MaxStates-state)*c.SettlementDelta
+}
+
+// WatchWindow returns the height range in which a unilateral close of the
+// given state must be published: from its own maturity until the previous
+// state matures and becomes publishable too. For the initial state there is
+// no earlier state, so the window is open ended.
+func (c *Channel) WatchWindow(state uint64) (from uint64, to uint64) {
+	from = c.MaturityHeight(state)
+	if state == 0 {
+		return from, 0
+	}
+	return from, c.MaturityHeight(state - 1)
+}
+
+// ExpiryHeight is the height by which the channel must be closed or rolled
+// over: past it, no further state can be published inside its own window.
+func (c *Channel) ExpiryHeight() uint64 { return c.OpenHeight + c.Lifetime() }
+
+// RemainingUpdates reports how many further updates the channel supports.
+func (c *Channel) RemainingUpdates() uint64 {
+	if c.StateIndex+1 >= c.MaxStates {
+		return 0
+	}
+	return c.MaxStates - 1 - c.StateIndex
+}
+
+// Balances describes how a settlement splits the channel.
+type Balances struct {
+	// LocalNotes and RemoteNotes are the denominations paid to each party,
+	// and Addrs the fresh addresses receiving them (one per note).
+	LocalNotes  []uint8
+	LocalAddrs  []common.Address
+	RemoteNotes []uint8
+	RemoteAddrs []common.Address
+}
+
+// EncodeLockTime renders an absolute height as the Qi transaction Data field
+// that carries a transaction-level locktime.
+func EncodeLockTime(height uint64) []byte {
+	data := make([]byte, params.QiTxLockTimeDataLength)
+	binary.BigEndian.PutUint64(data, height)
+	return data
+}
+
+// BuildSettlement constructs the unsigned settlement transaction for a state:
+// a single-input spend of the funding output paying out the balances, with a
+// locktime set from the state's maturity height. The fee is the difference
+// between the channel capacity and the paid-out notes.
+//
+// Both parties build this identically and sign it with SignSettlement; each
+// keeps the fully signed transaction as its unilateral exit for that state.
+func (c *Channel) BuildSettlement(state uint64, balances Balances) (*types.QiTx, error) {
+	if state >= c.MaxStates {
+		return nil, ErrChannelExhausted
+	}
+	return c.buildSpend(balances, EncodeLockTime(c.MaturityHeight(state)))
+}
+
+// BuildCooperativeClose constructs a settlement with no locktime, which
+// confirms as soon as it is mined. This is the normal way to close: both
+// parties are online and agree on the final split, so no delay is needed and
+// the transaction is indistinguishable from an ordinary payment.
+func (c *Channel) BuildCooperativeClose(balances Balances) (*types.QiTx, error) {
+	return c.buildSpend(balances, nil)
+}
+
+func (c *Channel) buildSpend(balances Balances, data []byte) (*types.QiTx, error) {
+	if len(balances.LocalNotes) != len(balances.LocalAddrs) {
+		return nil, fmt.Errorf("qichannel: %d local notes but %d addresses", len(balances.LocalNotes), len(balances.LocalAddrs))
+	}
+	if len(balances.RemoteNotes) != len(balances.RemoteAddrs) {
+		return nil, fmt.Errorf("qichannel: %d remote notes but %d addresses", len(balances.RemoteNotes), len(balances.RemoteAddrs))
+	}
+	paid := new(big.Int).Add(qiwallet.NotesValue(balances.LocalNotes), qiwallet.NotesValue(balances.RemoteNotes))
+	if paid.Cmp(c.Capacity) > 0 {
+		return nil, ErrBalanceMismatch
+	}
+
+	seen := map[common.AddressBytes]struct{}{c.FundingAddress.Bytes20(): {}}
+	txOut := make([]types.TxOut, 0, len(balances.LocalNotes)+len(balances.RemoteNotes))
+	appendOutputs := func(notes []uint8, addrs []common.Address) error {
+		for i, note := range notes {
+			addr := addrs[i]
+			if !qiwallet.InQiScope(addr, c.Location) {
+				return fmt.Errorf("qichannel: settlement address %s is not in Qi scope", addr)
+			}
+			if _, dup := seen[addr.Bytes20()]; dup {
+				return fmt.Errorf("qichannel: address %s reused within the settlement", addr)
+			}
+			seen[addr.Bytes20()] = struct{}{}
+			txOut = append(txOut, types.TxOut{Denomination: note, Address: addr.Bytes()})
+		}
+		return nil
+	}
+	if err := appendOutputs(balances.LocalNotes, balances.LocalAddrs); err != nil {
+		return nil, err
+	}
+	if err := appendOutputs(balances.RemoteNotes, balances.RemoteAddrs); err != nil {
+		return nil, err
+	}
+
+	return &types.QiTx{
+		ChainID: c.ChainID,
+		TxIn: []types.TxIn{{
+			PreviousOutPoint: c.FundingOutPoint,
+			PubKey:           c.aggKey.SerializeCompressed(),
+		}},
+		TxOut: txOut,
+		Data:  data,
+	}, nil
+}
+
+// Update advances the channel to the next state with a new balance split.
+// The caller is responsible for exchanging signatures on the new settlement
+// before treating the update as complete: until both parties hold a signed
+// settlement for state N+1, state N remains the enforceable one.
+func (c *Channel) Update(localBalance, remoteBalance *big.Int) error {
+	if c.RemainingUpdates() == 0 {
+		return ErrChannelExhausted
+	}
+	total := new(big.Int).Add(localBalance, remoteBalance)
+	for _, ptlc := range c.PTLCs {
+		total.Add(total, ptlc.Amount)
+	}
+	if total.Cmp(c.Capacity) > 0 {
+		return ErrBalanceMismatch
+	}
+	c.StateIndex++
+	c.LocalBalance = new(big.Int).Set(localBalance)
+	c.RemoteBalance = new(big.Int).Set(remoteBalance)
+	return nil
+}
+
+// SigningSession drives the two-round MuSig2 protocol both parties run to
+// sign a settlement (or any other channel transaction). Each party creates a
+// session, exchanges public nonces, produces a partial signature, and
+// combines the two into the single aggregate signature consensus verifies.
+type SigningSession struct {
+	channel  *Channel
+	nonces   *musig2.Nonces
+	pubKeys  []*btcec.PublicKey
+	digest   [32]byte
+	combined [musig2.PubNonceSize]byte
+	haveAgg  bool
+}
+
+// NewSigningSession starts a signing session for a transaction. Every session
+// generates a fresh nonce, which must never be reused across transactions or
+// across attempts at the same transaction.
+func (c *Channel) NewSigningSession(tx *types.QiTx, signer types.Signer) (*SigningSession, error) {
+	nonces, err := musig2.GenNonces(musig2.WithPublicKey(c.LocalKey.PubKey()))
+	if err != nil {
+		return nil, err
+	}
+	digest := signer.Hash(types.NewTx(tx))
+	var msg [32]byte
+	copy(msg[:], digest[:])
+	return &SigningSession{
+		channel: c,
+		nonces:  nonces,
+		pubKeys: FundingKeys(c.LocalKey.PubKey(), c.RemotePub),
+		digest:  msg,
+	}, nil
+}
+
+// PublicNonce returns the nonce to send to the counterparty.
+func (s *SigningSession) PublicNonce() [musig2.PubNonceSize]byte { return s.nonces.PubNonce }
+
+// RegisterRemoteNonce aggregates the counterparty's nonce with the local one.
+func (s *SigningSession) RegisterRemoteNonce(remote [musig2.PubNonceSize]byte) error {
+	combined, err := musig2.AggregateNonces([][musig2.PubNonceSize]byte{s.nonces.PubNonce, remote})
+	if err != nil {
+		return err
+	}
+	s.combined = combined
+	s.haveAgg = true
+	return nil
+}
+
+// Sign produces this party's partial signature.
+func (s *SigningSession) Sign() (*musig2.PartialSignature, error) {
+	if !s.haveAgg {
+		return nil, errors.New("qichannel: remote nonce not registered")
+	}
+	return musig2.Sign(s.nonces.SecNonce, s.channel.LocalKey, s.combined, s.pubKeys, s.digest)
+}
+
+// SignAdaptor produces this party's partial signature locked to an adaptor
+// point, for a PTLC claim that may only be completed by revealing the
+// payment secret.
+func (s *SigningSession) SignAdaptor(point *btcec.PublicKey) (*musig2.PartialSignature, error) {
+	if !s.haveAgg {
+		return nil, errors.New("qichannel: remote nonce not registered")
+	}
+	return adaptor.PreSignPartial(s.nonces.SecNonce, s.channel.LocalKey, s.combined, s.pubKeys, s.digest, point)
+}
+
+// Combine aggregates both partial signatures into the final signature and
+// attaches it to the transaction.
+func (s *SigningSession) Combine(tx *types.QiTx, partials ...*musig2.PartialSignature) (*types.Transaction, error) {
+	if len(partials) == 0 {
+		return nil, errors.New("qichannel: no partial signatures")
+	}
+	sum := new(btcec.ModNScalar)
+	for _, partial := range partials {
+		if partial == nil || partial.S == nil {
+			return nil, errors.New("qichannel: nil partial signature")
+		}
+		sum.Add(partial.S)
+	}
+	var rX btcec.FieldVal
+	rX.SetByteSlice(schnorr.SerializePubKey(partials[0].R))
+	sig := schnorr.NewSignature(&rX, sum)
+	if !sig.Verify(s.digest[:], s.channel.aggKey) {
+		return nil, errors.New("qichannel: combined signature does not verify under the aggregate key")
+	}
+	signed := *tx
+	signed.Signature = sig
+	return types.NewTx(&signed), nil
+}
+
+// CombineAdaptor aggregates partial adaptor signatures into a single adaptor
+// signature over the channel's aggregate key.
+func (s *SigningSession) CombineAdaptor(point *btcec.PublicKey, partials ...*musig2.PartialSignature) (*adaptor.Signature, error) {
+	return adaptor.CombinePartials(partials, s.pubKeys, s.digest, point)
+}
+
+// Digest returns the signing digest for the session's transaction.
+func (s *SigningSession) Digest() [32]byte { return s.digest }

--- a/qichannel/contracts/QiPtlcChannel.sol
+++ b/qichannel/contracts/QiPtlcChannel.sol
@@ -1,0 +1,337 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title QiPtlcChannel
+/// @notice A two-party payment channel on the Quai EVM ledger that settles
+/// point timelocked contracts (PTLCs) against the same payment-point space
+/// used by Qi channels.
+///
+/// A routed payment is atomic across ledgers because every hop is locked to
+/// the same kind of condition: reveal the scalar `t` such that `t*G == T`.
+/// On Qi that condition is enforced by an adaptor signature; here it is
+/// enforced by `pointAddress` below. A routing node holding a Qi channel on
+/// one side and this contract on the other can therefore forward a payment
+/// between the two ledgers, learning the secret from whichever side settles
+/// first and using it to settle the other.
+///
+/// Unlike the Qi-side channels, this contract can adjudicate: a stale state
+/// can be replaced during a challenge window by a state carrying a higher
+/// nonce. Channels here are therefore perpetual, with no bounded update
+/// count and no expiry.
+contract QiPtlcChannel {
+    // secp256k1 generator x coordinate and group order.
+    uint256 private constant GX =
+        0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798;
+    uint256 private constant N =
+        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141;
+
+    /// @notice The generator has an even y coordinate, so recovering against
+    /// it uses v = 27.
+    uint8 private constant GENERATOR_PARITY = 27;
+
+    enum Status {
+        Open,
+        Closing,
+        Closed
+    }
+
+    /// @param point   Address commitment to the payment point T, i.e. the
+    ///                last 20 bytes of keccak256(T.x || T.y). This is exactly
+    ///                what ecrecover yields for the point, which is what
+    ///                makes the check below cheap.
+    /// @param amount  Value held by this PTLC, in wei.
+    /// @param deadline Block number after which the payer may reclaim it.
+    /// @param toPartyB True if party B is the payee, false if party A is.
+    struct Ptlc {
+        address point;
+        uint256 amount;
+        uint64 deadline;
+        bool toPartyB;
+    }
+
+    address public immutable partyA;
+    address public immutable partyB;
+
+    /// @notice Blocks a counterparty has to replace a stale closing state.
+    uint64 public immutable challengePeriod;
+
+    Status public status;
+    uint256 public depositA;
+    uint256 public depositB;
+
+    /// @notice The closing state currently on record.
+    uint256 public closingNonce;
+    uint256 public closingBalanceA;
+    uint256 public closingBalanceB;
+    uint64 public challengeDeadline;
+    Ptlc[] public closingPtlcs;
+    /// @notice Tracks which PTLCs of the closing state have been resolved.
+    mapping(uint256 => bool) public ptlcResolved;
+
+    event Funded(address indexed party, uint256 amount);
+    event ClosingStarted(uint256 indexed nonce, uint64 challengeDeadline);
+    event ClosingChallenged(uint256 indexed nonce, uint64 challengeDeadline);
+    /// @notice Emitted when a PTLC is claimed. The secret is published here
+    /// deliberately: it is what lets the upstream hop settle its own leg, and
+    /// is the mechanism that makes a routed payment atomic.
+    event SecretRevealed(address indexed point, uint256 secret);
+    event Settled(uint256 balanceA, uint256 balanceB);
+
+    error NotAParty();
+    error WrongStatus();
+    error BadSignature();
+    error StaleState();
+    error ChallengeOngoing();
+    error DeadlineNotReached();
+    error DeadlinePassed();
+    error AlreadyResolved();
+    error BadScalar();
+    error WrongSecret();
+    error BalanceMismatch();
+    error TransferFailed();
+
+    modifier onlyParty() {
+        if (msg.sender != partyA && msg.sender != partyB) revert NotAParty();
+        _;
+    }
+
+    constructor(address _partyA, address _partyB, uint64 _challengePeriod) {
+        require(_partyA != address(0) && _partyB != address(0) && _partyA != _partyB, "bad parties");
+        require(_challengePeriod > 0, "bad challenge period");
+        partyA = _partyA;
+        partyB = _partyB;
+        challengePeriod = _challengePeriod;
+    }
+
+    /// @notice Deposit funds into the channel. Only possible while open.
+    function fund() external payable onlyParty {
+        if (status != Status.Open) revert WrongStatus();
+        if (msg.sender == partyA) {
+            depositA += msg.value;
+        } else {
+            depositB += msg.value;
+        }
+        emit Funded(msg.sender, msg.value);
+    }
+
+    /// @notice Total value held by the channel.
+    function capacity() public view returns (uint256) {
+        return depositA + depositB;
+    }
+
+    /// @notice Hash of a channel state, signed by both parties off chain.
+    /// Binding the contract address in prevents a state signed for one
+    /// channel from being replayed against another.
+    function stateHash(
+        uint256 nonce,
+        uint256 balanceA,
+        uint256 balanceB,
+        Ptlc[] memory ptlcs
+    ) public view returns (bytes32) {
+        return keccak256(abi.encode(address(this), block.chainid, nonce, balanceA, balanceB, ptlcs));
+    }
+
+    /// @notice Close immediately on a state both parties agree on. No
+    /// challenge period is needed because neither party can be cheated by a
+    /// state they just signed.
+    function closeCooperative(
+        uint256 nonce,
+        uint256 balanceA,
+        uint256 balanceB,
+        bytes calldata signatureA,
+        bytes calldata signatureB
+    ) external onlyParty {
+        if (status == Status.Closed) revert WrongStatus();
+        bytes32 digest = stateHash(nonce, balanceA, balanceB, new Ptlc[](0));
+        _requireBothSignatures(digest, signatureA, signatureB);
+        if (balanceA + balanceB != capacity()) revert BalanceMismatch();
+
+        status = Status.Closed;
+        _payout(balanceA, balanceB);
+    }
+
+    /// @notice Begin a unilateral close with the latest state one holds. The
+    /// counterparty may replace it with a higher-nonce state until the
+    /// challenge deadline.
+    function startClose(
+        uint256 nonce,
+        uint256 balanceA,
+        uint256 balanceB,
+        Ptlc[] calldata ptlcs,
+        bytes calldata signatureA,
+        bytes calldata signatureB
+    ) external onlyParty {
+        if (status != Status.Open) revert WrongStatus();
+        _recordState(nonce, balanceA, balanceB, ptlcs, signatureA, signatureB);
+        status = Status.Closing;
+        emit ClosingStarted(nonce, challengeDeadline);
+    }
+
+    /// @notice Replace the recorded state with a strictly newer one. This is
+    /// what makes stale states unprofitable, and why channels on this side
+    /// need no expiry.
+    function challengeClose(
+        uint256 nonce,
+        uint256 balanceA,
+        uint256 balanceB,
+        Ptlc[] calldata ptlcs,
+        bytes calldata signatureA,
+        bytes calldata signatureB
+    ) external onlyParty {
+        if (status != Status.Closing) revert WrongStatus();
+        if (block.number > challengeDeadline) revert DeadlinePassed();
+        if (nonce <= closingNonce) revert StaleState();
+        _recordState(nonce, balanceA, balanceB, ptlcs, signatureA, signatureB);
+        emit ClosingChallenged(nonce, challengeDeadline);
+    }
+
+    function _recordState(
+        uint256 nonce,
+        uint256 balanceA,
+        uint256 balanceB,
+        Ptlc[] calldata ptlcs,
+        bytes calldata signatureA,
+        bytes calldata signatureB
+    ) private {
+        bytes32 digest = stateHash(nonce, balanceA, balanceB, ptlcs);
+        _requireBothSignatures(digest, signatureA, signatureB);
+
+        uint256 locked;
+        for (uint256 i = 0; i < ptlcs.length; i++) {
+            locked += ptlcs[i].amount;
+        }
+        if (balanceA + balanceB + locked != capacity()) revert BalanceMismatch();
+
+        // Clear any previously recorded PTLC resolutions before replacing.
+        for (uint256 i = 0; i < closingPtlcs.length; i++) {
+            delete ptlcResolved[i];
+        }
+        delete closingPtlcs;
+        for (uint256 i = 0; i < ptlcs.length; i++) {
+            closingPtlcs.push(ptlcs[i]);
+        }
+
+        closingNonce = nonce;
+        closingBalanceA = balanceA;
+        closingBalanceB = balanceB;
+        challengeDeadline = uint64(block.number) + challengePeriod;
+    }
+
+    /// @notice Derive the address commitment of the point `scalar * G`.
+    ///
+    /// ecrecover(h, v, r, s) returns the address of `r^-1 * (s*R - h*G)`,
+    /// where R is the curve point with x coordinate r and parity from v.
+    /// Taking h = 0, r = GX and s = scalar*GX mod N makes R the generator and
+    /// collapses the expression to `scalar * G`, so the precompile performs a
+    /// scalar multiplication for about 3000 gas.
+    function pointAddress(uint256 scalar) public pure returns (address) {
+        if (scalar == 0 || scalar >= N) revert BadScalar();
+        return ecrecover(bytes32(0), GENERATOR_PARITY, bytes32(GX), bytes32(mulmod(scalar, GX, N)));
+    }
+
+    /// @notice Claim a PTLC by revealing the scalar behind its payment point.
+    /// The secret is emitted so the payer's upstream hop can observe it and
+    /// settle its own leg.
+    function claimPtlc(uint256 index, uint256 secret) external {
+        if (status != Status.Closing) revert WrongStatus();
+        if (index >= closingPtlcs.length) revert AlreadyResolved();
+        if (ptlcResolved[index]) revert AlreadyResolved();
+
+        Ptlc storage ptlc = closingPtlcs[index];
+        if (block.number > ptlc.deadline) revert DeadlinePassed();
+        if (pointAddress(secret) != ptlc.point) revert WrongSecret();
+
+        ptlcResolved[index] = true;
+        if (ptlc.toPartyB) {
+            closingBalanceB += ptlc.amount;
+        } else {
+            closingBalanceA += ptlc.amount;
+        }
+        emit SecretRevealed(ptlc.point, secret);
+    }
+
+    /// @notice Reclaim a PTLC whose deadline has passed without a claim.
+    function refundPtlc(uint256 index) external {
+        if (status != Status.Closing) revert WrongStatus();
+        if (index >= closingPtlcs.length) revert AlreadyResolved();
+        if (ptlcResolved[index]) revert AlreadyResolved();
+
+        Ptlc storage ptlc = closingPtlcs[index];
+        if (block.number <= ptlc.deadline) revert DeadlineNotReached();
+
+        ptlcResolved[index] = true;
+        // The payer is whichever party is not the payee.
+        if (ptlc.toPartyB) {
+            closingBalanceA += ptlc.amount;
+        } else {
+            closingBalanceB += ptlc.amount;
+        }
+    }
+
+    /// @notice Pay out the recorded state once the challenge window has
+    /// closed and every PTLC has been claimed or refunded.
+    function finalize() external {
+        if (status != Status.Closing) revert WrongStatus();
+        if (block.number <= challengeDeadline) revert ChallengeOngoing();
+        for (uint256 i = 0; i < closingPtlcs.length; i++) {
+            if (!ptlcResolved[i]) {
+                // An unresolved PTLC past its deadline reverts to the payer.
+                if (block.number <= closingPtlcs[i].deadline) revert DeadlineNotReached();
+                ptlcResolved[i] = true;
+                if (closingPtlcs[i].toPartyB) {
+                    closingBalanceA += closingPtlcs[i].amount;
+                } else {
+                    closingBalanceB += closingPtlcs[i].amount;
+                }
+            }
+        }
+        status = Status.Closed;
+        _payout(closingBalanceA, closingBalanceB);
+    }
+
+    function _payout(uint256 balanceA, uint256 balanceB) private {
+        emit Settled(balanceA, balanceB);
+        if (balanceA > 0) {
+            (bool okA, ) = partyA.call{value: balanceA}("");
+            if (!okA) revert TransferFailed();
+        }
+        if (balanceB > 0) {
+            (bool okB, ) = partyB.call{value: balanceB}("");
+            if (!okB) revert TransferFailed();
+        }
+    }
+
+    function _requireBothSignatures(
+        bytes32 digest,
+        bytes calldata signatureA,
+        bytes calldata signatureB
+    ) private view {
+        if (_recover(digest, signatureA) != partyA) revert BadSignature();
+        if (_recover(digest, signatureB) != partyB) revert BadSignature();
+    }
+
+    function _recover(bytes32 digest, bytes calldata signature) private pure returns (address) {
+        if (signature.length != 65) revert BadSignature();
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        assembly {
+            r := calldataload(signature.offset)
+            s := calldataload(add(signature.offset, 32))
+            v := byte(0, calldataload(add(signature.offset, 64)))
+        }
+        if (v < 27) v += 27;
+        // Reject the malleable upper half of the s range.
+        if (uint256(s) > 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) {
+            revert BadSignature();
+        }
+        address recovered = ecrecover(digest, v, r, s);
+        if (recovered == address(0)) revert BadSignature();
+        return recovered;
+    }
+
+    /// @notice Number of PTLCs in the recorded closing state.
+    function closingPtlcCount() external view returns (uint256) {
+        return closingPtlcs.length;
+    }
+}

--- a/qichannel/invoice.go
+++ b/qichannel/invoice.go
@@ -1,0 +1,197 @@
+package qichannel
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/dominant-strategies/go-quai/common/hexutil"
+)
+
+// Ledger identifies which ledger an invoice is denominated on. The payment
+// layer is ledger agnostic: a route may traverse Qi channels and Quai
+// contract-channels interchangeably, because atomicity comes from the
+// payment point rather than from anything ledger specific.
+type Ledger uint8
+
+const (
+	LedgerQi Ledger = iota
+	LedgerQuai
+)
+
+func (l Ledger) String() string {
+	switch l {
+	case LedgerQi:
+		return "qi"
+	case LedgerQuai:
+		return "quai"
+	default:
+		return "unknown"
+	}
+}
+
+func parseLedger(s string) (Ledger, error) {
+	switch s {
+	case "qi":
+		return LedgerQi, nil
+	case "quai":
+		return LedgerQuai, nil
+	default:
+		return 0, fmt.Errorf("qichannel: unknown ledger %q", s)
+	}
+}
+
+// Invoice is a request for payment. The payee generates a payment secret,
+// keeps it, and publishes the corresponding point: any route that ends in a
+// PTLC locked to this point pays this invoice, and settling it necessarily
+// reveals the secret back up the route.
+//
+// The invoice carries no payment hash, unlike Lightning: the point IS the
+// identifier, and because each hop blinds it differently, the point never
+// appears on the wire between intermediaries.
+type Invoice struct {
+	// PaymentPoint is T = t*G, where t is the secret the payee holds.
+	PaymentPoint *btcec.PublicKey
+	// Destination is the payee's node key, used for routing and onion
+	// construction.
+	Destination *btcec.PublicKey
+	// Amount is the requested value, in the smallest unit of Ledger (qits
+	// for Qi).
+	Amount *big.Int
+	// Ledger is the ledger the payee wants to be paid on.
+	Ledger Ledger
+	// ExpiryHeight is the height after which the payee will no longer
+	// accept the payment; senders must choose a final PTLC deadline
+	// comfortably below it.
+	ExpiryHeight uint64
+	// Memo is an optional free-form description.
+	Memo string
+}
+
+// NewInvoice creates an invoice along with the payment secret the payee must
+// retain to claim it.
+func NewInvoice(destination *btcec.PublicKey, amount *big.Int, ledger Ledger, expiryHeight uint64, memo string) (*Invoice, *PaymentSecret, error) {
+	if destination == nil || amount == nil || amount.Sign() <= 0 {
+		return nil, nil, errors.New("qichannel: destination and a positive amount are required")
+	}
+	secret, point, err := NewPayment()
+	if err != nil {
+		return nil, nil, err
+	}
+	return &Invoice{
+		PaymentPoint: point,
+		Destination:  destination,
+		Amount:       amount,
+		Ledger:       ledger,
+		ExpiryHeight: expiryHeight,
+		Memo:         memo,
+	}, secret, nil
+}
+
+// Validate checks that an invoice is complete and not already expired at the
+// given height.
+func (inv *Invoice) Validate(currentHeight uint64) error {
+	if inv == nil || inv.PaymentPoint == nil || inv.Destination == nil {
+		return errors.New("qichannel: incomplete invoice")
+	}
+	if inv.Amount == nil || inv.Amount.Sign() <= 0 {
+		return errors.New("qichannel: invoice amount must be positive")
+	}
+	if inv.ExpiryHeight != 0 && currentHeight >= inv.ExpiryHeight {
+		return fmt.Errorf("qichannel: invoice expired at height %d", inv.ExpiryHeight)
+	}
+	return nil
+}
+
+// Encode renders an invoice as a compact, self-describing string:
+//
+//	qichan:<ledger>:<point>:<destination>:<amount>:<expiry>[:<memo>]
+//
+// Points and keys are hex-encoded compressed public keys, and amount and
+// expiry are hex quantities. This is deliberately simple; a production
+// deployment would want a checksummed, human-readable encoding.
+func (inv *Invoice) Encode() (string, error) {
+	if err := inv.Validate(0); err != nil {
+		return "", err
+	}
+	if strings.ContainsRune(inv.Memo, ':') {
+		return "", errors.New("qichannel: memo may not contain a colon")
+	}
+	var expiry [8]byte
+	binary.BigEndian.PutUint64(expiry[:], inv.ExpiryHeight)
+	parts := []string{
+		"qichan",
+		inv.Ledger.String(),
+		hexutil.Encode(inv.PaymentPoint.SerializeCompressed()),
+		hexutil.Encode(inv.Destination.SerializeCompressed()),
+		hexutil.Encode(inv.Amount.Bytes()),
+		hexutil.Encode(expiry[:]),
+	}
+	if inv.Memo != "" {
+		parts = append(parts, inv.Memo)
+	}
+	return strings.Join(parts, ":"), nil
+}
+
+// DecodeInvoice parses an encoded invoice.
+func DecodeInvoice(encoded string) (*Invoice, error) {
+	parts := strings.Split(encoded, ":")
+	if len(parts) < 6 || len(parts) > 7 || parts[0] != "qichan" {
+		return nil, errors.New("qichannel: malformed invoice")
+	}
+	ledger, err := parseLedger(parts[1])
+	if err != nil {
+		return nil, err
+	}
+	pointBytes, err := hexutil.Decode(parts[2])
+	if err != nil {
+		return nil, fmt.Errorf("qichannel: bad payment point: %w", err)
+	}
+	point, err := btcec.ParsePubKey(pointBytes)
+	if err != nil {
+		return nil, fmt.Errorf("qichannel: bad payment point: %w", err)
+	}
+	destBytes, err := hexutil.Decode(parts[3])
+	if err != nil {
+		return nil, fmt.Errorf("qichannel: bad destination: %w", err)
+	}
+	destination, err := btcec.ParsePubKey(destBytes)
+	if err != nil {
+		return nil, fmt.Errorf("qichannel: bad destination: %w", err)
+	}
+	amountBytes, err := hexutil.Decode(parts[4])
+	if err != nil {
+		return nil, fmt.Errorf("qichannel: bad amount: %w", err)
+	}
+	expiryBytes, err := hexutil.Decode(parts[5])
+	if err != nil {
+		return nil, fmt.Errorf("qichannel: bad expiry: %w", err)
+	}
+	if len(expiryBytes) != 8 {
+		return nil, errors.New("qichannel: bad expiry length")
+	}
+	inv := &Invoice{
+		PaymentPoint: point,
+		Destination:  destination,
+		Amount:       new(big.Int).SetBytes(amountBytes),
+		Ledger:       ledger,
+		ExpiryHeight: binary.BigEndian.Uint64(expiryBytes),
+	}
+	if len(parts) == 7 {
+		inv.Memo = parts[6]
+	}
+	return inv, inv.Validate(0)
+}
+
+// RouteFor builds a route that pays this invoice through the given nodes,
+// leaving safety margin between the final PTLC deadline and the invoice
+// expiry.
+func (inv *Invoice) RouteFor(nodes []*btcec.PublicKey, fees []*big.Int, finalDeadline, hopDelta uint64) (*Route, error) {
+	if inv.ExpiryHeight != 0 && finalDeadline >= inv.ExpiryHeight {
+		return nil, fmt.Errorf("qichannel: final deadline %d is not before the invoice expiry %d", finalDeadline, inv.ExpiryHeight)
+	}
+	return BuildRoute(inv.PaymentPoint, inv.Amount, nodes, fees, finalDeadline, hopDelta)
+}

--- a/qichannel/pointaddress.go
+++ b/qichannel/pointaddress.go
@@ -1,0 +1,85 @@
+package qichannel
+
+import (
+	"errors"
+	"math/big"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/crypto"
+)
+
+// Curve constants shared with the Quai-side channel contract.
+var (
+	// secp256k1GX is the x coordinate of the generator. The generator's y
+	// coordinate is even, which is why recovery against it uses v = 27.
+	secp256k1GX, _ = new(big.Int).SetString("79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798", 16)
+	// secp256k1N is the group order.
+	secp256k1N, _ = new(big.Int).SetString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141", 16)
+)
+
+// ErrBadScalar is returned for a scalar outside [1, n-1].
+var ErrBadScalar = errors.New("qichannel: scalar is outside the valid range")
+
+// PointAddress returns the 20-byte address commitment to a payment point:
+// the last 20 bytes of keccak256(T.x || T.y).
+//
+// This is the form a payment point takes on the Quai ledger. The channel
+// contract cannot afford to store or manipulate curve points directly, but it
+// can obtain exactly this value from the ecrecover precompile for about 3000
+// gas, so a Qi payment point and its Quai counterpart are the same condition
+// expressed two ways. That is what allows a single routed payment to cross
+// between the two ledgers.
+func PointAddress(point *btcec.PublicKey) common.AddressBytes {
+	var addr common.AddressBytes
+	if point == nil {
+		return addr
+	}
+	// Skip the 0x04 prefix of the uncompressed encoding, matching how an
+	// address is derived from a public key.
+	hashed := crypto.Keccak256(point.SerializeUncompressed()[1:])
+	copy(addr[:], hashed[12:])
+	return addr
+}
+
+// SecretPointAddress returns the point address a secret unlocks, which is
+// what a payee publishes and the contract stores.
+func SecretPointAddress(secret *PaymentSecret) (common.AddressBytes, error) {
+	if secret == nil || secret.IsZero() {
+		return common.AddressBytes{}, ErrBadScalar
+	}
+	var point btcec.JacobianPoint
+	btcec.ScalarBaseMultNonConst(secret, &point)
+	point.ToAffine()
+	return PointAddress(btcec.NewPublicKey(&point.X, &point.Y)), nil
+}
+
+// ContractRecoveryArgs returns the (hash, v, r, s) arguments the Quai-side
+// contract passes to ecrecover in order to compute the point address of a
+// scalar, i.e. what `pointAddress(secret)` evaluates in Solidity.
+//
+// ecrecover(h, v, r, s) recovers r^-1 * (s*R - h*G), where R is the curve
+// point with x coordinate r and parity from v. Taking h = 0, r = Gx and
+// s = secret*Gx mod n makes R the generator and collapses the expression to
+// secret*G, so the precompile performs a scalar multiplication.
+//
+// This function exists so the Go side can verify, against the same curve
+// implementation the EVM precompile uses, that the contract's constants and
+// derivation are correct.
+func ContractRecoveryArgs(secret *PaymentSecret) (hash [32]byte, v byte, r, s *big.Int, err error) {
+	if secret == nil || secret.IsZero() {
+		return hash, 0, nil, nil, ErrBadScalar
+	}
+	scalarBytes := secret.Bytes()
+	scalar := new(big.Int).SetBytes(scalarBytes[:])
+	if scalar.Sign() == 0 || scalar.Cmp(secp256k1N) >= 0 {
+		return hash, 0, nil, nil, ErrBadScalar
+	}
+	r = new(big.Int).Set(secp256k1GX)
+	s = new(big.Int).Mod(new(big.Int).Mul(scalar, secp256k1GX), secp256k1N)
+	if s.Sign() == 0 {
+		return hash, 0, nil, nil, ErrBadScalar
+	}
+	// v = 27 in Solidity terms; the Go recovery API uses 0-based recovery ids.
+	return hash, 0, r, s, nil
+}

--- a/qichannel/pointaddress_test.go
+++ b/qichannel/pointaddress_test.go
@@ -1,0 +1,151 @@
+package qichannel_test
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/dominant-strategies/go-quai/crypto"
+	"github.com/dominant-strategies/go-quai/qichannel"
+)
+
+// recoverPointAddress performs the recovery the Quai-side contract performs
+// via the ecrecover precompile, using the same secp256k1 implementation the
+// precompile is backed by.
+func recoverPointAddress(t *testing.T, secret *btcec.ModNScalar) []byte {
+	t.Helper()
+	hash, v, r, s, err := qichannel.ContractRecoveryArgs(secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sig := make([]byte, 65)
+	r.FillBytes(sig[0:32])
+	s.FillBytes(sig[32:64])
+	sig[64] = v
+
+	pubKey, err := crypto.Ecrecover(hash[:], sig)
+	if err != nil {
+		t.Fatalf("ecrecover failed: %v", err)
+	}
+	// Strip the 0x04 prefix and hash, matching how the precompile derives an
+	// address from the recovered point.
+	return crypto.Keccak256(pubKey[1:])[12:]
+}
+
+// TestContractPointAddressMatchesScalarMult is the load-bearing check for
+// cross-ledger routing: the contract verifies a payment secret by asking
+// ecrecover for the address of secret*G, and that must equal the address of
+// the payment point the payee committed to. If the contract's curve
+// constants or derivation were wrong, this would diverge.
+func TestContractPointAddressMatchesScalarMult(t *testing.T) {
+	for i := 0; i < 64; i++ {
+		secret, point, err := qichannel.NewPayment()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// What the payee publishes and the contract stores.
+		want := qichannel.PointAddress(point)
+		// What the contract computes from the revealed secret.
+		got := recoverPointAddress(t, secret)
+
+		if !bytes.Equal(want[:], got) {
+			t.Fatalf("iteration %d: contract recovery gives %x, want %x", i, got, want[:])
+		}
+
+		// SecretPointAddress must agree with both.
+		derived, err := qichannel.SecretPointAddress(secret)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if derived != want {
+			t.Fatalf("iteration %d: SecretPointAddress diverges from PointAddress", i)
+		}
+	}
+}
+
+// TestWrongSecretGivesDifferentAddress checks the contract's claim path
+// actually discriminates: a secret that is not the discrete log of the stored
+// point must not recover to it.
+func TestWrongSecretGivesDifferentAddress(t *testing.T) {
+	_, point, err := qichannel.NewPayment()
+	if err != nil {
+		t.Fatal(err)
+	}
+	other, _, err := qichannel.NewPayment()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := qichannel.PointAddress(point)
+	got := recoverPointAddress(t, other)
+	if bytes.Equal(want[:], got) {
+		t.Fatal("an unrelated secret recovered to the stored point address")
+	}
+}
+
+// TestBlindedPointsWorkOnBothLedgers checks that the per-hop blinding used
+// for route decorrelation survives the translation to the contract's
+// representation, so a hop may be a Qi channel on one side and this contract
+// on the other.
+func TestBlindedPointsWorkOnBothLedgers(t *testing.T) {
+	secret, point, err := qichannel.NewPayment()
+	if err != nil {
+		t.Fatal(err)
+	}
+	blinded, blind, err := qichannel.BlindPoint(point)
+	if err != nil {
+		t.Fatal(err)
+	}
+	blindedSecret := new(btcec.ModNScalar)
+	blindedSecret.Set(secret).Add(blind)
+
+	// The blinded point's on-chain commitment must be unlockable by the
+	// blinded secret, exactly as the unblinded pair is.
+	want := qichannel.PointAddress(blinded)
+	got := recoverPointAddress(t, blindedSecret)
+	if !bytes.Equal(want[:], got) {
+		t.Fatal("blinded point does not match the secret that should unlock it on the contract side")
+	}
+
+	// And the underlying secret is still recoverable from the blinded one,
+	// which is what lets the upstream hop settle.
+	if recovered := qichannel.UnblindSecret(blindedSecret, blind); !recovered.Equals(secret) {
+		t.Fatal("unblinding failed")
+	}
+}
+
+func TestContractRecoveryArgsRejectsBadScalars(t *testing.T) {
+	if _, _, _, _, err := qichannel.ContractRecoveryArgs(nil); err == nil {
+		t.Fatal("expected nil scalar to be rejected")
+	}
+	zero := new(btcec.ModNScalar)
+	if _, _, _, _, err := qichannel.ContractRecoveryArgs(zero); err == nil {
+		t.Fatal("expected zero scalar to be rejected")
+	}
+	if _, err := qichannel.SecretPointAddress(zero); err == nil {
+		t.Fatal("expected zero scalar to be rejected")
+	}
+}
+
+// TestRecoveryArgsUseGeneratorConstants pins the r value the contract passes
+// to ecrecover to the generator's x coordinate, since the trick only reduces
+// to a scalar multiplication for that specific point.
+func TestRecoveryArgsUseGeneratorConstants(t *testing.T) {
+	secret, _, err := qichannel.NewPayment()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, r, s, err := qichannel.ContractRecoveryArgs(secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gx, _ := new(big.Int).SetString("79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798", 16)
+	n, _ := new(big.Int).SetString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141", 16)
+	if r.Cmp(gx) != 0 {
+		t.Fatal("r is not the generator x coordinate")
+	}
+	if s.Sign() == 0 || s.Cmp(n) >= 0 {
+		t.Fatal("s is outside the valid range")
+	}
+}

--- a/qichannel/ptlc.go
+++ b/qichannel/ptlc.go
@@ -1,0 +1,193 @@
+package qichannel
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/core/types"
+	"github.com/dominant-strategies/go-quai/crypto/adaptor"
+	"github.com/dominant-strategies/go-quai/qiwallet"
+)
+
+// PTLC is a point timelocked contract: an amount held in a channel that the
+// payee can claim by revealing the discrete log of PaymentPoint, and that
+// otherwise reverts to the payer after Deadline.
+//
+// PTLCs replace Lightning's HTLCs. The claim condition lives entirely in an
+// adaptor signature rather than in a script, which is what makes them
+// expressible on Qi at all - and, as a bonus, lets every hop of a route use a
+// different point, so intermediaries cannot correlate a payment across hops
+// the way a shared payment hash allows.
+type PTLC struct {
+	// PaymentPoint is T = t*G; claiming requires revealing t.
+	PaymentPoint *btcec.PublicKey
+	// Amount is the value held, in qits.
+	Amount *big.Int
+	// Deadline is the height after which the payer may reclaim the amount.
+	Deadline uint64
+	// Incoming reports whether this node is the payee (true) or payer.
+	Incoming bool
+}
+
+// PaymentSecret is the scalar that unlocks a PTLC.
+type PaymentSecret = btcec.ModNScalar
+
+// NewPayment generates a fresh payment secret and its point. The payee
+// generates this, keeps the secret, and publishes the point in an invoice.
+func NewPayment() (*PaymentSecret, *btcec.PublicKey, error) {
+	return adaptor.NewSecret()
+}
+
+// BlindPoint returns T + r*G together with r, for decorrelating a payment
+// across hops: each hop is locked to a different point, so two colluding
+// intermediaries cannot tell they are forwarding the same payment.
+func BlindPoint(point *btcec.PublicKey) (*btcec.PublicKey, *PaymentSecret, error) {
+	blind, blindPoint, err := adaptor.NewSecret()
+	if err != nil {
+		return nil, nil, err
+	}
+	blinded, err := adaptor.AddPoints(point, blindPoint)
+	if err != nil {
+		return nil, nil, err
+	}
+	return blinded, blind, nil
+}
+
+// UnblindSecret recovers the underlying payment secret from the secret that
+// satisfied a blinded point: t = t' - r.
+func UnblindSecret(blindedSecret, blind *PaymentSecret) *PaymentSecret {
+	var negated btcec.ModNScalar
+	negated.Set(blind)
+	negated.Negate()
+	secret := new(btcec.ModNScalar)
+	secret.Set(blindedSecret).Add(&negated)
+	return secret
+}
+
+// AddPTLC registers an in-flight payment against the channel, reserving its
+// amount from the payer's balance.
+func (c *Channel) AddPTLC(ptlc *PTLC) error {
+	if ptlc == nil || ptlc.PaymentPoint == nil || ptlc.Amount == nil {
+		return errors.New("qichannel: incomplete PTLC")
+	}
+	if ptlc.Deadline >= c.ExpiryHeight() {
+		return fmt.Errorf("qichannel: PTLC deadline %d is beyond the channel expiry %d", ptlc.Deadline, c.ExpiryHeight())
+	}
+	payer := c.LocalBalance
+	if ptlc.Incoming {
+		payer = c.RemoteBalance
+	}
+	if payer.Cmp(ptlc.Amount) < 0 {
+		return fmt.Errorf("qichannel: PTLC amount %s exceeds the payer's balance %s", ptlc.Amount, payer)
+	}
+	payer.Sub(payer, ptlc.Amount)
+	c.PTLCs = append(c.PTLCs, ptlc)
+	return nil
+}
+
+// SettlePTLC removes a PTLC and credits its amount to the payee, which is
+// what both parties do off-chain once the payment secret is revealed.
+func (c *Channel) SettlePTLC(ptlc *PTLC, claimed bool) error {
+	for i, existing := range c.PTLCs {
+		if existing != ptlc {
+			continue
+		}
+		c.PTLCs = append(c.PTLCs[:i], c.PTLCs[i+1:]...)
+		payee, payer := c.RemoteBalance, c.LocalBalance
+		if ptlc.Incoming {
+			payee, payer = c.LocalBalance, c.RemoteBalance
+		}
+		if claimed {
+			payee.Add(payee, ptlc.Amount)
+		} else {
+			payer.Add(payer, ptlc.Amount)
+		}
+		return nil
+	}
+	return errors.New("qichannel: PTLC not found in this channel")
+}
+
+// PTLCOutput describes the on-chain output a PTLC occupies when a channel is
+// closed unilaterally while the payment is still in flight. It pays to a
+// 2-of-2 aggregate, and is resolved by one of two pre-signed spends: a claim
+// (adaptor locked to the payment point) or a refund (locktimed to the
+// deadline).
+type PTLCOutput struct {
+	OutPoint     types.OutPoint
+	Denomination uint8
+	AggregateKey *btcec.PublicKey
+}
+
+// BuildPTLCClaim constructs the unsigned transaction the payee uses to claim
+// a PTLC output. It carries no locktime, so it is valid immediately: the only
+// thing standing between the payee and the funds is the adaptor signature,
+// which requires the payment secret. Publishing it reveals that secret, which
+// is exactly what lets the upstream hop claim in turn.
+func (c *Channel) BuildPTLCClaim(out PTLCOutput, payeeNotes []uint8, payeeAddrs []common.Address) (*types.QiTx, error) {
+	return c.buildPTLCSpend(out, payeeNotes, payeeAddrs, nil)
+}
+
+// BuildPTLCRefund constructs the unsigned transaction the payer uses to
+// reclaim a PTLC output once its deadline passes. Its locktime is the
+// deadline, so it cannot confirm earlier - which is what guarantees the payee
+// a window in which only the claim path is available.
+func (c *Channel) BuildPTLCRefund(out PTLCOutput, deadline uint64, payerNotes []uint8, payerAddrs []common.Address) (*types.QiTx, error) {
+	return c.buildPTLCSpend(out, payerNotes, payerAddrs, EncodeLockTime(deadline))
+}
+
+func (c *Channel) buildPTLCSpend(out PTLCOutput, notes []uint8, addrs []common.Address, data []byte) (*types.QiTx, error) {
+	if len(notes) != len(addrs) {
+		return nil, fmt.Errorf("qichannel: %d notes but %d addresses", len(notes), len(addrs))
+	}
+	if out.AggregateKey == nil {
+		return nil, errors.New("qichannel: PTLC output has no aggregate key")
+	}
+	seen := make(map[common.AddressBytes]struct{})
+	txOut := make([]types.TxOut, 0, len(notes))
+	for i, note := range notes {
+		addr := addrs[i]
+		if !qiwallet.InQiScope(addr, c.Location) {
+			return nil, fmt.Errorf("qichannel: address %s is not in Qi scope", addr)
+		}
+		if _, dup := seen[addr.Bytes20()]; dup {
+			return nil, fmt.Errorf("qichannel: address %s reused within the transaction", addr)
+		}
+		seen[addr.Bytes20()] = struct{}{}
+		txOut = append(txOut, types.TxOut{Denomination: note, Address: addr.Bytes()})
+	}
+	return &types.QiTx{
+		ChainID: c.ChainID,
+		TxIn: []types.TxIn{{
+			PreviousOutPoint: out.OutPoint,
+			PubKey:           out.AggregateKey.SerializeCompressed(),
+		}},
+		TxOut: txOut,
+		Data:  data,
+	}, nil
+}
+
+// ClaimWithSecret completes an adaptor-signed claim transaction with the
+// payment secret, producing a broadcastable transaction.
+func ClaimWithSecret(tx *types.QiTx, sig *adaptor.Signature, secret *PaymentSecret) (*types.Transaction, error) {
+	final, err := sig.Adapt(secret)
+	if err != nil {
+		return nil, err
+	}
+	claimed := *tx
+	claimed.Signature = final
+	return types.NewTx(&claimed), nil
+}
+
+// SecretFromClaim recovers the payment secret from a claim transaction that
+// the payee has published, given the adaptor signature it was completed from.
+// A routing node calls this on the downstream settlement to learn what it
+// needs to settle upstream.
+func SecretFromClaim(sig *adaptor.Signature, claimed *types.Transaction) (*PaymentSecret, error) {
+	if claimed.GetSchnorrSignature() == nil {
+		return nil, errors.New("qichannel: claim transaction is unsigned")
+	}
+	return sig.Extract(claimed.GetSchnorrSignature())
+}

--- a/qichannel/qichannel_test.go
+++ b/qichannel/qichannel_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/dominant-strategies/go-quai/core"
 	"github.com/dominant-strategies/go-quai/core/types"
+	"github.com/dominant-strategies/go-quai/crypto/adaptor"
 	"github.com/dominant-strategies/go-quai/qichannel"
 	"github.com/dominant-strategies/go-quai/qiwallet"
 )
@@ -16,6 +17,11 @@ var (
 	testLocation = common.Location{0, 0}
 	testChainID  = big.NewInt(1337)
 )
+
+func adaptorVerifySecret(t *testing.T, secret *btcec.ModNScalar, point *btcec.PublicKey) bool {
+	t.Helper()
+	return adaptor.VerifySecret(secret, point)
+}
 
 func newKey(t *testing.T) *btcec.PrivateKey {
 	t.Helper()
@@ -342,5 +348,58 @@ func TestRouteFitsChannels(t *testing.T) {
 	}
 	if err := late.FitsChannels([]*qichannel.Channel{a}); err == nil {
 		t.Fatal("expected a route past channel expiry to be rejected")
+	}
+}
+
+func TestInvoiceRoundTrip(t *testing.T) {
+	dest := newKey(t).PubKey()
+	inv, secret, err := qichannel.NewInvoice(dest, big.NewInt(12345), qichannel.LedgerQi, 9000, "coffee")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if secret == nil {
+		t.Fatal("no payment secret returned")
+	}
+	encoded, err := inv.Encode()
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := qichannel.DecodeInvoice(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !decoded.PaymentPoint.IsEqual(inv.PaymentPoint) || !decoded.Destination.IsEqual(inv.Destination) {
+		t.Fatal("keys did not survive the round trip")
+	}
+	if decoded.Amount.Cmp(inv.Amount) != 0 || decoded.ExpiryHeight != inv.ExpiryHeight ||
+		decoded.Ledger != inv.Ledger || decoded.Memo != inv.Memo {
+		t.Fatal("fields did not survive the round trip")
+	}
+	// The payment point must be exactly the point of the retained secret.
+	if !adaptorVerifySecret(t, secret, inv.PaymentPoint) {
+		t.Fatal("invoice point is not the point of the payment secret")
+	}
+	// Expired invoices and malformed strings must be rejected.
+	if err := inv.Validate(9000); err == nil {
+		t.Fatal("expected an expired invoice to be rejected")
+	}
+	if _, err := qichannel.DecodeInvoice("qichan:qi:nonsense"); err == nil {
+		t.Fatal("expected malformed invoice to be rejected")
+	}
+}
+
+func TestInvoiceRouteRespectsExpiry(t *testing.T) {
+	dest := newKey(t).PubKey()
+	inv, _, err := qichannel.NewInvoice(dest, big.NewInt(1000), qichannel.LedgerQi, 5000, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	nodes := []*btcec.PublicKey{newKey(t).PubKey()}
+	fees := []*big.Int{big.NewInt(0)}
+	if _, err := inv.RouteFor(nodes, fees, 4000, 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := inv.RouteFor(nodes, fees, 5000, 0); err == nil {
+		t.Fatal("expected a deadline at or past invoice expiry to be rejected")
 	}
 }

--- a/qichannel/qichannel_test.go
+++ b/qichannel/qichannel_test.go
@@ -1,0 +1,346 @@
+package qichannel_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/core"
+	"github.com/dominant-strategies/go-quai/core/types"
+	"github.com/dominant-strategies/go-quai/qichannel"
+	"github.com/dominant-strategies/go-quai/qiwallet"
+)
+
+var (
+	testLocation = common.Location{0, 0}
+	testChainID  = big.NewInt(1337)
+)
+
+func newKey(t *testing.T) *btcec.PrivateKey {
+	t.Helper()
+	key, err := btcec.NewPrivateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return key
+}
+
+// openChannel sets up both parties' views of the same channel.
+func openChannel(t *testing.T, capacity int64, openHeight uint64) (*qichannel.Channel, *qichannel.Channel) {
+	t.Helper()
+	remote := newKey(t)
+	local, addr, err := qichannel.GrindFundingKey(remote.PubKey(), testLocation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !qiwallet.InQiScope(addr, testLocation) {
+		t.Fatal("ground funding address is not in Qi scope")
+	}
+
+	var fundingHash common.Hash
+	fundingHash[0] = 0xAB
+	funding := types.OutPoint{TxHash: fundingHash, Index: 0}
+	p := qichannel.DefaultParams(testChainID, testLocation)
+
+	half := big.NewInt(capacity / 2)
+	a, err := qichannel.New(p, local, remote.PubKey(), funding, big.NewInt(capacity), openHeight, half, half)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := qichannel.New(p, remote, local.PubKey(), funding, big.NewInt(capacity), openHeight, half, half)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Both parties must derive the same funding address and aggregate key.
+	if !a.FundingAddress.Equal(b.FundingAddress) {
+		t.Fatal("parties disagree on the funding address")
+	}
+	if !a.AggregateKey().IsEqual(b.AggregateKey()) {
+		t.Fatal("parties disagree on the aggregate key")
+	}
+	return a, b
+}
+
+// TestMaturityOrdering is the security property the construction rests on:
+// newer states must mature strictly earlier, so an honest party can always
+// publish the latest state before any stale one its counterparty holds
+// becomes valid.
+func TestMaturityOrdering(t *testing.T) {
+	a, _ := openChannel(t, 100000, 1000)
+	prev := a.MaturityHeight(0)
+	for state := uint64(1); state < a.MaxStates; state++ {
+		cur := a.MaturityHeight(state)
+		if cur >= prev {
+			t.Fatalf("state %d matures at %d, not before state %d at %d", state, cur, state-1, prev)
+		}
+		if prev-cur != a.SettlementDelta {
+			t.Fatalf("state %d watch window is %d, want %d", state, prev-cur, a.SettlementDelta)
+		}
+		prev = cur
+	}
+	// The watch window for a state ends when the previous state matures.
+	from, to := a.WatchWindow(5)
+	if from != a.MaturityHeight(5) || to != a.MaturityHeight(4) {
+		t.Fatal("watch window does not span until the previous state matures")
+	}
+	if _, openEnded := a.WatchWindow(0); openEnded != 0 {
+		t.Fatal("the initial state should have an open ended window")
+	}
+}
+
+func TestUpdateAccounting(t *testing.T) {
+	a, _ := openChannel(t, 100000, 1000)
+	if err := a.Update(big.NewInt(40000), big.NewInt(60000)); err != nil {
+		t.Fatal(err)
+	}
+	if a.StateIndex != 1 {
+		t.Fatalf("state index %d, want 1", a.StateIndex)
+	}
+	// Overspending the channel must be rejected.
+	if err := a.Update(big.NewInt(90000), big.NewInt(90000)); err == nil {
+		t.Fatal("expected overspend to be rejected")
+	}
+	// Exhausting the update budget must be reported, not silently allowed.
+	a.StateIndex = a.MaxStates - 1
+	if a.RemainingUpdates() != 0 {
+		t.Fatal("expected no remaining updates")
+	}
+	if err := a.Update(big.NewInt(1), big.NewInt(1)); err == nil {
+		t.Fatal("expected exhausted channel to reject updates")
+	}
+}
+
+func settlementAddrs(t *testing.T, n int) []common.Address {
+	t.Helper()
+	addrs := make([]common.Address, n)
+	for i := range addrs {
+		_, addr, _, err := qiwallet.GrindQiAddress(testLocation, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		addrs[i] = addr
+	}
+	return addrs
+}
+
+// TestSettlementCarriesLockTime checks that settlements are locktimed to
+// their state's maturity and cooperative closes are not, and that the
+// locktime is the encoding consensus recognizes.
+func TestSettlementCarriesLockTime(t *testing.T) {
+	a, _ := openChannel(t, 100000, 1000)
+	balances := qichannel.Balances{
+		LocalNotes: []uint8{6}, LocalAddrs: settlementAddrs(t, 1),
+		RemoteNotes: []uint8{6}, RemoteAddrs: settlementAddrs(t, 1),
+	}
+	settlement, err := a.BuildSettlement(3, balances)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lockTime, ok := core.QiTxLockTime(types.NewTx(settlement))
+	if !ok {
+		t.Fatal("settlement carries no locktime")
+	}
+	if lockTime != a.MaturityHeight(3) {
+		t.Fatalf("locktime %d, want maturity %d", lockTime, a.MaturityHeight(3))
+	}
+
+	coop, err := a.BuildCooperativeClose(balances)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(coop.Data) != 0 {
+		t.Fatal("cooperative close should carry no locktime")
+	}
+	// Settlement spends exactly the funding output, under the aggregate key.
+	if len(settlement.TxIn) != 1 || settlement.TxIn[0].PreviousOutPoint != a.FundingOutPoint {
+		t.Fatal("settlement does not spend the funding output")
+	}
+}
+
+func TestSettlementRejectsBadBalances(t *testing.T) {
+	a, _ := openChannel(t, 2000, 1000)
+	addrs := settlementAddrs(t, 2)
+	// Paying out more than the capacity must fail.
+	_, err := a.BuildSettlement(0, qichannel.Balances{
+		LocalNotes: []uint8{10}, LocalAddrs: addrs[:1],
+		RemoteNotes: []uint8{10}, RemoteAddrs: addrs[1:],
+	})
+	if err == nil {
+		t.Fatal("expected overspending settlement to be rejected")
+	}
+	// Reusing an address across outputs violates the consensus rule.
+	_, err = a.BuildSettlement(0, qichannel.Balances{
+		LocalNotes: []uint8{6}, LocalAddrs: addrs[:1],
+		RemoteNotes: []uint8{6}, RemoteAddrs: addrs[:1],
+	})
+	if err == nil {
+		t.Fatal("expected address reuse to be rejected")
+	}
+}
+
+// TestCooperativeSigning runs the full two-round MuSig2 exchange between the
+// two parties and checks the result verifies under the aggregate key, which
+// is what Qi consensus checks.
+func TestCooperativeSigning(t *testing.T) {
+	a, b := openChannel(t, 100000, 1000)
+	balances := qichannel.Balances{
+		LocalNotes: []uint8{6}, LocalAddrs: settlementAddrs(t, 1),
+		RemoteNotes: []uint8{6}, RemoteAddrs: settlementAddrs(t, 1),
+	}
+	tx, err := a.BuildCooperativeClose(balances)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer := types.LatestSignerForChainID(testChainID, testLocation)
+
+	sessionA, err := a.NewSigningSession(tx, signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessionB, err := b.NewSigningSession(tx, signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sessionA.RegisterRemoteNonce(sessionB.PublicNonce()); err != nil {
+		t.Fatal(err)
+	}
+	if err := sessionB.RegisterRemoteNonce(sessionA.PublicNonce()); err != nil {
+		t.Fatal(err)
+	}
+	partialA, err := sessionA.Sign()
+	if err != nil {
+		t.Fatal(err)
+	}
+	partialB, err := sessionB.Sign()
+	if err != nil {
+		t.Fatal(err)
+	}
+	signed, err := sessionA.Combine(tx, partialA, partialB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Verify the way consensus does.
+	digest := signer.Hash(signed)
+	if !signed.GetSchnorrSignature().Verify(digest[:], a.AggregateKey()) {
+		t.Fatal("signed settlement does not verify under the aggregate key")
+	}
+	// One party alone must not be able to produce a valid signature.
+	if _, err := sessionA.Combine(tx, partialA); err == nil {
+		t.Fatal("a single partial signature produced a valid settlement")
+	}
+}
+
+func TestPTLCAccounting(t *testing.T) {
+	a, _ := openChannel(t, 100000, 1000)
+	_, point, err := qichannel.NewPayment()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ptlc := &qichannel.PTLC{PaymentPoint: point, Amount: big.NewInt(10000), Deadline: a.OpenHeight + 100}
+	if err := a.AddPTLC(ptlc); err != nil {
+		t.Fatal(err)
+	}
+	if a.LocalBalance.Cmp(big.NewInt(40000)) != 0 {
+		t.Fatalf("payer balance %s, want 40000", a.LocalBalance)
+	}
+	if err := a.SettlePTLC(ptlc, true); err != nil {
+		t.Fatal(err)
+	}
+	if a.RemoteBalance.Cmp(big.NewInt(60000)) != 0 {
+		t.Fatalf("payee balance %s, want 60000", a.RemoteBalance)
+	}
+	// A deadline beyond the channel's own expiry is unenforceable.
+	late := &qichannel.PTLC{PaymentPoint: point, Amount: big.NewInt(1), Deadline: a.ExpiryHeight() + 1}
+	if err := a.AddPTLC(late); err == nil {
+		t.Fatal("expected a PTLC past channel expiry to be rejected")
+	}
+	// A PTLC larger than the payer's balance must be rejected.
+	oversized := &qichannel.PTLC{PaymentPoint: point, Amount: a.Capacity, Deadline: a.OpenHeight + 100}
+	if err := a.AddPTLC(oversized); err == nil {
+		t.Fatal("expected an oversized PTLC to be rejected")
+	}
+}
+
+func TestBlindingRoundTrip(t *testing.T) {
+	secret, point, err := qichannel.NewPayment()
+	if err != nil {
+		t.Fatal(err)
+	}
+	blinded, blind, err := qichannel.BlindPoint(point)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if blinded.IsEqual(point) {
+		t.Fatal("blinded point equals the original")
+	}
+	// The secret satisfying the blinded point is t + r, and removing r
+	// recovers t.
+	blindedSecret := new(btcec.ModNScalar)
+	blindedSecret.Set(secret).Add(blind)
+	if got := qichannel.UnblindSecret(blindedSecret, blind); !got.Equals(secret) {
+		t.Fatal("unblinding did not recover the payment secret")
+	}
+}
+
+func TestBuildRouteStaircase(t *testing.T) {
+	_, point, err := qichannel.NewPayment()
+	if err != nil {
+		t.Fatal(err)
+	}
+	nodes := []*btcec.PublicKey{newKey(t).PubKey(), newKey(t).PubKey(), newKey(t).PubKey()}
+	fees := []*big.Int{big.NewInt(0), big.NewInt(100), big.NewInt(50)}
+	route, err := qichannel.BuildRoute(point, big.NewInt(10000), nodes, fees, 5000, qichannel.DefaultHopDelta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := route.Validate(qichannel.DefaultHopDelta); err != nil {
+		t.Fatal(err)
+	}
+	// Deadlines must decrease toward the payee, amounts must decrease too.
+	for i := 1; i < len(route.Hops); i++ {
+		if route.Hops[i].Deadline >= route.Hops[i-1].Deadline {
+			t.Fatalf("hop %d deadline is not earlier than hop %d", i, i-1)
+		}
+		if route.Hops[i].Amount.Cmp(route.Hops[i-1].Amount) > 0 {
+			t.Fatalf("hop %d forwards more than hop %d", i, i-1)
+		}
+	}
+	// The sender pays the delivered amount plus all downstream fees.
+	if route.TotalAmount.Cmp(big.NewInt(10000+100+50)) != 0 {
+		t.Fatalf("total amount %s, want 10150", route.TotalAmount)
+	}
+	// Every hop is locked to a distinct point (decorrelation).
+	for i := range route.Hops {
+		for j := i + 1; j < len(route.Hops); j++ {
+			if route.Hops[i].PaymentPoint.IsEqual(route.Hops[j].PaymentPoint) {
+				t.Fatalf("hops %d and %d share a payment point", i, j)
+			}
+		}
+	}
+}
+
+func TestRouteFitsChannels(t *testing.T) {
+	a, _ := openChannel(t, 100000, 1000)
+	_, point, err := qichannel.NewPayment()
+	if err != nil {
+		t.Fatal(err)
+	}
+	nodes := []*btcec.PublicKey{newKey(t).PubKey()}
+	// A deadline inside the channel's life is fine.
+	route, err := qichannel.BuildRoute(point, big.NewInt(1000), nodes, []*big.Int{big.NewInt(0)}, a.OpenHeight+10, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := route.FitsChannels([]*qichannel.Channel{a}); err != nil {
+		t.Fatal(err)
+	}
+	// One past its expiry is not.
+	late, err := qichannel.BuildRoute(point, big.NewInt(1000), nodes, []*big.Int{big.NewInt(0)}, a.ExpiryHeight()+1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := late.FitsChannels([]*qichannel.Channel{a}); err == nil {
+		t.Fatal("expected a route past channel expiry to be rejected")
+	}
+}

--- a/qichannel/route.go
+++ b/qichannel/route.go
@@ -1,0 +1,141 @@
+package qichannel
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+)
+
+// DefaultHopDelta is the safety margin between consecutive hops' PTLC
+// deadlines: the number of blocks a routing node has to settle upstream after
+// being settled downstream, including time to get a transaction confirmed.
+const DefaultHopDelta uint64 = 144
+
+// Hop is one leg of a route.
+type Hop struct {
+	// Node identifies the peer this hop forwards to.
+	Node *btcec.PublicKey
+	// Amount is the value forwarded on this hop in qits, including the fees
+	// of all downstream hops.
+	Amount *big.Int
+	// Fee is what this hop's forwarding node keeps.
+	Fee *big.Int
+	// Deadline is the PTLC deadline on this hop.
+	Deadline uint64
+	// PaymentPoint is the (blinded) point this hop is locked to.
+	PaymentPoint *btcec.PublicKey
+	// Blind is the offset added to the payment point for this hop, known
+	// only to the sender.
+	Blind *PaymentSecret
+}
+
+// Route is a fully constructed path from sender to payee.
+type Route struct {
+	Hops []Hop
+	// TotalAmount is what the sender pays, including all forwarding fees.
+	TotalAmount *big.Int
+	// FinalDeadline is the PTLC deadline on the last hop.
+	FinalDeadline uint64
+}
+
+// BuildRoute constructs the amount and deadline schedule for a payment.
+//
+// Deadlines form a staircase: the hop closest to the payee has the earliest
+// deadline, and each hop upstream gets hopDelta more blocks, so an
+// intermediary always has time to claim upstream after being claimed
+// downstream. Amounts accumulate in the other direction: each hop carries the
+// amount delivered plus the fees of every hop below it.
+//
+// Each hop is locked to a distinct blinded payment point, so intermediaries
+// cannot correlate hops of the same payment.
+func BuildRoute(destinationPoint *btcec.PublicKey, amount *big.Int, nodes []*btcec.PublicKey,
+	fees []*big.Int, finalDeadline uint64, hopDelta uint64) (*Route, error) {
+
+	if destinationPoint == nil || amount == nil {
+		return nil, errors.New("qichannel: destination point and amount are required")
+	}
+	if len(nodes) == 0 {
+		return nil, errors.New("qichannel: a route needs at least one hop")
+	}
+	if len(fees) != len(nodes) {
+		return nil, fmt.Errorf("qichannel: %d hops but %d fees", len(nodes), len(fees))
+	}
+	if hopDelta == 0 {
+		hopDelta = DefaultHopDelta
+	}
+
+	hops := make([]Hop, len(nodes))
+	// Walk from the payee backwards: amounts accumulate fees and deadlines
+	// grow by hopDelta with each step upstream.
+	runningAmount := new(big.Int).Set(amount)
+	deadline := finalDeadline
+	for i := len(nodes) - 1; i >= 0; i-- {
+		blinded, blind, err := BlindPoint(destinationPoint)
+		if err != nil {
+			return nil, err
+		}
+		if i != len(nodes)-1 {
+			runningAmount = new(big.Int).Add(runningAmount, fees[i+1])
+			deadline += hopDelta
+		}
+		hops[i] = Hop{
+			Node:         nodes[i],
+			Amount:       new(big.Int).Set(runningAmount),
+			Fee:          new(big.Int).Set(fees[i]),
+			Deadline:     deadline,
+			PaymentPoint: blinded,
+			Blind:        blind,
+		}
+	}
+	return &Route{
+		Hops:          hops,
+		TotalAmount:   new(big.Int).Set(hops[0].Amount),
+		FinalDeadline: finalDeadline,
+	}, nil
+}
+
+// Validate checks a route's internal consistency: deadlines must decrease
+// toward the payee by at least hopDelta, and amounts must not increase.
+func (r *Route) Validate(hopDelta uint64) error {
+	if len(r.Hops) == 0 {
+		return errors.New("qichannel: empty route")
+	}
+	if hopDelta == 0 {
+		hopDelta = DefaultHopDelta
+	}
+	for i := 1; i < len(r.Hops); i++ {
+		prev, cur := r.Hops[i-1], r.Hops[i]
+		if prev.Deadline < cur.Deadline+hopDelta {
+			return fmt.Errorf("qichannel: hop %d deadline %d leaves less than %d blocks over hop %d's %d",
+				i-1, prev.Deadline, hopDelta, i, cur.Deadline)
+		}
+		if cur.Amount.Cmp(prev.Amount) > 0 {
+			return fmt.Errorf("qichannel: hop %d forwards more than hop %d", i, i-1)
+		}
+	}
+	return nil
+}
+
+// FitsChannels checks that every hop's deadline falls inside the usable
+// lifetime of the channel that will carry it. Because channels here are time
+// bounded, routing capacity decays as a channel approaches expiry, and a
+// route must be rejected rather than stranded.
+func (r *Route) FitsChannels(channels []*Channel) error {
+	if len(channels) != len(r.Hops) {
+		return fmt.Errorf("qichannel: %d hops but %d channels", len(r.Hops), len(channels))
+	}
+	for i, hop := range r.Hops {
+		if channels[i] == nil {
+			return fmt.Errorf("qichannel: no channel for hop %d", i)
+		}
+		if expiry := channels[i].ExpiryHeight(); hop.Deadline >= expiry {
+			return fmt.Errorf("qichannel: hop %d deadline %d does not fit channel expiring at %d", i, hop.Deadline, expiry)
+		}
+		if channels[i].RemainingUpdates() == 0 {
+			return fmt.Errorf("qichannel: channel for hop %d has no updates remaining", i)
+		}
+	}
+	return nil
+}

--- a/qiwallet/address.go
+++ b/qiwallet/address.go
@@ -1,0 +1,54 @@
+package qiwallet
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/crypto"
+)
+
+// maxGrindAttempts bounds address grinding. Landing in a specific zone and
+// in Qi scope constrains 9 bits, so ~512 attempts are needed on average;
+// 65536 makes failure astronomically unlikely.
+const maxGrindAttempts = 65536
+
+// QiAddressFromKey returns the Qi address a public key spends with: the
+// Keccak hash of the uncompressed public key, as consensus derives it from
+// TxIn public keys.
+func QiAddressFromKey(pubKey *btcec.PublicKey, location common.Location) common.Address {
+	return crypto.PubkeyBytesToAddress(pubKey.SerializeUncompressed(), location)
+}
+
+// InQiScope reports whether an address is spendable in the given zone's Qi
+// ledger: its first byte must encode the zone and the high bit of its
+// second byte must be set.
+func InQiScope(addr common.Address, location common.Location) bool {
+	return common.IsInChainScope(addr.Bytes(), location) && addr.IsInQiLedgerScope()
+}
+
+// GrindQiAddress derives fresh key pairs until one lands in the given
+// zone's Qi address scope, returning the key, its address and the number of
+// attempts used. newKey may be nil, in which case fresh random keys are
+// generated; pass a custom derivation (e.g. sequential HD child keys) to
+// grind deterministically from a seed.
+func GrindQiAddress(location common.Location, newKey func() (*btcec.PrivateKey, error)) (*btcec.PrivateKey, common.Address, int, error) {
+	if newKey == nil {
+		newKey = btcec.NewPrivateKey
+	}
+	for attempts := 1; attempts <= maxGrindAttempts; attempts++ {
+		key, err := newKey()
+		if err != nil {
+			return nil, common.Address{}, attempts, err
+		}
+		if key == nil {
+			return nil, common.Address{}, attempts, errors.New("key derivation returned nil")
+		}
+		addr := QiAddressFromKey(key.PubKey(), location)
+		if InQiScope(addr, location) {
+			return key, addr, attempts, nil
+		}
+	}
+	return nil, common.Address{}, maxGrindAttempts, fmt.Errorf("no Qi address found in %d attempts", maxGrindAttempts)
+}

--- a/qiwallet/coinselect.go
+++ b/qiwallet/coinselect.go
@@ -1,0 +1,375 @@
+package qiwallet
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	mrand "math/rand"
+	"sort"
+
+	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/core/types"
+)
+
+// OwnedUTXO describes a spendable UTXO held by the wallet.
+type OwnedUTXO struct {
+	OutPoint       types.OutPoint
+	Denomination   uint8
+	Address        common.Address
+	PubKey         []byte   // public key that spends this UTXO (compressed or uncompressed)
+	CreationHeight uint64   // block height the UTXO was created at; 0 if unknown
+	Lock           *big.Int // unlock height; nil or 0 if unlocked
+}
+
+// FeeFunc returns the fee in qits a transaction with the given input and
+// output counts must pay. Wallets typically derive this from
+// quai_estimateFeeForQi or from the intrinsic gas formula, the base fee and
+// the Quai-to-Qi exchange rate.
+type FeeFunc func(numInputs, numOutputs int) *big.Int
+
+// Selection is the result of coin selection: which UTXOs to spend and the
+// denominations of the payment and change outputs. The implied fee is the
+// input total minus the value of all output notes.
+type Selection struct {
+	Inputs       []OwnedUTXO
+	PaymentNotes []uint8
+	ChangeNotes  []uint8
+	FeeQits      *big.Int
+}
+
+// notePool tracks available note counts per denomination, supporting the
+// cashier's change-making discipline: notes may only be broken downward.
+// Any multiset of outputs formed this way satisfies the consensus
+// no-combining rule (core.CheckDenominations) with respect to the inputs
+// the pool was built from.
+type notePool struct {
+	counts map[uint8]uint64
+}
+
+func newNotePool(inputs []OwnedUTXO) *notePool {
+	pool := &notePool{counts: make(map[uint8]uint64)}
+	for _, input := range inputs {
+		pool.counts[input.Denomination]++
+	}
+	return pool
+}
+
+func (p *notePool) clone() *notePool {
+	clone := &notePool{counts: make(map[uint8]uint64, len(p.counts))}
+	for d, c := range p.counts {
+		clone.counts[d] = c
+	}
+	return clone
+}
+
+// makeChange forms exactly target qits of output notes from the pool,
+// breaking larger notes downward as needed, and removes the used value.
+func (p *notePool) makeChange(target *big.Int) ([]uint8, error) {
+	if target.Sign() < 0 {
+		return nil, errors.New("negative change target")
+	}
+	remaining := new(big.Int).Set(target)
+	notes := make([]uint8, 0)
+	for remaining.Sign() > 0 {
+		// Take the largest available note that fits under the remainder.
+		taken := false
+		for d := types.MaxDenomination; d >= 0; d-- {
+			if p.counts[uint8(d)] == 0 {
+				continue
+			}
+			if types.Denominations[uint8(d)].Cmp(remaining) <= 0 {
+				p.counts[uint8(d)]--
+				remaining.Sub(remaining, types.Denominations[uint8(d)])
+				notes = append(notes, uint8(d))
+				taken = true
+				break
+			}
+		}
+		if taken {
+			continue
+		}
+		// No available note fits: break the smallest available note downward.
+		broke := false
+		for d := uint8(1); d <= types.MaxDenomination; d++ {
+			if p.counts[d] > 0 {
+				p.counts[d]--
+				p.counts[d-1] += denominationRatio(d)
+				broke = true
+				break
+			}
+		}
+		if !broke {
+			return nil, errors.New("insufficient note value for change target")
+		}
+	}
+	return notes, nil
+}
+
+// checkNoCombining mirrors consensus CheckDenominations: walking from the
+// largest denomination down, outputs at each level must be covered by
+// inputs at that level plus value carried down from above.
+func checkNoCombining(inputs, outputs map[uint]uint64) error {
+	carries := make(map[uint]uint64)
+	for i := types.MaxDenomination; i >= 1; i-- {
+		totalInputs := inputs[uint(i)] + carries[uint(i)]
+		if outputs[uint(i)] > totalInputs {
+			return fmt.Errorf("outputs combine smaller denominations into larger one at denomination %d", i)
+		}
+		diff := new(big.Int).SetUint64(totalInputs - outputs[uint(i)])
+		carries[uint(i-1)] += diff.Mul(diff, new(big.Int).Div(types.Denominations[uint8(i)], types.Denominations[uint8(i-1)])).Uint64()
+	}
+	return nil
+}
+
+// ExpiryUrgencyWindow is the default look-ahead used by SelectUTXOs to pull
+// soon-to-be-trimmed notes into a transaction: one day of blocks.
+const ExpiryUrgencyWindow = 17280
+
+// SelectUTXOs chooses inputs covering amount (in qits) plus fee, and builds
+// payment and change denominations that satisfy the consensus no-combining
+// rule by construction.
+//
+// Selection policy: notes expiring within ExpiryUrgencyWindow blocks are
+// included first whenever their value exceeds the marginal fee of an extra
+// input (rescuing them from being burned by the trimmer); remaining value
+// is covered largest-note-first. Change absorbs everything above amount and
+// fee; the fee is whatever feeFor demands for the final shape, with any
+// sub-note remainder overpaid to the miner.
+func SelectUTXOs(utxos []OwnedUTXO, amount *big.Int, currentHeight uint64, feeFor FeeFunc, maxNotes int, rng *mrand.Rand) (*Selection, error) {
+	if amount == nil || amount.Sign() <= 0 {
+		return nil, errors.New("amount must be positive")
+	}
+	if feeFor == nil {
+		return nil, errors.New("feeFor must be provided")
+	}
+	if rng == nil {
+		rng = NewRand()
+	}
+
+	// Filter to currently spendable notes.
+	spendable := make([]OwnedUTXO, 0, len(utxos))
+	for _, utxo := range utxos {
+		if utxo.Lock != nil && utxo.Lock.Sign() != 0 && utxo.Lock.Cmp(new(big.Int).SetUint64(currentHeight)) > 0 {
+			continue
+		}
+		expiry := ExpiryHeight(utxo.Denomination, utxo.CreationHeight, utxo.Lock)
+		if expiry != 0 && expiry <= currentHeight {
+			continue // already trimmed or about to be; do not rely on it
+		}
+		spendable = append(spendable, utxo)
+	}
+
+	urgent := make([]OwnedUTXO, 0)
+	rest := make([]OwnedUTXO, 0, len(spendable))
+	for _, utxo := range spendable {
+		expiry := ExpiryHeight(utxo.Denomination, utxo.CreationHeight, utxo.Lock)
+		if expiry != 0 && expiry-currentHeight <= ExpiryUrgencyWindow {
+			urgent = append(urgent, utxo)
+		} else {
+			rest = append(rest, utxo)
+		}
+	}
+	sort.SliceStable(urgent, func(i, j int) bool {
+		return ExpiryHeight(urgent[i].Denomination, urgent[i].CreationHeight, urgent[i].Lock) <
+			ExpiryHeight(urgent[j].Denomination, urgent[j].CreationHeight, urgent[j].Lock)
+	})
+	sort.SliceStable(rest, func(i, j int) bool { return rest[i].Denomination > rest[j].Denomination })
+
+	selected := make([]OwnedUTXO, 0, 8)
+	total := big.NewInt(0)
+	addInput := func(utxo OwnedUTXO) {
+		selected = append(selected, utxo)
+		total.Add(total, types.Denominations[utxo.Denomination])
+	}
+
+	// Rescue expiring notes when their value beats the marginal input fee.
+	estimatedOutputs := 4
+	if greedy, err := DecomposeGreedy(amount); err == nil {
+		estimatedOutputs = len(greedy) + 2
+	}
+	for _, utxo := range urgent {
+		marginalFee := new(big.Int).Sub(feeFor(len(selected)+1, estimatedOutputs), feeFor(len(selected), estimatedOutputs))
+		if types.Denominations[utxo.Denomination].Cmp(marginalFee) > 0 {
+			addInput(utxo)
+		}
+	}
+
+	// Cover amount plus fee, largest notes first.
+	nextRest := 0
+	for {
+		need := new(big.Int).Add(amount, feeFor(len(selected), estimatedOutputs))
+		if total.Cmp(need) >= 0 {
+			break
+		}
+		if nextRest >= len(rest) {
+			return nil, fmt.Errorf("insufficient funds: have %s qits spendable, need %s plus fees", total.String(), amount.String())
+		}
+		addInput(rest[nextRest])
+		nextRest++
+	}
+
+	// Build outputs from the selected notes by making change downward, then
+	// iterate the fee/change fixpoint: change value depends on the fee,
+	// which depends on the output count.
+	buildPayment := func() (*notePool, []uint8, error) {
+		pool := newNotePool(selected)
+		payment, err := pool.makeChange(amount)
+		if err != nil {
+			return nil, nil, err
+		}
+		return pool, payment, nil
+	}
+	pool, payment, err := buildPayment()
+	if err != nil {
+		return nil, err
+	}
+
+	var change []uint8
+	changeValue := big.NewInt(0)
+	for iteration := 0; iteration < 12; iteration++ {
+		fee := feeFor(len(selected), len(payment)+len(change))
+		newChangeValue := new(big.Int).Sub(total, amount)
+		newChangeValue.Sub(newChangeValue, fee)
+		if newChangeValue.Sign() < 0 {
+			// The fee outgrew our margin; pull in one more input and rebuild.
+			if nextRest >= len(rest) {
+				return nil, errors.New("insufficient funds to cover the fee")
+			}
+			addInput(rest[nextRest])
+			nextRest++
+			pool, payment, err = buildPayment()
+			if err != nil {
+				return nil, err
+			}
+			change = nil
+			changeValue = big.NewInt(0)
+			continue
+		}
+		if iteration > 0 && newChangeValue.Cmp(changeValue) == 0 {
+			break
+		}
+		changePool := pool.clone()
+		change, err = changePool.makeChange(newChangeValue)
+		if err != nil {
+			return nil, err
+		}
+		changeValue = newChangeValue
+	}
+	if len(payment)+len(change) > maxNotes {
+		return nil, fmt.Errorf("transaction needs %d output notes, more than the maximum of %d", len(payment)+len(change), maxNotes)
+	}
+
+	// Privacy shaping: randomly split change notes downward, within a modest
+	// budget, so change does not follow the canonical greedy shape. Done
+	// before the final fee check so the fee covers the final output count.
+	if budget := min(maxNotes-len(payment), len(change)+4); len(change) > 0 && budget > len(change) {
+		change = SplitNotes(change, budget, rng)
+	}
+
+	// Final feasibility: drop change notes (smallest first, their value goes
+	// to the fee) until the implied fee covers the requirement for the final
+	// transaction shape.
+	for {
+		impliedFee := new(big.Int).Sub(total, amount)
+		impliedFee.Sub(impliedFee, changeValue)
+		required := feeFor(len(selected), len(payment)+len(change))
+		if impliedFee.Cmp(required) >= 0 {
+			break
+		}
+		if len(change) == 0 {
+			return nil, errors.New("unable to satisfy fee requirement")
+		}
+		smallest := 0
+		for i := range change {
+			if change[i] < change[smallest] {
+				smallest = i
+			}
+		}
+		changeValue.Sub(changeValue, types.Denominations[change[smallest]])
+		change = append(change[:smallest], change[smallest+1:]...)
+	}
+
+	// Sanity: the combined outputs must satisfy the consensus rule.
+	inputCounts := make(map[uint]uint64)
+	for _, utxo := range selected {
+		inputCounts[uint(utxo.Denomination)]++
+	}
+	outputCounts := make(map[uint]uint64)
+	for _, note := range payment {
+		outputCounts[uint(note)]++
+	}
+	for _, note := range change {
+		outputCounts[uint(note)]++
+	}
+	if err := checkNoCombining(inputCounts, outputCounts); err != nil {
+		return nil, fmt.Errorf("internal error: selection violates no-combining rule: %w", err)
+	}
+
+	fee := new(big.Int).Sub(total, amount)
+	fee.Sub(fee, changeValue)
+	return &Selection{
+		Inputs:       selected,
+		PaymentNotes: payment,
+		ChangeNotes:  change,
+		FeeQits:      fee,
+	}, nil
+}
+
+// BuildQiTx assembles an unsigned QiTx from a selection. paymentAddrs must
+// contain one fresh address per payment note (provided by the payee) and
+// changeAddrs one fresh address per change note (owned by this wallet).
+// Output order is shuffled so change position carries no information. The
+// within-transaction address reuse ban is enforced here so an invalid
+// combination fails before signing.
+func BuildQiTx(chainID *big.Int, location common.Location, sel *Selection, paymentAddrs, changeAddrs []common.Address, rng *mrand.Rand) (*types.QiTx, error) {
+	if len(paymentAddrs) != len(sel.PaymentNotes) {
+		return nil, fmt.Errorf("need %d payment addresses, got %d", len(sel.PaymentNotes), len(paymentAddrs))
+	}
+	if len(changeAddrs) != len(sel.ChangeNotes) {
+		return nil, fmt.Errorf("need %d change addresses, got %d", len(sel.ChangeNotes), len(changeAddrs))
+	}
+	if rng == nil {
+		rng = NewRand()
+	}
+
+	seen := make(map[common.AddressBytes]struct{})
+	txIns := make([]types.TxIn, 0, len(sel.Inputs))
+	for _, input := range sel.Inputs {
+		if len(input.PubKey) == 0 {
+			return nil, fmt.Errorf("input %v has no public key", input.OutPoint)
+		}
+		txIns = append(txIns, types.TxIn{PreviousOutPoint: input.OutPoint, PubKey: input.PubKey})
+		seen[input.Address.Bytes20()] = struct{}{}
+	}
+
+	type output struct {
+		note uint8
+		addr common.Address
+	}
+	outputs := make([]output, 0, len(sel.PaymentNotes)+len(sel.ChangeNotes))
+	for i, note := range sel.PaymentNotes {
+		outputs = append(outputs, output{note, paymentAddrs[i]})
+	}
+	for i, note := range sel.ChangeNotes {
+		outputs = append(outputs, output{note, changeAddrs[i]})
+	}
+	rng.Shuffle(len(outputs), func(a, b int) { outputs[a], outputs[b] = outputs[b], outputs[a] })
+
+	txOuts := make([]types.TxOut, 0, len(outputs))
+	for _, out := range outputs {
+		if !out.addr.IsInQiLedgerScope() {
+			return nil, fmt.Errorf("output address %s is not in Qi ledger scope", out.addr.String())
+		}
+		if _, exists := seen[out.addr.Bytes20()]; exists {
+			return nil, fmt.Errorf("address %s reused within the transaction", out.addr.String())
+		}
+		seen[out.addr.Bytes20()] = struct{}{}
+		txOuts = append(txOuts, types.TxOut{Denomination: out.note, Address: out.addr.Bytes(), Lock: nil})
+	}
+
+	return &types.QiTx{
+		ChainID: chainID,
+		TxIn:    txIns,
+		TxOut:   txOuts,
+	}, nil
+}

--- a/qiwallet/denomination.go
+++ b/qiwallet/denomination.go
@@ -1,0 +1,102 @@
+package qiwallet
+
+import (
+	crand "crypto/rand"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math/big"
+	mrand "math/rand"
+
+	"github.com/dominant-strategies/go-quai/core/types"
+)
+
+// NewRand returns a math/rand generator seeded from crypto/rand. Wallets
+// should use this (or their own CSPRNG-backed source) for decomposition
+// shaping and output shuffling; a predictable seed makes shapes linkable.
+func NewRand() *mrand.Rand {
+	var seed [8]byte
+	if _, err := crand.Read(seed[:]); err != nil {
+		// Extremely unlikely; fall back to a fixed seed rather than failing.
+		return mrand.New(mrand.NewSource(1))
+	}
+	return mrand.New(mrand.NewSource(int64(binary.LittleEndian.Uint64(seed[:]))))
+}
+
+// NotesValue returns the total value in qits of a multiset of denominations.
+func NotesValue(notes []uint8) *big.Int {
+	total := big.NewInt(0)
+	for _, note := range notes {
+		total.Add(total, types.Denominations[note])
+	}
+	return total
+}
+
+// denominationRatio returns how many notes of denomination d-1 one note of
+// denomination d is worth. All adjacent ratios in the table are integral.
+func denominationRatio(d uint8) uint64 {
+	return new(big.Int).Div(types.Denominations[d], types.Denominations[d-1]).Uint64()
+}
+
+// DecomposeGreedy splits a positive value (in qits) into the minimal
+// multiset of denominations, largest first. This is the canonical shape;
+// wallets should prefer DecomposeRandom for outputs they put on chain.
+func DecomposeGreedy(value *big.Int) ([]uint8, error) {
+	if value == nil || value.Sign() <= 0 {
+		return nil, errors.New("value must be positive")
+	}
+	remaining := new(big.Int).Set(value)
+	notes := make([]uint8, 0, 8)
+	for d := types.MaxDenomination; d >= 0; d-- {
+		denomination := types.Denominations[uint8(d)]
+		for remaining.Cmp(denomination) >= 0 {
+			remaining.Sub(remaining, denomination)
+			notes = append(notes, uint8(d))
+		}
+	}
+	if remaining.Sign() != 0 {
+		return nil, errors.New("value is not a whole number of qits")
+	}
+	return notes, nil
+}
+
+// SplitNotes randomly splits notes into smaller denominations, preserving
+// total value, until maxNotes is reached or no split is chosen. Randomized
+// shapes prevent observers from recognizing the canonical greedy pattern
+// and separating change from payment. The result is shuffled.
+func SplitNotes(notes []uint8, maxNotes int, rng *mrand.Rand) []uint8 {
+	out := append([]uint8(nil), notes...)
+	for attempts := 0; attempts < 4*maxNotes && len(out) < maxNotes; attempts++ {
+		i := rng.Intn(len(out))
+		d := out[i]
+		if d == 0 {
+			continue
+		}
+		ratio := int(denominationRatio(d))
+		if len(out)-1+ratio > maxNotes {
+			continue
+		}
+		if rng.Intn(2) == 0 {
+			continue
+		}
+		out = append(out[:i], out[i+1:]...)
+		for j := 0; j < ratio; j++ {
+			out = append(out, d-1)
+		}
+	}
+	rng.Shuffle(len(out), func(a, b int) { out[a], out[b] = out[b], out[a] })
+	return out
+}
+
+// DecomposeRandom decomposes a value (in qits) into a randomized multiset of
+// at most maxNotes denominations.
+func DecomposeRandom(value *big.Int, maxNotes int, rng *mrand.Rand) ([]uint8, error) {
+	notes, err := DecomposeGreedy(value)
+	if err != nil {
+		return nil, err
+	}
+	if len(notes) > maxNotes {
+		return nil, fmt.Errorf("value requires %d notes, more than the maximum of %d", len(notes), maxNotes)
+	}
+	return SplitNotes(notes, maxNotes, rng), nil
+}

--- a/qiwallet/doc.go
+++ b/qiwallet/doc.go
@@ -1,0 +1,47 @@
+// Package qiwallet is a reference library for building Qi wallets.
+//
+// Every Qi wallet must independently solve a set of sharp-edged problems
+// that are easy to get subtly wrong. This package provides vetted building
+// blocks for each of them:
+//
+//   - Denomination decomposition (DecomposeGreedy, DecomposeRandom): Qi
+//     values are carried in fixed-denomination notes. Deterministic greedy
+//     decomposition leaks information: observers can separate change from
+//     payment by shape. DecomposeRandom produces value-preserving randomized
+//     shapes.
+//
+//   - Coin selection (SelectUTXOs): consensus forbids combining smaller
+//     denominations into larger ones (core.CheckDenominations), so outputs
+//     must be constructible from the chosen inputs by breaking notes
+//     downward, like a cashier making change. SelectUTXOs also prefers
+//     notes that are close to being trimmed (expiry) and accounts for the
+//     fee, which is simply inputs minus outputs.
+//
+//   - Transaction assembly (BuildQiTx): consensus rejects a transaction in
+//     which any output address equals another output address or any input
+//     address, so every note needs a fresh address. Output order is
+//     shuffled so change position leaks nothing.
+//
+//   - Signing (SignQiTx): a Qi transaction carries one aggregate Schnorr
+//     signature over all inputs. Multi-input transactions require the
+//     MuSig2 protocol across the input keys, mirroring consensus
+//     verification exactly (unsorted key aggregation, BIP-340 Schnorr for
+//     the single-input case). Nonces are generated fresh from crypto/rand
+//     for every signing session; MuSig2 nonces must NEVER be derived
+//     deterministically or reused - doing so can leak the private key.
+//
+//   - Address grinding (GrindQiAddress): a Qi address must land in the
+//     wallet's zone (first byte) and in Qi ledger scope (high bit of the
+//     second byte), which takes ~512 key derivations on average.
+//
+//   - Expiry tracking (ExpiryHeight, RefreshCandidates): denominations 0-5
+//     are trimmed (burned) 2-12 weeks after creation. Wallets must refresh
+//     or spend them before expiry or the funds are destroyed.
+//
+// Operational notes: the default node mempool drops Qi transactions after
+// 30 minutes, so wallets should rebroadcast unconfirmed transactions well
+// inside that window, and use the txpool_qiTxStatus RPC to detect drops.
+// Denomination-consolidation transactions (which fail the no-combining
+// rule) are only minable in the first Qi slot of a block and compete in a
+// per-block fee auction; expect them to confirm more slowly.
+package qiwallet

--- a/qiwallet/expiry.go
+++ b/qiwallet/expiry.go
@@ -1,0 +1,40 @@
+package qiwallet
+
+import (
+	"math/big"
+
+	"github.com/dominant-strategies/go-quai/core/types"
+)
+
+// ExpiryHeight returns the chain height at which a UTXO of the given
+// denomination created at creationHeight will be trimmed (burned), or 0 if
+// it is not subject to trimming. Denominations above MaxTrimDenomination
+// never expire, locked outputs are skipped by the trimmer, and a zero
+// creationHeight means the creation height is unknown.
+func ExpiryHeight(denomination uint8, creationHeight uint64, lock *big.Int) uint64 {
+	if denomination > types.MaxTrimDenomination || creationHeight == 0 {
+		return 0
+	}
+	if lock != nil && lock.Sign() != 0 {
+		return 0
+	}
+	return creationHeight + types.TrimDepths[denomination]
+}
+
+// RefreshCandidates returns the subset of utxos that will be trimmed within
+// window blocks of currentHeight and are therefore candidates for an urgent
+// refresh spend. Whether refreshing is economical depends on the fee; see
+// SelectUTXOs, which weighs each expiring note against its marginal fee.
+func RefreshCandidates(utxos []OwnedUTXO, currentHeight, window uint64) []OwnedUTXO {
+	candidates := make([]OwnedUTXO, 0)
+	for _, utxo := range utxos {
+		expiry := ExpiryHeight(utxo.Denomination, utxo.CreationHeight, utxo.Lock)
+		if expiry == 0 || expiry <= currentHeight {
+			continue
+		}
+		if expiry-currentHeight <= window {
+			candidates = append(candidates, utxo)
+		}
+	}
+	return candidates
+}

--- a/qiwallet/qiwallet_test.go
+++ b/qiwallet/qiwallet_test.go
@@ -1,0 +1,283 @@
+package qiwallet_test
+
+import (
+	"math/big"
+	mrand "math/rand"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
+	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/core"
+	"github.com/dominant-strategies/go-quai/core/types"
+	"github.com/dominant-strategies/go-quai/qiwallet"
+)
+
+var testLocation = common.Location{0, 0}
+
+// qiAddress fabricates a syntactically valid Qi-scope address for zone 0-0.
+func qiAddress(seed byte) common.Address {
+	var b [20]byte
+	b[0] = 0x00        // region 0, zone 0
+	b[1] = 0x80 | seed // Qi ledger scope
+	for i := 2; i < 20; i++ {
+		b[i] = seed
+	}
+	return common.BytesToAddress(b[:], testLocation)
+}
+
+func TestDecomposeGreedy(t *testing.T) {
+	notes, err := qiwallet.DecomposeGreedy(big.NewInt(1234))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if qiwallet.NotesValue(notes).Cmp(big.NewInt(1234)) != 0 {
+		t.Fatalf("greedy decomposition value mismatch: %v", notes)
+	}
+	// 1234 = 1000 + 2x100 + 3x10 + 4x1
+	if len(notes) != 10 {
+		t.Fatalf("expected 10 notes, got %d: %v", len(notes), notes)
+	}
+	if _, err := qiwallet.DecomposeGreedy(big.NewInt(0)); err == nil {
+		t.Fatal("expected error for zero value")
+	}
+}
+
+func TestDecomposeRandomPreservesValue(t *testing.T) {
+	rng := mrand.New(mrand.NewSource(42))
+	for i := 0; i < 50; i++ {
+		value := big.NewInt(int64(rng.Intn(5000000) + 1))
+		notes, err := qiwallet.DecomposeRandom(value, 40, rng)
+		if err != nil {
+			// Values needing more than 40 greedy notes are legitimately rejected.
+			continue
+		}
+		if qiwallet.NotesValue(notes).Cmp(value) != 0 {
+			t.Fatalf("value %s not preserved by %v", value, notes)
+		}
+		if len(notes) > 40 {
+			t.Fatalf("note budget exceeded: %d", len(notes))
+		}
+	}
+}
+
+func makeUTXO(denomination uint8, seed byte, creationHeight uint64) qiwallet.OwnedUTXO {
+	var txHash common.Hash
+	txHash[0] = seed
+	txHash[1] = denomination
+	return qiwallet.OwnedUTXO{
+		OutPoint:       types.OutPoint{TxHash: txHash, Index: uint16(seed)},
+		Denomination:   denomination,
+		Address:        qiAddress(seed),
+		CreationHeight: creationHeight,
+	}
+}
+
+func testFee(numIn, numOut int) *big.Int {
+	return big.NewInt(int64(10*numIn + 20*numOut))
+}
+
+func TestSelectUTXOs(t *testing.T) {
+	rng := mrand.New(mrand.NewSource(7))
+	utxos := []qiwallet.OwnedUTXO{
+		makeUTXO(6, 1, 0), makeUTXO(6, 2, 0), makeUTXO(6, 3, 0),
+		makeUTXO(4, 4, 0), makeUTXO(4, 5, 0), makeUTXO(4, 6, 0),
+		makeUTXO(2, 7, 0), makeUTXO(0, 8, 0),
+	}
+	amount := big.NewInt(1500)
+	sel, err := qiwallet.SelectUTXOs(utxos, amount, 1_000_000, testFee, 30, rng)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Payment must equal the requested amount.
+	if qiwallet.NotesValue(sel.PaymentNotes).Cmp(amount) != 0 {
+		t.Fatalf("payment notes %v do not sum to %s", sel.PaymentNotes, amount)
+	}
+	// Conservation: inputs = payment + change + fee.
+	totalIn := big.NewInt(0)
+	inputCounts := make(map[uint]uint64)
+	for _, in := range sel.Inputs {
+		totalIn.Add(totalIn, types.Denominations[in.Denomination])
+		inputCounts[uint(in.Denomination)]++
+	}
+	spent := new(big.Int).Add(qiwallet.NotesValue(sel.PaymentNotes), qiwallet.NotesValue(sel.ChangeNotes))
+	spent.Add(spent, sel.FeeQits)
+	if totalIn.Cmp(spent) != 0 {
+		t.Fatalf("value not conserved: in %s, out+fee %s", totalIn, spent)
+	}
+	// Fee must satisfy the fee function for the final shape.
+	required := testFee(len(sel.Inputs), len(sel.PaymentNotes)+len(sel.ChangeNotes))
+	if sel.FeeQits.Cmp(required) < 0 {
+		t.Fatalf("fee %s below required %s", sel.FeeQits, required)
+	}
+	// Cross-check against the actual consensus rule.
+	outputCounts := make(map[uint]uint64)
+	for _, n := range sel.PaymentNotes {
+		outputCounts[uint(n)]++
+	}
+	for _, n := range sel.ChangeNotes {
+		outputCounts[uint(n)]++
+	}
+	if err := core.CheckDenominations(inputCounts, outputCounts); err != nil {
+		t.Fatalf("consensus CheckDenominations rejected the selection: %v", err)
+	}
+}
+
+func TestSelectUTXOsRescuesExpiring(t *testing.T) {
+	currentHeight := uint64(1_000_000)
+	// Expires 100 blocks from now: must be pulled in even though the big
+	// note alone would cover the payment.
+	expiringCreation := currentHeight - types.TrimDepths[4] + 100
+	utxos := []qiwallet.OwnedUTXO{
+		makeUTXO(6, 1, 0),
+		makeUTXO(4, 2, expiringCreation),
+	}
+	sel, err := qiwallet.SelectUTXOs(utxos, big.NewInt(300), currentHeight, testFee, 30, mrand.New(mrand.NewSource(1)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, in := range sel.Inputs {
+		if in.CreationHeight == expiringCreation {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expiring note was not rescued")
+	}
+}
+
+func TestSelectUTXOsInsufficient(t *testing.T) {
+	utxos := []qiwallet.OwnedUTXO{makeUTXO(2, 1, 0)}
+	if _, err := qiwallet.SelectUTXOs(utxos, big.NewInt(100000), 100, testFee, 30, mrand.New(mrand.NewSource(1))); err == nil {
+		t.Fatal("expected insufficient funds error")
+	}
+}
+
+func TestBuildQiTxAddressReuseBan(t *testing.T) {
+	key, err := btcec.NewPrivateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := makeUTXO(6, 1, 0)
+	input.PubKey = key.PubKey().SerializeUncompressed()
+	sel := &qiwallet.Selection{
+		Inputs:       []qiwallet.OwnedUTXO{input},
+		PaymentNotes: []uint8{5},
+		ChangeNotes:  []uint8{4},
+		FeeQits:      big.NewInt(400),
+	}
+	// Reusing the same address for payment and change must be rejected.
+	dup := qiAddress(9)
+	if _, err := qiwallet.BuildQiTx(big.NewInt(1337), testLocation, sel, []common.Address{dup}, []common.Address{dup}, mrand.New(mrand.NewSource(1))); err == nil {
+		t.Fatal("expected address reuse to be rejected")
+	}
+	// Distinct addresses succeed.
+	qiTx, err := qiwallet.BuildQiTx(big.NewInt(1337), testLocation, sel, []common.Address{qiAddress(9)}, []common.Address{qiAddress(10)}, mrand.New(mrand.NewSource(1)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(qiTx.TxIn) != 1 || len(qiTx.TxOut) != 2 {
+		t.Fatalf("unexpected tx shape: %d in, %d out", len(qiTx.TxIn), len(qiTx.TxOut))
+	}
+}
+
+// buildUnsignedTx constructs an n-input QiTx with the given keys.
+func buildUnsignedTx(t *testing.T, keys []*btcec.PrivateKey) *types.QiTx {
+	t.Helper()
+	txIns := make([]types.TxIn, len(keys))
+	for i, key := range keys {
+		var prevHash common.Hash
+		prevHash[0] = byte(i + 1)
+		txIns[i] = types.TxIn{
+			PreviousOutPoint: types.OutPoint{TxHash: prevHash, Index: 0},
+			PubKey:           key.PubKey().SerializeUncompressed(),
+		}
+	}
+	return &types.QiTx{
+		ChainID: big.NewInt(1337),
+		TxIn:    txIns,
+		TxOut:   []types.TxOut{{Denomination: 5, Address: qiAddress(200).Bytes()}},
+	}
+}
+
+// verifyLikeConsensus mirrors the verification in ValidateQiTxOutputsAndSignature.
+func verifyLikeConsensus(t *testing.T, tx *types.Transaction, signer types.Signer) bool {
+	t.Helper()
+	pubKeys := make([]*btcec.PublicKey, 0, len(tx.TxIn()))
+	for _, txIn := range tx.TxIn() {
+		pubKey, err := btcec.ParsePubKey(txIn.PubKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pubKeys = append(pubKeys, pubKey)
+	}
+	var finalKey *btcec.PublicKey
+	if len(pubKeys) > 1 {
+		aggKey, _, _, err := musig2.AggregateKeys(pubKeys, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		finalKey = aggKey.FinalKey
+	} else {
+		finalKey = pubKeys[0]
+	}
+	digest := signer.Hash(tx)
+	return tx.GetSchnorrSignature().Verify(digest[:], finalKey)
+}
+
+func TestSignQiTxSingleInput(t *testing.T) {
+	key, err := btcec.NewPrivateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer := types.LatestSignerForChainID(big.NewInt(1337), testLocation)
+	signed, err := qiwallet.SignQiTx(buildUnsignedTx(t, []*btcec.PrivateKey{key}), signer, []*btcec.PrivateKey{key})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !verifyLikeConsensus(t, signed, signer) {
+		t.Fatal("single-input signature failed consensus-style verification")
+	}
+}
+
+func TestSignQiTxMultiInputMuSig2(t *testing.T) {
+	keys := make([]*btcec.PrivateKey, 3)
+	for i := range keys {
+		key, err := btcec.NewPrivateKey()
+		if err != nil {
+			t.Fatal(err)
+		}
+		keys[i] = key
+	}
+	signer := types.LatestSignerForChainID(big.NewInt(1337), testLocation)
+	signed, err := qiwallet.SignQiTx(buildUnsignedTx(t, keys), signer, keys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !verifyLikeConsensus(t, signed, signer) {
+		t.Fatal("multi-input MuSig2 signature failed consensus-style verification")
+	}
+	// Wrong key order must be rejected up front (aggregation is order-sensitive).
+	swapped := []*btcec.PrivateKey{keys[1], keys[0], keys[2]}
+	if _, err := qiwallet.SignQiTx(buildUnsignedTx(t, keys), signer, swapped); err == nil {
+		t.Fatal("expected key/input mismatch to be rejected")
+	}
+}
+
+func TestGrindQiAddress(t *testing.T) {
+	key, addr, attempts, err := qiwallet.GrindQiAddress(testLocation, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if key == nil || attempts < 1 {
+		t.Fatal("invalid grind result")
+	}
+	if !qiwallet.InQiScope(addr, testLocation) {
+		t.Fatalf("ground address %s not in Qi scope for %v", addr, testLocation)
+	}
+	if got := qiwallet.QiAddressFromKey(key.PubKey(), testLocation); !got.Equal(addr) {
+		t.Fatal("address does not round-trip from key")
+	}
+}

--- a/qiwallet/sign.go
+++ b/qiwallet/sign.go
@@ -1,0 +1,119 @@
+package qiwallet
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
+	"github.com/dominant-strategies/go-quai/core/types"
+)
+
+// SignQiTx signs an unsigned QiTx whose inputs are all controlled by the
+// provided private keys, given in the same order as the transaction inputs.
+// It produces the single aggregate Schnorr signature consensus expects:
+// plain BIP-340 Schnorr for one input, and the local MuSig2 protocol across
+// the input keys for several, mirroring consensus verification exactly
+// (unsorted key aggregation, no tweaks).
+//
+// Nonces are drawn fresh from crypto/rand for every call. Never substitute
+// deterministic or reused nonces in a MuSig2 session: nonce reuse leaks the
+// private key. Hardware signers must persist no nonce state across calls.
+//
+// The returned transaction is fully signed and ready for submission.
+func SignQiTx(qiTx *types.QiTx, signer types.Signer, keys []*btcec.PrivateKey) (*types.Transaction, error) {
+	if qiTx == nil || signer == nil {
+		return nil, errors.New("nil transaction or signer")
+	}
+	if len(keys) == 0 || len(keys) != len(qiTx.TxIn) {
+		return nil, fmt.Errorf("need exactly one key per input: %d keys for %d inputs", len(keys), len(qiTx.TxIn))
+	}
+
+	pubKeys := make([]*btcec.PublicKey, len(keys))
+	for i, key := range keys {
+		if key == nil {
+			return nil, fmt.Errorf("nil key at index %d", i)
+		}
+		pubKeys[i] = key.PubKey()
+		txInKey, err := btcec.ParsePubKey(qiTx.TxIn[i].PubKey)
+		if err != nil {
+			return nil, fmt.Errorf("input %d has an unparseable public key: %w", i, err)
+		}
+		if !txInKey.IsEqual(pubKeys[i]) {
+			return nil, fmt.Errorf("key at index %d does not match input %d's public key", i, i)
+		}
+	}
+
+	// The signing digest covers type, chain ID, inputs, outputs and data,
+	// but not the signature itself, so it can be computed pre-signature.
+	digest := signer.Hash(types.NewTx(qiTx))
+	var msg [32]byte
+	copy(msg[:], digest[:])
+
+	var signature *schnorr.Signature
+	if len(keys) == 1 {
+		sig, err := schnorr.Sign(keys[0], msg[:])
+		if err != nil {
+			return nil, err
+		}
+		signature = sig
+	} else {
+		sig, err := musig2SignLocal(keys, pubKeys, msg)
+		if err != nil {
+			return nil, err
+		}
+		signature = sig
+	}
+
+	// Fail fast: verify against the same aggregate the consensus code uses.
+	finalKey := pubKeys[0]
+	if len(pubKeys) > 1 {
+		aggKey, _, _, err := musig2.AggregateKeys(pubKeys, false)
+		if err != nil {
+			return nil, err
+		}
+		finalKey = aggKey.FinalKey
+	}
+	if !signature.Verify(msg[:], finalKey) {
+		return nil, errors.New("produced signature does not verify against the aggregate key")
+	}
+
+	signed := &types.QiTx{
+		ChainID:   qiTx.ChainID,
+		TxIn:      qiTx.TxIn,
+		TxOut:     qiTx.TxOut,
+		Data:      qiTx.Data,
+		Signature: signature,
+	}
+	return types.NewTx(signed), nil
+}
+
+// musig2SignLocal runs the two-round MuSig2 protocol entirely locally
+// across the given keys, matching consensus verification: keys aggregated
+// in input order, unsorted, untweaked.
+func musig2SignLocal(keys []*btcec.PrivateKey, pubKeys []*btcec.PublicKey, msg [32]byte) (*schnorr.Signature, error) {
+	nonces := make([]*musig2.Nonces, len(keys))
+	pubNonces := make([][musig2.PubNonceSize]byte, len(keys))
+	for i, key := range keys {
+		nonce, err := musig2.GenNonces(musig2.WithPublicKey(key.PubKey()))
+		if err != nil {
+			return nil, err
+		}
+		nonces[i] = nonce
+		pubNonces[i] = nonce.PubNonce
+	}
+	combinedNonce, err := musig2.AggregateNonces(pubNonces)
+	if err != nil {
+		return nil, err
+	}
+	partialSigs := make([]*musig2.PartialSignature, len(keys))
+	for i, key := range keys {
+		partial, err := musig2.Sign(nonces[i].SecNonce, key, combinedNonce, pubKeys, msg)
+		if err != nil {
+			return nil, err
+		}
+		partialSigs[i] = partial
+	}
+	return musig2.CombineSigs(partialSigs[0].R, partialSigs), nil
+}

--- a/quai/api_backend.go
+++ b/quai/api_backend.go
@@ -435,6 +435,10 @@ func (b *QuaiAPIBackend) QiTxPoolStatus(txHash common.Hash) *core.QiTxPoolStatus
 	return b.quai.core.QiTxPoolStatus(txHash)
 }
 
+func (b *QuaiAPIBackend) ReceiveStemTransaction(tx *types.Transaction) error {
+	return b.quai.core.ReceiveStemTransaction(tx)
+}
+
 func (b *QuaiAPIBackend) GetBlockFilter(blockHash common.Hash) []byte {
 	return b.quai.core.GetBlockFilter(blockHash)
 }

--- a/quai/api_backend.go
+++ b/quai/api_backend.go
@@ -435,6 +435,10 @@ func (b *QuaiAPIBackend) QiTxPoolStatus(txHash common.Hash) *core.QiTxPoolStatus
 	return b.quai.core.QiTxPoolStatus(txHash)
 }
 
+func (b *QuaiAPIBackend) GetBlockFilter(blockHash common.Hash) []byte {
+	return b.quai.core.GetBlockFilter(blockHash)
+}
+
 func (b *QuaiAPIBackend) GetRollingFeeInfo() (min, max, avg *big.Int) {
 	return b.quai.core.GetRollingFeeInfo()
 }

--- a/quai/api_backend.go
+++ b/quai/api_backend.go
@@ -431,6 +431,10 @@ func (b *QuaiAPIBackend) SendTxToSharingClients(tx *types.Transaction) error {
 	return b.quai.core.SendTxToSharingClients(tx)
 }
 
+func (b *QuaiAPIBackend) QiTxPoolStatus(txHash common.Hash) *core.QiTxPoolStatus {
+	return b.quai.core.QiTxPoolStatus(txHash)
+}
+
 func (b *QuaiAPIBackend) GetRollingFeeInfo() (min, max, avg *big.Int) {
 	return b.quai.core.GetRollingFeeInfo()
 }

--- a/quaiclient/quaiclient.go
+++ b/quaiclient/quaiclient.go
@@ -402,6 +402,21 @@ func (ec *Client) SendTransactionToPoolSharingClient(ctx context.Context, tx *ty
 	return ec.c.CallContext(ctx, nil, "quai_receiveTxFromPoolSharingClient", hexutil.Encode(data))
 }
 
+// SendStemTransaction relays a Qi transaction to a peer node as a Dandelion
+// stem hop: the receiver adds it to its pool without broadcasting and either
+// relays the stem onward or fluffs it.
+func (ec *Client) SendStemTransaction(ctx context.Context, tx *types.Transaction) error {
+	protoTx, err := tx.ProtoEncode()
+	if err != nil {
+		return err
+	}
+	data, err := proto.Marshal(protoTx)
+	if err != nil {
+		return err
+	}
+	return ec.c.CallContext(ctx, nil, "quai_receiveStemTransaction", hexutil.Encode(data))
+}
+
 func (ec *Client) GetWorkShareP2PThreshold(ctx context.Context) uint64 {
 	var threshold hexutil.Uint64
 	err := ec.c.CallContext(ctx, &threshold, "quai_getWorkShareP2PThreshold")


### PR DESCRIPTION
## Goal

Improve the privacy and usability of the Qi UTXO ledger without changing what
Qi is: fixed denominations, one aggregate Schnorr signature per transaction,
transparent auditable supply. Most of this is wallet/node-layer work that
needs no consensus change; two small fork-gated consensus changes unlock an
off-chain contract layer.

Branched from `v0.55.0`. 12 commits, 36 files, +5,796/-34. `go build ./...`
is clean and all touched packages' tests pass.

---

## Part 1 — On-chain privacy and usability (no consensus change)

**`1002c5d29` Make the Qi mempool deterministic**
The Qi pool was an LRU keyed only by tx hash: conflicting spends coexisted and
were resolved silently at block-building time, and denomination-combining txs
(only minable in a block's first Qi slot) were admitted indistinguishably from
normal ones. Adds an outpoint→tx index kept in sync via the LRU eviction
callback, an explicit replace-by-fee policy, `CheckDenominations` at admission
with combining txs segregated, a `Has()`/`Status()` fix so they see Qi txs, and
a `txpool_qiTxStatus` RPC.

**`265b3d4fd` Auction the first Qi tx slot to the highest-fee consolidation tx**
The first Qi tx in a block is already exempt from the no-combining rule, but
nothing used that deliberately, so users had no way to merge small notes upward
and dust could only die by trimming. The block builder now awards that slot to
the highest-fee combining tx that fits. Turns an existing carve-out into a
consolidation fee market with no consensus change.

**`9256c8290` BIP-158-style compact block filters**
`GetOutpointsByAddress
Locally submitted txs previously entered the broadcast set and fanned out to
every pool-sharing client immediately, so the first hop could tie a tx to its
origin. Qi txs now relay to one randomly chosen peer (`quai_receiveStemTransaction`)
before public fluff, with a randomized 10–30s embargo so a stem peer cannot
black-hole them. Default on; nodes without sharing clients behave exactly as
before.

**`b21f388ab` `qiwallet`: reference wallet library**
Every wallet must independently solve the same sharp edges. Provides randomized
denomination decomposition (deterministic greedy shapes let observers separate
change from payment), coin selection that satisfies the no-combining rule by
construction, expiring-note rescue weighed against marginal fee, reuse-ban
enforcement with shuffled outputs, and MuSig2/BIP-340 signing that round-trips
against consensus-style verification.

---

## Part 2 — Off-chain contract and payment layer

Non-zero `TxOut.Lock` was always rejected though it was already stored and
enforced at spend time. Now permitted on local Qi-scope outputs, restricted to
denominations above `MaxTrimDenomination` (the trimmer skips locked entries, so
a small locked note would never be trimmed) and capped at one year out.

**`950b6bea0` Transaction-level locktime** *(consensus, fork-gated)*
**Important design correction:** an output lock delays spending a UTXO that
already exists; it is not `nLockTime`. Every channel state spends the *same*
funding output, so they all inherit identical timing — the previous commit
alone does **not** enable channels. This adds a real transaction locktime,
encoded as an 8-byte height in the Qi `Data` field, which is already covered by
the signing digest (so it is not malleable) and already carries typed payloads
at other lengths. Encoding it there avoids any protobuf, RLP or transaction-hash
change.
decrementing locktime, so the newest always matures first — no revocation
secrets, no penalty transactions, no watchtowers, at the cost of a bounded
lifetime and a defined watch window (both exposed by the API). PTLC claims are
gated only by an adaptor signature; refunds carry the deadline as locktime.
Per-hop point blinding makes hops of one payment uncorrelatable, which HTLCs
cannot do.

**`edbcf4d0e` Invoices + design doc**
Ledger-agnostic invoices carrying a payment point rather than a hash.
`doc/qi-offchain-layer
finding, and what is not constructible.

**`0ca9aeeb9` Sphinx onion packets**
Fixed-size onion routing on the BOLT-4 design. Hop instructions carry a point
delta rather than a payment hash, which is what makes per-hop decorrelation
work end to end. Tested over every route length to the 20-hop max, plus
constant packet size, tamper/replay detection and session unlinkability.

**`e6dc724f6` Quai-side PTLC channel contract**
A two-party EVM channe
address commitment the payee publishes. Quai-side channels are perpetual
(challenge-window adjudication), unlike the time-bounded Qi side.

---

## Consensus impact

Two changes, both gated on `params.QiUserLockForkBlock`. No protobuf, RLP or
transaction-hash changes, so existing transactions serialize and hash
identically. Everything in Part 1 is non-consensus.

## Known gaps / not ready to ship as-is

- **`QiUserLockForkBlock` is a placeholder** (2,400,000) and must be set.
- **The contract's state machine is untested.** It compiles under solc 0.8.26
  and its point derivation is verified in Go against the same secp256k1
  implementation the precompile uses, but this repo has no EVM harness, so
  close/challenge/claim/refund/finalize have never been executed. Must be
  covered before it handles funds.
- **The Dandelion stem path has no network-level test** — unit coverage only.
- **Not implemented:** gossip, pathfinding, routing economics, and node/daemon
  integration. `qichannel` and `crypto/sphinx` are libraries; nothing is wired
  into the node.
- The `Data`-field locktime encoding is pragmatic. If a tx-format revision is
  already planned, a proper field is cleaner — worth deciding before the fork
  height is fixed.

## Review guide

Each commit is self-contained with reasoning in its message; `git log v0.55.0..HEAD`
gives the sequence. `doc/qi-offchain-layer.md` is the best entry point for Part 2.
Part 1 and Part 2 are independent and could ship separately.