### PR TITLE
feat: add live coordinated Pebble snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 The reference implementation of the Quai protocol, written in Go.
 
 [![API Reference](
-https://camo.githubusercontent.com/915b7be44ada53c290eb157634330494ebe3e30a/68747470733a2f2f676f646f632e6f72672f6769746875622e636f6d2f676f6c616e672f6764646f3f7374617475732e737667
+https://camo.githubusercontent.com/915b7be44ada53c290eb157634330494ebe3e30a/68747470733a2f2f676f646f63732e6f72672f6769746875622e636f6d2f676f6c616e672f6764646f3f7374617475732e737667
 )](https://pkg.go.dev/github.com/dominant-strategies/go-quai/common)
 [![Go Report Card](https://goreportcard.com/badge/github.com/dominant-strategies/go-quai)](https://goreportcard.com/report/github.com/dominant-strategies/go-quai)
 [![Discord](https://img.shields.io/badge/discord-join%20chat-blue.svg)](https://discord.gg/s8y8asPwNC)
@@ -25,6 +25,14 @@ To run a go-quai node, simply execute the `go-quai start` command. Be sure to sp
 For example, here is the run command for miner (0x00a3e45aa16163F2663015b6695894D918866d19) in cyprus-1 (zone-0-0) on the "garden" test network:
 ```shell
 ./build/bin/go-quai start --node.slices "[0 0]" --node.coinbases "0x00a3e45aa16163F2663015b6695894D918866d19" --node.environment "garden"
+```
+
+### Restoring a Pebble snapshot
+
+Snapshots created by the live snapshot feature contain Pebble databases. When starting a node from one of these snapshots, include:
+
+```shell
+--node.db-engine pebble
 ```
 
 For the full list of available options and their default values, consult the help menu:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 The reference implementation of the Quai protocol, written in Go.
 
 [![API Reference](
-https://camo.githubusercontent.com/915b7be44ada53c290eb157634330494ebe3e30a/68747470733a2f2f676f646f63732e6f72672f6769746875622e636f6d2f676f6c616e672f6764646f3f7374617475732e737667
+https://camo.githubusercontent.com/915b7be44ada53c290eb157634330494ebe3e30a/68747470733a2f2f676f646f632e6f72672f6769746875622e636f6d2f676f6c616e672f6764646f3f7374617475732e737667
 )](https://pkg.go.dev/github.com/dominant-strategies/go-quai/common)
 [![Go Report Card](https://goreportcard.com/badge/github.com/dominant-strategies/go-quai)](https://goreportcard.com/report/github.com/dominant-strategies/go-quai)
 [![Discord](https://img.shields.io/badge/discord-join%20chat-blue.svg)](https://discord.gg/s8y8asPwNC)

--- a/cmd/go-quai/start.go
+++ b/cmd/go-quai/start.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/dominant-strategies/go-quai/cmd/utils"
 	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/core/rawdb"
 	"github.com/dominant-strategies/go-quai/internal/quaiapi"
 	"github.com/dominant-strategies/go-quai/log"
 	"github.com/dominant-strategies/go-quai/p2p/node"
@@ -179,16 +180,37 @@ func runStart(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// wait for a SIGINT or SIGTERM signal
-	ch := make(chan os.Signal, 1)
-	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
+	// SIGINT and SIGTERM shut the node down. SIGUSR1 requests a live
+	// coordinated Pebble snapshot without interrupting normal operation.
+	stopCh := make(chan os.Signal, 1)
+	snapshotCh := make(chan os.Signal, 1)
 
-	select {
-	case <-ch:
-		log.Global.Warn("Received 'stop' signal, shutting down gracefully...")
-	case <-quitCh:
-		log.Global.Warn("Received 'quit' signal from child, shutting down...")
+	signal.Notify(stopCh, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(snapshotCh, syscall.SIGUSR1)
+
+waitLoop:
+	for {
+		select {
+		case <-snapshotCh:
+			log.Global.Warn("Received SIGUSR1, requesting live Pebble snapshot")
+			if err := rawdb.TriggerPebbleSnapshot(log.Global); err != nil {
+				log.Global.WithField("error", err).Error(
+					"Unable to start live Pebble snapshot",
+				)
+			}
+
+		case <-stopCh:
+			log.Global.Warn("Received 'stop' signal, shutting down gracefully...")
+			break waitLoop
+
+		case <-quitCh:
+			log.Global.Warn("Received 'quit' signal from child, shutting down...")
+			break waitLoop
+		}
 	}
+
+	signal.Stop(snapshotCh)
+	signal.Stop(stopCh)
 
 	cancel()
 	// If the stratum API is running, stop it first

--- a/cmd/quai-snapshot-verify/main.go
+++ b/cmd/quai-snapshot-verify/main.go
@@ -1,0 +1,257 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/core/rawdb"
+	pebblestore "github.com/dominant-strategies/go-quai/ethdb/pebble"
+	"github.com/dominant-strategies/go-quai/log"
+)
+
+type snapshotHeadManifest struct {
+	Number    uint64 `json:"number"`
+	NumberHex string `json:"number_hex"`
+	Hash      string `json:"hash"`
+}
+
+type snapshotContextManifest struct {
+	Path          string               `json:"path"`
+	CapturedAt    string               `json:"captured_at"`
+	Duration      int64                `json:"duration"`
+	DurationHuman string               `json:"duration_human"`
+	Ancients      uint64               `json:"ancients"`
+	Head          snapshotHeadManifest `json:"head"`
+}
+
+type snapshotManifest struct {
+	Version   int                                `json:"version"`
+	CreatedAt string                             `json:"created_at"`
+	DBEngine  string                             `json:"db_engine"`
+	Contexts  map[string]snapshotContextManifest `json:"contexts"`
+}
+
+type contextSpec struct {
+	name     string
+	location common.Location
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(
+			os.Stderr,
+			"usage: %s SNAPSHOT_DIR\n",
+			filepath.Base(os.Args[0]),
+		)
+		os.Exit(2)
+	}
+
+	if err := verifySnapshot(os.Args[1]); err != nil {
+		fmt.Fprintf(os.Stderr, "SNAPSHOT VERIFY: FAIL: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("SNAPSHOT VERIFY: PASS")
+}
+
+func verifySnapshot(snapshotRoot string) error {
+	root, err := filepath.Abs(filepath.Clean(snapshotRoot))
+	if err != nil {
+		return fmt.Errorf("resolve snapshot path: %w", err)
+	}
+
+	manifestPath := filepath.Join(root, "manifest.json")
+
+	manifestBytes, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return fmt.Errorf("read manifest: %w", err)
+	}
+
+	var manifest snapshotManifest
+
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+		return fmt.Errorf("parse manifest: %w", err)
+	}
+
+	if manifest.Version != 1 {
+		return fmt.Errorf(
+			"unsupported manifest version: %d",
+			manifest.Version,
+		)
+	}
+
+	if manifest.DBEngine != "pebble" {
+		return fmt.Errorf(
+			"unexpected db_engine: %q",
+			manifest.DBEngine,
+		)
+	}
+
+	specs := []contextSpec{
+		{
+			name:     "prime",
+			location: common.Location{},
+		},
+		{
+			name:     "region-0",
+			location: common.Location{0},
+		},
+		{
+			name:     "zone-0-0",
+			location: common.Location{0, 0},
+		},
+	}
+
+	fmt.Printf("snapshot=%s\n", root)
+	fmt.Printf("created_at=%s\n\n", manifest.CreatedAt)
+
+	for _, spec := range specs {
+		entry, ok := manifest.Contexts[spec.name]
+		if !ok {
+			return fmt.Errorf(
+				"%s: missing from manifest",
+				spec.name,
+			)
+		}
+
+		if entry.Ancients != 0 {
+			return fmt.Errorf(
+				"%s: manifest contains unsupported ancient count %d",
+				spec.name,
+				entry.Ancients,
+			)
+		}
+
+		dbPath := filepath.Join(
+			root,
+			filepath.FromSlash(entry.Path),
+		)
+
+		rel, err := filepath.Rel(root, dbPath)
+		if err != nil {
+			return fmt.Errorf(
+				"%s: resolve database path: %w",
+				spec.name,
+				err,
+			)
+		}
+
+		if rel == ".." ||
+			len(rel) >= 3 && rel[:3] == ".."+string(filepath.Separator) {
+			return fmt.Errorf(
+				"%s: manifest path escapes snapshot root: %q",
+				spec.name,
+				entry.Path,
+			)
+		}
+
+		if _, err := os.Stat(
+			filepath.Join(dbPath, "CURRENT"),
+		); err != nil {
+			return fmt.Errorf(
+				"%s: missing CURRENT: %w",
+				spec.name,
+				err,
+			)
+		}
+
+		db, err := pebblestore.New(
+			dbPath,
+			16,
+			16,
+			"snapshot/verify",
+			true,
+			log.Global,
+			spec.location,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"%s: open Pebble read-only: %w",
+				spec.name,
+				err,
+			)
+		}
+
+		headHash := rawdb.ReadHeadBlockHash(db)
+
+		if headHash == (common.Hash{}) {
+			db.Close()
+
+			return fmt.Errorf(
+				"%s: no canonical head hash",
+				spec.name,
+			)
+		}
+
+		headNumber := rawdb.ReadHeaderNumber(
+			db,
+			headHash,
+		)
+
+		if headNumber == nil {
+			db.Close()
+
+			return fmt.Errorf(
+				"%s: no number for head hash %s",
+				spec.name,
+				headHash.String(),
+			)
+		}
+
+		if err := db.Close(); err != nil {
+			return fmt.Errorf(
+				"%s: close Pebble: %w",
+				spec.name,
+				err,
+			)
+		}
+
+		actualHash := headHash.String()
+		actualHex := fmt.Sprintf(
+			"0x%x",
+			*headNumber,
+		)
+
+		fmt.Printf(
+			"%-10s number=%d hex=%s hash=%s\n",
+			spec.name,
+			*headNumber,
+			actualHex,
+			actualHash,
+		)
+
+		if *headNumber != entry.Head.Number {
+			return fmt.Errorf(
+				"%s: head number mismatch: manifest=%d actual=%d",
+				spec.name,
+				entry.Head.Number,
+				*headNumber,
+			)
+		}
+
+		if actualHex != entry.Head.NumberHex {
+			return fmt.Errorf(
+				"%s: head hex mismatch: manifest=%s actual=%s",
+				spec.name,
+				entry.Head.NumberHex,
+				actualHex,
+			)
+		}
+
+		if actualHash != entry.Head.Hash {
+			return fmt.Errorf(
+				"%s: head hash mismatch: manifest=%s actual=%s",
+				spec.name,
+				entry.Head.Hash,
+				actualHash,
+			)
+		}
+
+		fmt.Printf("%-10s PASS\n\n", spec.name)
+	}
+
+	return nil
+}

--- a/core/rawdb/pebble_snapshot.go
+++ b/core/rawdb/pebble_snapshot.go
@@ -1,0 +1,475 @@
+package rawdb
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/ethdb"
+	pebblestore "github.com/dominant-strategies/go-quai/ethdb/pebble"
+	"github.com/dominant-strategies/go-quai/log"
+)
+
+type snapshotRegistration struct {
+	name     string
+	db       ethdb.Database
+	location common.Location
+}
+
+type SnapshotHeadManifest struct {
+	Number    uint64 `json:"number"`
+	NumberHex string `json:"number_hex"`
+	Hash      string `json:"hash"`
+}
+
+type SnapshotContextManifest struct {
+	Path          string               `json:"path"`
+	CapturedAt    time.Time            `json:"captured_at"`
+	Duration      time.Duration        `json:"duration"`
+	DurationHuman string               `json:"duration_human"`
+	Ancients      uint64               `json:"ancients"`
+	Head          SnapshotHeadManifest `json:"head"`
+}
+
+type SnapshotManifest struct {
+	Version   int                                `json:"version"`
+	CreatedAt time.Time                          `json:"created_at"`
+	DBEngine  string                             `json:"db_engine"`
+	Contexts  map[string]SnapshotContextManifest `json:"contexts"`
+}
+
+var pebbleSnapshotCoordinator = struct {
+	sync.Mutex
+	root      string
+	dbs       map[string]snapshotRegistration
+	capturing bool
+}{
+	dbs: make(map[string]snapshotRegistration),
+}
+
+func unwrapPebble(db interface{}) (*pebblestore.Database, error) {
+	switch db := db.(type) {
+	case interface{ UnwrapDatabase() ethdb.Database }:
+		return unwrapPebble(db.UnwrapDatabase())
+
+	case *freezerdb:
+		return unwrapPebble(db.KeyValueStore)
+
+	case *nofreezedb:
+		return unwrapPebble(db.KeyValueStore)
+
+	case *pebblestore.Database:
+		return db, nil
+
+	default:
+		return nil, fmt.Errorf(
+			"snapshot requires Pebble backing database, got %T",
+			db,
+		)
+	}
+}
+
+// RegisterPebbleSnapshotDatabase registers one live chain context with the
+// process-wide snapshot coordinator. Registration does not itself trigger a
+// snapshot.
+func RegisterPebbleSnapshotDatabase(
+	root string,
+	name string,
+	db ethdb.Database,
+	location common.Location,
+	logger *log.Logger,
+) {
+	if root == "" {
+		return
+	}
+
+	switch name {
+	case "prime", "region-0", "zone-0-0":
+	default:
+		logger.WithField("context", name).Error(
+			"Refusing unknown context in coordinated Pebble snapshot",
+		)
+		return
+	}
+
+	pebbleSnapshotCoordinator.Lock()
+	defer pebbleSnapshotCoordinator.Unlock()
+
+	if pebbleSnapshotCoordinator.root == "" {
+		pebbleSnapshotCoordinator.root = root
+	} else if pebbleSnapshotCoordinator.root != root {
+		logger.WithFields(log.Fields{
+			"existingRoot": pebbleSnapshotCoordinator.root,
+			"newRoot":      root,
+		}).Error("Snapshot root changed while registering databases")
+		return
+	}
+
+	pebbleSnapshotCoordinator.dbs[name] = snapshotRegistration{
+		name:     name,
+		db:       db,
+		location: location,
+	}
+
+	logger.WithFields(log.Fields{
+		"context":    name,
+		"registered": len(pebbleSnapshotCoordinator.dbs),
+		"required":   3,
+		"root":       root,
+	}).Info("Registered database for coordinated Pebble snapshot")
+}
+
+// TriggerPebbleSnapshot starts one asynchronous coordinated snapshot.
+//
+// It returns an error immediately if registration is incomplete or another
+// snapshot is already running.
+func TriggerPebbleSnapshot(logger *log.Logger) error {
+	pebbleSnapshotCoordinator.Lock()
+
+	if pebbleSnapshotCoordinator.capturing {
+		pebbleSnapshotCoordinator.Unlock()
+		return fmt.Errorf("Pebble snapshot already in progress")
+	}
+
+	required := []string{"prime", "region-0", "zone-0-0"}
+
+	if pebbleSnapshotCoordinator.root == "" {
+		pebbleSnapshotCoordinator.Unlock()
+		return fmt.Errorf("Pebble snapshot root is not configured")
+	}
+
+	for _, name := range required {
+		if _, ok := pebbleSnapshotCoordinator.dbs[name]; !ok {
+			pebbleSnapshotCoordinator.Unlock()
+			return fmt.Errorf(
+				"Pebble snapshot database %q is not registered",
+				name,
+			)
+		}
+	}
+
+	root := pebbleSnapshotCoordinator.root
+
+	dbs := []snapshotRegistration{
+		pebbleSnapshotCoordinator.dbs["prime"],
+		pebbleSnapshotCoordinator.dbs["region-0"],
+		pebbleSnapshotCoordinator.dbs["zone-0-0"],
+	}
+
+	pebbleSnapshotCoordinator.capturing = true
+	pebbleSnapshotCoordinator.Unlock()
+
+	go func() {
+		start := time.Now()
+
+		err := capturePebbleSnapshotSet(root, dbs, logger)
+
+		pebbleSnapshotCoordinator.Lock()
+		pebbleSnapshotCoordinator.capturing = false
+		pebbleSnapshotCoordinator.Unlock()
+
+		if err != nil {
+			logger.WithFields(log.Fields{
+				"err":      err,
+				"duration": time.Since(start),
+			}).Error("Coordinated Pebble snapshot failed")
+			return
+		}
+
+		logger.WithField(
+			"duration",
+			time.Since(start),
+		).Warn("Snapshot request completed")
+	}()
+
+	return nil
+}
+
+func readCheckpointHead(
+	dest string,
+	location common.Location,
+	logger *log.Logger,
+) (SnapshotHeadManifest, error) {
+	db, err := pebblestore.New(
+		dest,
+		16,
+		16,
+		"snapshot/verify",
+		true,
+		logger,
+		location,
+	)
+	if err != nil {
+		return SnapshotHeadManifest{}, fmt.Errorf(
+			"open checkpoint read-only: %w",
+			err,
+		)
+	}
+	defer db.Close()
+
+	headHash := ReadHeadBlockHash(db)
+	if headHash == (common.Hash{}) {
+		return SnapshotHeadManifest{}, fmt.Errorf(
+			"checkpoint has no canonical head block hash",
+		)
+	}
+
+	headNumber := ReadHeaderNumber(db, headHash)
+	if headNumber == nil {
+		return SnapshotHeadManifest{}, fmt.Errorf(
+			"checkpoint head hash %s has no block number",
+			headHash.String(),
+		)
+	}
+
+	return SnapshotHeadManifest{
+		Number:    *headNumber,
+		NumberHex: fmt.Sprintf("0x%x", *headNumber),
+		Hash:      headHash.String(),
+	}, nil
+}
+
+func capturePebbleSnapshotSet(
+	root string,
+	dbs []snapshotRegistration,
+	logger *log.Logger,
+) error {
+	if err := os.MkdirAll(root, 0755); err != nil {
+		return fmt.Errorf("create snapshot root: %w", err)
+	}
+
+	now := time.Now().UTC()
+	stamp := now.Format("20060102T150405.000000000Z")
+
+	building := filepath.Join(
+		root,
+		fmt.Sprintf(".building-%s-%d", stamp, os.Getpid()),
+	)
+	final := filepath.Join(root, "quai-snapshot-"+stamp)
+
+	if _, err := os.Stat(building); !os.IsNotExist(err) {
+		return fmt.Errorf(
+			"building destination already exists: %s",
+			building,
+		)
+	}
+
+	if _, err := os.Stat(final); !os.IsNotExist(err) {
+		return fmt.Errorf(
+			"final destination already exists: %s",
+			final,
+		)
+	}
+
+	if err := os.Mkdir(building, 0755); err != nil {
+		return fmt.Errorf("create building directory: %w", err)
+	}
+
+	success := false
+
+	defer func() {
+		if !success {
+			if err := os.RemoveAll(building); err != nil {
+				logger.WithFields(log.Fields{
+					"path": building,
+					"err":  err,
+				}).Error("Failed cleaning incomplete snapshot")
+			}
+		}
+	}()
+
+	// V1 checkpoints only the Pebble KV database. Until freezer files are
+	// included in the snapshot format, refuse to produce an incomplete set
+	// whenever any context contains ancient records.
+	for _, entry := range dbs {
+		ancients, err := entry.db.Ancients()
+		if err != nil {
+			return fmt.Errorf(
+				"%s: cannot determine ancient count: %w",
+				entry.name,
+				err,
+			)
+		}
+
+		if ancients != 0 {
+			return fmt.Errorf(
+				"%s: refusing incomplete snapshot: ancient count is %d",
+				entry.name,
+				ancients,
+			)
+		}
+	}
+
+	manifest := SnapshotManifest{
+		Version:   1,
+		CreatedAt: now,
+		DBEngine:  "pebble",
+		Contexts:  make(map[string]SnapshotContextManifest, len(dbs)),
+	}
+
+	for _, entry := range dbs {
+		pebbleDB, err := unwrapPebble(entry.db)
+		if err != nil {
+			return fmt.Errorf("%s: %w", entry.name, err)
+		}
+
+		rel := filepath.Join(
+			entry.name,
+			"go-quai",
+			"chaindata",
+		)
+		dest := filepath.Join(building, rel)
+
+		if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+			return fmt.Errorf(
+				"%s: create destination parent: %w",
+				entry.name,
+				err,
+			)
+		}
+
+		start := time.Now()
+
+		logger.WithFields(log.Fields{
+			"context":     entry.name,
+			"destination": dest,
+		}).Warn("Starting native Pebble checkpoint")
+
+		if err := pebbleDB.Checkpoint(dest); err != nil {
+			return fmt.Errorf(
+				"%s checkpoint: %w",
+				entry.name,
+				err,
+			)
+		}
+
+		duration := time.Since(start)
+		capturedAt := time.Now().UTC()
+
+		ancients, err := entry.db.Ancients()
+		if err != nil {
+			return fmt.Errorf(
+				"%s: cannot re-check ancient count: %w",
+				entry.name,
+				err,
+			)
+		}
+
+		if ancients != 0 {
+			return fmt.Errorf(
+				"%s: ancient count changed during capture to %d",
+				entry.name,
+				ancients,
+			)
+		}
+
+		if err := os.MkdirAll(
+			filepath.Join(dest, "ancient"),
+			0755,
+		); err != nil {
+			return fmt.Errorf(
+				"%s: create empty ancient directory: %w",
+				entry.name,
+				err,
+			)
+		}
+
+		head, err := readCheckpointHead(
+			dest,
+			entry.location,
+			logger,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"%s: read frozen checkpoint head: %w",
+				entry.name,
+				err,
+			)
+		}
+
+		manifest.Contexts[entry.name] = SnapshotContextManifest{
+			Path:          rel,
+			CapturedAt:    capturedAt,
+			Duration:      duration,
+			DurationHuman: duration.String(),
+			Ancients:      ancients,
+			Head:          head,
+		}
+
+		logger.WithFields(log.Fields{
+			"context":  entry.name,
+			"duration": duration,
+		}).Warn("Native Pebble checkpoint completed")
+	}
+
+	// Re-check the entire set immediately before publication. A freezer could
+	// theoretically advance in an earlier context while a later context was
+	// being checkpointed.
+	for _, entry := range dbs {
+		ancients, err := entry.db.Ancients()
+		if err != nil {
+			return fmt.Errorf(
+				"%s: cannot perform final ancient-count check: %w",
+				entry.name,
+				err,
+			)
+		}
+		if ancients != 0 {
+			return fmt.Errorf(
+				"%s: refusing publication: ancient count changed to %d",
+				entry.name,
+				ancients,
+			)
+		}
+	}
+
+	manifestPath := filepath.Join(building, "manifest.json")
+
+	f, err := os.OpenFile(
+		manifestPath,
+		os.O_WRONLY|os.O_CREATE|os.O_EXCL,
+		0644,
+	)
+	if err != nil {
+		return fmt.Errorf("create manifest: %w", err)
+	}
+
+	encoder := json.NewEncoder(f)
+	encoder.SetIndent("", "  ")
+
+	if err := encoder.Encode(&manifest); err != nil {
+		f.Close()
+		return fmt.Errorf("encode manifest: %w", err)
+	}
+
+	if err := f.Sync(); err != nil {
+		f.Close()
+		return fmt.Errorf("sync manifest: %w", err)
+	}
+
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close manifest: %w", err)
+	}
+
+	if err := os.Rename(building, final); err != nil {
+		return fmt.Errorf(
+			"publish completed snapshot directory: %w",
+			err,
+		)
+	}
+
+	success = true
+
+	logger.WithFields(log.Fields{
+		"path":      final,
+		"createdAt": manifest.CreatedAt,
+		"contexts":  len(manifest.Contexts),
+		"dbEngine":  manifest.DBEngine,
+	}).Warn("Coordinated Pebble snapshot completed")
+
+	return nil
+}

--- a/ethdb/pebble/checkpoint.go
+++ b/ethdb/pebble/checkpoint.go
@@ -1,0 +1,20 @@
+// Copyright 2026
+//
+// Experimental online checkpoint support for go-quai Pebble databases.
+
+package pebble
+
+import "github.com/cockroachdb/pebble"
+
+// Checkpoint creates a standalone point-in-time copy of the open Pebble
+// database while allowing the live database to continue serving reads/writes.
+func (d *Database) Checkpoint(destDir string) error {
+	d.quitLock.RLock()
+	defer d.quitLock.RUnlock()
+
+	if d.closed {
+		return pebble.ErrClosed
+	}
+
+	return d.db.Checkpoint(destDir)
+}

--- a/ethdb/pebble/checkpoint_test.go
+++ b/ethdb/pebble/checkpoint_test.go
@@ -1,0 +1,262 @@
+package pebble
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	cockroachpebble "github.com/cockroachdb/pebble"
+	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/log"
+)
+
+func TestOnlineCheckpoint(t *testing.T) {
+	root := t.TempDir()
+	liveDir := filepath.Join(root, "live")
+	checkpointDir := filepath.Join(root, "checkpoint")
+
+	logger := log.NewLogger("test", filepath.Join(root, "test.log"), 0)
+
+	db, err := New(
+		liveDir,
+		16,
+		16,
+		"checkpoint-test",
+		false,
+		logger,
+		common.Location{},
+	)
+	if err != nil {
+		t.Fatalf("open live db: %v", err)
+	}
+	defer db.Close()
+
+	// State that must exist in both the live DB and checkpoint.
+	if err := db.Put([]byte("before"), []byte("state-A")); err != nil {
+		t.Fatalf("write before checkpoint: %v", err)
+	}
+
+	// Capture the DB while it remains open.
+	if err := db.Checkpoint(checkpointDir); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+
+	// This write occurs strictly after the checkpoint.
+	if err := db.Put([]byte("after"), []byte("state-B")); err != nil {
+		t.Fatalf("write after checkpoint: %v", err)
+	}
+
+	// Live database must contain both values.
+	got, err := db.Get([]byte("before"))
+	if err != nil {
+		t.Fatalf("live get before: %v", err)
+	}
+	if string(got) != "state-A" {
+		t.Fatalf("live before = %q, want %q", got, "state-A")
+	}
+
+	got, err = db.Get([]byte("after"))
+	if err != nil {
+		t.Fatalf("live get after: %v", err)
+	}
+	if string(got) != "state-B" {
+		t.Fatalf("live after = %q, want %q", got, "state-B")
+	}
+
+	// Open the checkpoint independently, read-only.
+	checkpoint, err := cockroachpebble.Open(
+		checkpointDir,
+		&cockroachpebble.Options{ReadOnly: true},
+	)
+	if err != nil {
+		t.Fatalf("open checkpoint: %v", err)
+	}
+	defer checkpoint.Close()
+
+	// State written before Checkpoint must exist.
+	value, closer, err := checkpoint.Get([]byte("before"))
+	if err != nil {
+		t.Fatalf("checkpoint get before: %v", err)
+	}
+	if string(value) != "state-A" {
+		closer.Close()
+		t.Fatalf("checkpoint before = %q, want %q", value, "state-A")
+	}
+	if err := closer.Close(); err != nil {
+		t.Fatalf("close checkpoint value: %v", err)
+	}
+
+	// State written afterward must NOT exist.
+	_, closer, err = checkpoint.Get([]byte("after"))
+	if closer != nil {
+		closer.Close()
+	}
+	if !errors.Is(err, cockroachpebble.ErrNotFound) {
+		t.Fatalf("checkpoint unexpectedly contains post-checkpoint write; err=%v", err)
+	}
+}
+
+func TestOnlineCheckpointConcurrentWrites(t *testing.T) {
+	root := t.TempDir()
+	liveDir := filepath.Join(root, "live")
+
+	logger := log.NewLogger("test", filepath.Join(root, "test.log"), 0)
+
+	db, err := New(
+		liveDir,
+		16,
+		16,
+		"checkpoint-concurrent-test",
+		false,
+		logger,
+		common.Location{},
+	)
+	if err != nil {
+		t.Fatalf("open live db: %v", err)
+	}
+	defer db.Close()
+
+	// Seed immutable baseline state. Every checkpoint must contain this.
+	const baselineKeys = 1000
+	for i := 0; i < baselineKeys; i++ {
+		key := []byte(fmt.Sprintf("baseline-%08d", i))
+		value := []byte(fmt.Sprintf("value-%08d", i))
+		if err := db.Put(key, value); err != nil {
+			t.Fatalf("seed baseline %d: %v", i, err)
+		}
+	}
+
+	var (
+		stop      = make(chan struct{})
+		writerErr = make(chan error, 1)
+		writes    atomic.Uint64
+	)
+
+	// Continuously mutate the live DB while checkpoints are being created.
+	go func() {
+		for i := uint64(0); ; i++ {
+			select {
+			case <-stop:
+				writerErr <- nil
+				return
+			default:
+			}
+
+			key := []byte(fmt.Sprintf("live-%012d", i))
+			value := []byte(fmt.Sprintf("payload-%012d", i))
+
+			if err := db.Put(key, value); err != nil {
+				writerErr <- err
+				return
+			}
+			writes.Store(i + 1)
+		}
+	}()
+
+	// Produce several checkpoints while writes continue.
+	const checkpointCount = 10
+
+	for n := 0; n < checkpointCount; n++ {
+		checkpointDir := filepath.Join(
+			root,
+			fmt.Sprintf("checkpoint-%02d", n),
+		)
+
+		before := writes.Load()
+
+		if err := db.Checkpoint(checkpointDir); err != nil {
+			close(stop)
+			<-writerErr
+			t.Fatalf("checkpoint %d: %v", n, err)
+		}
+
+		after := writes.Load()
+
+		cp, err := cockroachpebble.Open(
+			checkpointDir,
+			&cockroachpebble.Options{ReadOnly: true},
+		)
+		if err != nil {
+			close(stop)
+			<-writerErr
+			t.Fatalf("open checkpoint %d: %v", n, err)
+		}
+
+		// Verify baseline state is intact in every checkpoint.
+		for i := 0; i < baselineKeys; i++ {
+			key := []byte(fmt.Sprintf("baseline-%08d", i))
+			want := fmt.Sprintf("value-%08d", i)
+
+			value, closer, err := cp.Get(key)
+			if err != nil {
+				cp.Close()
+				close(stop)
+				<-writerErr
+				t.Fatalf(
+					"checkpoint %d missing baseline key %d: %v",
+					n, i, err,
+				)
+			}
+
+			got := string(value)
+			closer.Close()
+
+			if got != want {
+				cp.Close()
+				close(stop)
+				<-writerErr
+				t.Fatalf(
+					"checkpoint %d baseline key %d = %q, want %q",
+					n, i, got, want,
+				)
+			}
+		}
+
+		// A key definitely created after Checkpoint returned must not
+		// magically appear in the checkpoint.
+		postKeyNum := after + 1000000
+		postKey := []byte(fmt.Sprintf("post-%012d", postKeyNum))
+
+		if err := db.Put(postKey, []byte("written-after-checkpoint")); err != nil {
+			cp.Close()
+			close(stop)
+			<-writerErr
+			t.Fatalf("write post-checkpoint key: %v", err)
+		}
+
+		_, closer, err := cp.Get(postKey)
+		if closer != nil {
+			closer.Close()
+		}
+		if !errors.Is(err, cockroachpebble.ErrNotFound) {
+			cp.Close()
+			close(stop)
+			<-writerErr
+			t.Fatalf(
+				"checkpoint %d contains explicit post-checkpoint key; err=%v",
+				n, err,
+			)
+		}
+
+		if err := cp.Close(); err != nil {
+			close(stop)
+			<-writerErr
+			t.Fatalf("close checkpoint %d: %v", n, err)
+		}
+
+		t.Logf(
+			"checkpoint %d valid; concurrent writes before=%d after=%d",
+			n, before, after,
+		)
+	}
+
+	close(stop)
+
+	if err := <-writerErr; err != nil {
+		t.Fatalf("writer failed: %v", err)
+	}
+
+	t.Logf("total concurrent writes: %d", writes.Load())
+}

--- a/ethdb/pebble/multicheckpoint_test.go
+++ b/ethdb/pebble/multicheckpoint_test.go
@@ -1,0 +1,272 @@
+package pebble
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	cockroachpebble "github.com/cockroachdb/pebble"
+	"github.com/dominant-strategies/go-quai/common"
+	"github.com/dominant-strategies/go-quai/log"
+)
+
+type checkpointManifest struct {
+	CreatedAtUTC string                    `json:"created_at_utc"`
+	DurationMS   int64                     `json:"duration_ms"`
+	Chains       map[string]checkpointInfo `json:"chains"`
+}
+
+type checkpointInfo struct {
+	Marker string `json:"marker"`
+	Writes uint64 `json:"writes_at_checkpoint"`
+}
+
+type testChain struct {
+	name   string
+	db     *Database
+	writes atomic.Uint64
+}
+
+func TestMultiDatabaseOnlineCheckpoint(t *testing.T) {
+	root := t.TempDir()
+	liveRoot := filepath.Join(root, "live")
+	snapshotRoot := filepath.Join(root, "snapshot")
+
+	logger := log.NewLogger(
+		"test",
+		filepath.Join(root, "test.log"),
+		0,
+	)
+
+	names := []string{
+		"prime",
+		"region-0",
+		"zone-0-0",
+	}
+
+	chains := make([]*testChain, 0, len(names))
+
+	for _, name := range names {
+		db, err := New(
+			filepath.Join(liveRoot, name, "chaindata"),
+			16,
+			16,
+			"multi-checkpoint-test",
+			false,
+			logger,
+			common.Location{},
+		)
+		if err != nil {
+			t.Fatalf("open %s: %v", name, err)
+		}
+
+		chains = append(chains, &testChain{
+			name: name,
+			db:   db,
+		})
+	}
+
+	defer func() {
+		for _, chain := range chains {
+			chain.db.Close()
+		}
+	}()
+
+	// Stable state that must exist in every checkpoint.
+	for _, chain := range chains {
+		key := []byte("canonical-marker")
+		value := []byte("marker-" + chain.name)
+
+		if err := chain.db.Put(key, value); err != nil {
+			t.Fatalf("seed %s marker: %v", chain.name, err)
+		}
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Simulate active chain writes against all three DBs.
+	for _, chain := range chains {
+		chain := chain
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for i := uint64(0); ; i++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+
+				key := []byte(fmt.Sprintf(
+					"live-%s-%012d",
+					chain.name,
+					i,
+				))
+
+				value := []byte(fmt.Sprintf(
+					"value-%012d",
+					i,
+				))
+
+				if err := chain.db.Put(key, value); err != nil {
+					t.Errorf(
+						"writer %s failed: %v",
+						chain.name,
+						err,
+					)
+					return
+				}
+
+				chain.writes.Store(i + 1)
+			}
+		}()
+	}
+
+	manifest := checkpointManifest{
+		CreatedAtUTC: time.Now().UTC().Format(time.RFC3339Nano),
+		Chains:       make(map[string]checkpointInfo),
+	}
+
+	start := time.Now()
+
+	// Sequentially checkpoint all three DBs while writers continue.
+	for _, chain := range chains {
+		dest := filepath.Join(
+			snapshotRoot,
+			chain.name,
+			"chaindata",
+		)
+
+		if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+			close(stop)
+			wg.Wait()
+			t.Fatalf("mkdir %s: %v", chain.name, err)
+		}
+
+		before := chain.writes.Load()
+
+		cpStart := time.Now()
+
+		if err := chain.db.Checkpoint(dest); err != nil {
+			close(stop)
+			wg.Wait()
+			t.Fatalf(
+				"checkpoint %s: %v",
+				chain.name,
+				err,
+			)
+		}
+
+		cpDuration := time.Since(cpStart)
+
+		after := chain.writes.Load()
+
+		t.Logf(
+			"%s checkpoint duration=%s writes_before=%d writes_after=%d",
+			chain.name,
+			cpDuration,
+			before,
+			after,
+		)
+
+		manifest.Chains[chain.name] = checkpointInfo{
+			Marker: "marker-" + chain.name,
+			Writes: after,
+		}
+	}
+
+	manifest.DurationMS = time.Since(start).Milliseconds()
+
+	close(stop)
+	wg.Wait()
+
+	// Write snapshot manifest.
+	manifestBytes, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+
+	if err := os.WriteFile(
+		filepath.Join(snapshotRoot, "manifest.json"),
+		manifestBytes,
+		0644,
+	); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	t.Logf(
+		"total multi-db capture duration=%dms",
+		manifest.DurationMS,
+	)
+
+	// Independently reopen every checkpoint.
+	for _, chain := range chains {
+		dir := filepath.Join(
+			snapshotRoot,
+			chain.name,
+			"chaindata",
+		)
+
+		cp, err := cockroachpebble.Open(
+			dir,
+			&cockroachpebble.Options{
+				ReadOnly: true,
+			},
+		)
+		if err != nil {
+			t.Fatalf(
+				"open checkpoint %s: %v",
+				chain.name,
+				err,
+			)
+		}
+
+		value, closer, err := cp.Get(
+			[]byte("canonical-marker"),
+		)
+		if err != nil {
+			cp.Close()
+			t.Fatalf(
+				"checkpoint %s marker read: %v",
+				chain.name,
+				err,
+			)
+		}
+
+		got := string(value)
+		closer.Close()
+
+		want := "marker-" + chain.name
+
+		if got != want {
+			cp.Close()
+			t.Fatalf(
+				"%s marker=%q want=%q",
+				chain.name,
+				got,
+				want,
+			)
+		}
+
+		if err := cp.Close(); err != nil {
+			t.Fatalf(
+				"close checkpoint %s: %v",
+				chain.name,
+				err,
+			)
+		}
+
+		t.Logf(
+			"%s checkpoint independently verified",
+			chain.name,
+		)
+	}
+}

--- a/node/node.go
+++ b/node/node.go
@@ -564,6 +564,12 @@ type closeTrackingDB struct {
 	n *Node
 }
 
+// UnwrapDatabase exposes the wrapped database for internal tooling that needs
+// access to the concrete backing implementation without bypassing Close().
+func (db *closeTrackingDB) UnwrapDatabase() ethdb.Database {
+	return db.Database
+}
+
 func (db *closeTrackingDB) Close() error {
 	db.n.lock.Lock()
 	delete(db.n.databases, db)

--- a/quai/backend.go
+++ b/quai/backend.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"fmt"
 	"math/big"
+	"os"
 	"sync"
 	"time"
 
@@ -170,6 +171,36 @@ func New(stack *node.Node, p2p NetworkingAPI, config *quaiconfig.Config, nodeCtx
 		logger:            logger,
 		maxWsSubs:         maxWsSubs,
 		rpcVersion:        config.RpcVersion,
+	}
+
+	// Coordinated native Pebble snapshot capture. Only the three currently
+	// active chain contexts participate. Capture begins automatically once all
+	// three have registered with the coordinator.
+	if root := os.Getenv("GO_QUAI_SNAPSHOT_ROOT"); root != "" {
+		var snapshotContext string
+
+		switch {
+		case nodeCtx == common.PRIME_CTX:
+			snapshotContext = "prime"
+
+		case nodeCtx == common.REGION_CTX &&
+			config.NodeLocation.Region() == 0:
+			snapshotContext = "region-0"
+
+		case nodeCtx == common.ZONE_CTX &&
+			bytes.Equal(config.NodeLocation, common.Location{0, 0}):
+			snapshotContext = "zone-0-0"
+		}
+
+		if snapshotContext != "" {
+			rawdb.RegisterPebbleSnapshotDatabase(
+				root,
+				snapshotContext,
+				chainDb,
+				config.NodeLocation,
+				logger,
+			)
+		}
 	}
 
 	// Copy the chainConfig


### PR DESCRIPTION
## Summary

Adds a live, coordinated Pebble snapshot path for Prime, Region-0, and Zone-0-0 without stopping the node.

## What changed

- adds native online Pebble checkpoint support
- registers the three live chain contexts with a process-wide snapshot coordinator
- uses `SIGUSR1` to trigger an asynchronous coordinated capture
- writes snapshots through a temporary `.building-*` directory and atomically publishes only completed sets
- records frozen checkpoint head number/hash metadata in `manifest.json`
- fails closed if ancient/freezer records are present, since V1 does not yet package freezer data
- adds an independent `quai-snapshot-verify` command that reopens each frozen Pebble DB read-only and checks manifest head number/hash exactly
- adds Pebble checkpoint tests, including concurrent-write and multi-database coverage

## Validation

Validated on a live mainnet node after migration to Pebble:

- Prime, Region-0, and Zone-0-0 native checkpoints completed while production continued advancing
- repeated `SIGUSR1` snapshot requests completed without restart
- manifest head number/hash values were derived from the frozen checkpoint artifacts, not the live databases
- the independent verifier reopened all three checkpoint DBs and matched all recorded head numbers/hashes
- `zstd -t` passed on a packaged snapshot archive
- SHA-256 verification passed on the packaged archive
- targeted Go tests and builds passed

## End-to-end restore validation

A full physical restore was completed on separate hardware.

- the live Pebble snapshot was transferred to a second physical machine
- `quai-snapshot-verify` passed for Prime, Region-0, and Zone-0-0
- the destination node restored from the snapshot and resumed from the captured heads
- the restored node caught up to the live network tip
- Stratum was enabled afterward and an external SHA-256 miner connected successfully
- node-side Stratum stats showed valid shares with 0 stale and 0 invalid submissions

This validates the full path from live snapshot creation through transfer, verification, restore, catch-up, and normal post-restore operation.

## Scope

The earlier LevelDB-to-Pebble migration PoC used during development is intentionally not included in this change. This PR contains only the permanent native Pebble snapshot implementation and verifier.