### PR TITLE
fix(pebble): implement pending batch tracking

### DIFF
--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -410,15 +410,23 @@ func (d *Database) meter(refresh time.Duration) {
 // batch is a write-only batch that commits changes to its host database
 // when Write is called. A batch cannot be used concurrently.
 type batch struct {
-	b    *pebble.Batch
-	db   *Database
-	size int
+	b           *pebble.Batch
+	db          *Database
+	size        int
+	setPending  bool
+	pending     map[string]*[]byte
+	pendingLock sync.RWMutex
 }
 
 // Put inserts the given value into the batch for later committing.
 func (b *batch) Put(key, value []byte) error {
 	b.b.Set(key, value, nil)
 	b.size += len(key) + len(value)
+	if b.setPending {
+		b.pendingLock.Lock()
+		b.pending[string(key)] = &value
+		b.pendingLock.Unlock()
+	}
 	return nil
 }
 
@@ -426,6 +434,11 @@ func (b *batch) Put(key, value []byte) error {
 func (b *batch) Delete(key []byte) error {
 	b.b.Delete(key, nil)
 	b.size += len(key)
+	if b.setPending {
+		b.pendingLock.Lock()
+		b.pending[string(key)] = nil
+		b.pendingLock.Unlock()
+	}
 	return nil
 }
 
@@ -441,6 +454,9 @@ func (b *batch) Write() error {
 	if b.db.closed {
 		return pebble.ErrClosed
 	}
+
+	b.pending = nil
+	b.setPending = false
 	return b.b.Commit(pebble.Sync)
 }
 
@@ -448,6 +464,8 @@ func (b *batch) Write() error {
 func (b *batch) Reset() {
 	b.b.Reset()
 	b.size = 0
+	b.pending = nil
+	b.setPending = false
 }
 
 // Replay replays the batch contents.
@@ -475,9 +493,22 @@ func (b *batch) Logger() *log.Logger {
 	return b.db.logger
 }
 
-func (b *batch) SetPending(pending bool) {}
 func (b *batch) GetPending(key []byte) (bool, []byte) {
+	b.pendingLock.RLock()
+	defer b.pendingLock.RUnlock()
+	if val, ok := b.pending[string(key)]; ok {
+		if val == nil {
+			return true, nil
+		}
+		return false, *val
+	}
 	return false, nil
+}
+
+// SetPending must be called for the batch to keep track of pending writes outside of pebble.
+func (b *batch) SetPending(val bool) {
+	b.pending = make(map[string]*[]byte)
+	b.setPending = val
 }
 
 // pebbleIterator is a wrapper of underlying iterator in storage engine.

--- a/ethdb/pebble/pebble_test.go
+++ b/ethdb/pebble/pebble_test.go
@@ -42,3 +42,84 @@ func TestPebbleDB(t *testing.T) {
 		})
 	})
 }
+
+func TestPebbleBatchPending(t *testing.T) {
+	inner, err := pebble.Open("", &pebble.Options{
+		FS: vfs.NewMem(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer inner.Close()
+
+	db := &Database{db: inner}
+	batch := db.NewBatch()
+
+	key := []byte("pending-key")
+	value := []byte("pending-value")
+
+	// Pending tracking is opt-in.
+	if err := batch.Put(key, value); err != nil {
+		t.Fatal(err)
+	}
+	if deleted, data := batch.GetPending(key); deleted || data != nil {
+		t.Fatalf("unexpected pending value before SetPending: deleted=%t data=%q", deleted, data)
+	}
+
+	batch.Reset()
+	batch.SetPending(true)
+
+	// A pending write should be visible before the batch is committed.
+	if err := batch.Put(key, value); err != nil {
+		t.Fatal(err)
+	}
+	deleted, data := batch.GetPending(key)
+	if deleted {
+		t.Fatal("pending write reported as deleted")
+	}
+	if string(data) != string(value) {
+		t.Fatalf("pending write mismatch: have %q want %q", data, value)
+	}
+
+	// A later delete of the same key should replace the pending write.
+	if err := batch.Delete(key); err != nil {
+		t.Fatal(err)
+	}
+	deleted, data = batch.GetPending(key)
+	if !deleted || data != nil {
+		t.Fatalf("pending delete mismatch: deleted=%t data=%q", deleted, data)
+	}
+
+	// A later write should replace the pending delete.
+	replacement := []byte("replacement")
+	if err := batch.Put(key, replacement); err != nil {
+		t.Fatal(err)
+	}
+	deleted, data = batch.GetPending(key)
+	if deleted {
+		t.Fatal("replacement write reported as deleted")
+	}
+	if string(data) != string(replacement) {
+		t.Fatalf("replacement mismatch: have %q want %q", data, replacement)
+	}
+
+	// Writing the batch clears its pending overlay.
+	if err := batch.Write(); err != nil {
+		t.Fatal(err)
+	}
+	if deleted, data := batch.GetPending(key); deleted || data != nil {
+		t.Fatalf("pending state survived Write: deleted=%t data=%q", deleted, data)
+	}
+
+	// Reset must also clear pending tracking and pending values.
+	batch.Reset()
+	batch.SetPending(true)
+	if err := batch.Put(key, []byte("reset-value")); err != nil {
+		t.Fatal(err)
+	}
+	batch.Reset()
+
+	if deleted, data := batch.GetPending(key); deleted || data != nil {
+		t.Fatalf("pending state survived Reset: deleted=%t data=%q", deleted, data)
+	}
+}


### PR DESCRIPTION
## Summary

Implement Pebble batch pending-write tracking to match the existing LevelDB behavior required by `ethdb.Batch`.

- track pending `Put` values when `SetPending(true)` is enabled
- track pending `Delete` operations
- return pending writes/deletes from `GetPending`
- clear pending state on `Write` and `Reset`
- add regression coverage for opt-in tracking, write/delete replacement, and clearing behavior

Fixes #2740

## Validation

- `go test ./ethdb/pebble -count=1`
- `go test ./ethdb/... -count=1`
- `go test ./core/rawdb -count=1`
- `make go-quai`

All passed on top of current upstream `main`.